### PR TITLE
feat: 매장관리 상단에 온보딩 등록 정보(매장명·업종) 표시 및 수정 기능 추가

### DIFF
--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -24,6 +24,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
     const storeName = useCalendarStore((s) => s.storeName);
     const shopType = useCalendarStore((s) => s.shopType);
     const storeSettings = useCalendarStore((s) => s.storeSettings);
+    const updateStoreInfo = useCalendarStore((s) => s.updateStoreInfo);
     const updateStoreBusinessHours = useCalendarStore((s) => s.updateStoreBusinessHours);
     const updateStoreClosedDates = useCalendarStore((s) => s.updateStoreClosedDates);
     const [businessHours, setBusinessHours] = useState(storeSettings.businessHours);
@@ -32,11 +33,30 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
     const [closedDateError, setClosedDateError] = useState('');
     const [isEditingBusinessHours, setIsEditingBusinessHours] = useState(false);
     const [isEditingClosedDates, setIsEditingClosedDates] = useState(false);
+    const [isEditingStoreInfo, setIsEditingStoreInfo] = useState(false);
+    const [editStoreName, setEditStoreName] = useState(storeName);
+    const [editShopType, setEditShopType] = useState<string | null>(shopType);
+    const [storeInfoError, setStoreInfoError] = useState('');
 
     useEffect(() => {
         setBusinessHours(storeSettings.businessHours);
         setClosedDates(storeSettings.closedDates);
     }, [storeSettings]);
+
+    useEffect(() => {
+        setEditStoreName(storeName);
+        setEditShopType(shopType);
+    }, [storeName, shopType]);
+
+    const handleSaveStoreInfo = () => {
+        if (!editStoreName.trim()) {
+            setStoreInfoError('매장 이름을 입력해 주세요.');
+            return;
+        }
+        updateStoreInfo(editStoreName.trim(), editShopType);
+        setIsEditingStoreInfo(false);
+        setStoreInfoError('');
+    };
 
     const isBusinessHoursDirty = businessHours.start !== storeSettings.businessHours.start
         || businessHours.end !== storeSettings.businessHours.end;
@@ -71,14 +91,66 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
     return (
         <StyledStoreSection>
             <PageHero eyebrow="STORE" title="매장 관리" subtitle="영업시간과 휴업일을 설정합니다." />
-            {(storeName || shopType) && (
-                <StyledStoreInfoCard>
-                    {storeName && <StyledStoreInfoName>{storeName}</StyledStoreInfoName>}
-                    {shopType && (
-                        <StyledStoreInfoType>{SHOP_TYPE_LABELS[shopType] ?? shopType}</StyledStoreInfoType>
+            <StyledStoreCard>
+                <StyledStoreCardHeader>
+                    <StyledStoreCardTitle>매장 정보</StyledStoreCardTitle>
+                    {!isEditingStoreInfo && (
+                        <StyledEditBtn type="button" onClick={() => setIsEditingStoreInfo(true)}>수정</StyledEditBtn>
                     )}
-                </StyledStoreInfoCard>
-            )}
+                </StyledStoreCardHeader>
+                {isEditingStoreInfo ? (
+                    <>
+                        <StyledStoreFieldGrid>
+                            <StyledRangeInputWrap>
+                                <span>매장 이름</span>
+                                <StyledDateInput
+                                    type="text"
+                                    value={editStoreName}
+                                    onChange={(e) => {
+                                        setEditStoreName(e.target.value);
+                                        setStoreInfoError('');
+                                    }}
+                                    placeholder="매장 이름을 입력하세요"
+                                />
+                            </StyledRangeInputWrap>
+                        </StyledStoreFieldGrid>
+                        <StyledShopTypeGrid>
+                            {Object.entries(SHOP_TYPE_LABELS).map(([type, label]) => (
+                                <StyledShopTypeBtn
+                                    key={type}
+                                    type="button"
+                                    $selected={editShopType === type}
+                                    onClick={() => setEditShopType(type)}
+                                >
+                                    {label}
+                                </StyledShopTypeBtn>
+                            ))}
+                        </StyledShopTypeGrid>
+                        {storeInfoError && <StyledAddNotice>{storeInfoError}</StyledAddNotice>}
+                        <StyledStoreActionRow>
+                            <StyledCancelBtn
+                                type="button"
+                                onClick={() => {
+                                    setEditStoreName(storeName);
+                                    setEditShopType(shopType);
+                                    setStoreInfoError('');
+                                    setIsEditingStoreInfo(false);
+                                }}
+                            >
+                                취소
+                            </StyledCancelBtn>
+                            <StyledSaveBtn type="button" onClick={handleSaveStoreInfo}>저장</StyledSaveBtn>
+                        </StyledStoreActionRow>
+                    </>
+                ) : (
+                    <StyledStoreInfoRow>
+                        <StyledStoreInfoName>{storeName || <StyledInfoPlaceholder>매장 이름 없음</StyledInfoPlaceholder>}</StyledStoreInfoName>
+                        {shopType && (
+                            <StyledStoreInfoType>{SHOP_TYPE_LABELS[shopType] ?? shopType}</StyledStoreInfoType>
+                        )}
+                    </StyledStoreInfoRow>
+                )}
+            </StyledStoreCard>
             <StyledStoreCard>
                 <StyledStoreCardHeader>
                     <StyledStoreCardTitle>영업시간</StyledStoreCardTitle>
@@ -191,28 +263,31 @@ const StyledStoreSection = styled.div`
     grid-template-columns: 1fr 1fr;
     gap: 12px;
 
-    > :first-child { grid-column: 1 / -1; }
+    > :first-child,
+    > :nth-child(2) { grid-column: 1 / -1; }
 
     @media (max-width: 640px) {
         grid-template-columns: 1fr;
     }
 `;
 
-const StyledStoreInfoCard = styled.div`
-    grid-column: 1 / -1;
+const StyledStoreInfoRow = styled.div`
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 12px 14px;
-    border: 1px solid var(--light-gray-color);
-    border-radius: 10px;
-    background: var(--white-color);
+    flex-wrap: wrap;
 `;
 
 const StyledStoreInfoName = styled.strong`
     font-size: 15px;
     font-weight: 600;
     color: var(--black-color);
+`;
+
+const StyledInfoPlaceholder = styled.span`
+    font-size: 13px;
+    font-weight: 400;
+    color: var(--dark-gray-color2);
 `;
 
 const StyledStoreInfoType = styled.span`
@@ -222,6 +297,24 @@ const StyledStoreInfoType = styled.span`
     background: rgba(45, 127, 249, 0.08);
     padding: 2px 8px;
     border-radius: 4px;
+`;
+
+const StyledShopTypeGrid = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+`;
+
+const StyledShopTypeBtn = styled.button<{$selected: boolean}>`
+    padding: 4px 10px;
+    border: 1px solid ${(p) => p.$selected ? 'var(--blue-color)' : 'var(--light-gray-color)'};
+    border-radius: 16px;
+    background: ${(p) => p.$selected ? 'rgba(45, 127, 249, 0.08)' : 'var(--white-color)'};
+    color: ${(p) => p.$selected ? 'var(--blue-color)' : 'var(--dark-gray-color)'};
+    font-size: 12px;
+    font-weight: ${(p) => p.$selected ? '600' : '400'};
+    cursor: pointer;
+    transition: border-color 0.12s, background 0.12s;
 `;
 
 const StyledStoreCard = styled.div`

--- a/client/store/calendarStore.ts
+++ b/client/store/calendarStore.ts
@@ -23,6 +23,7 @@ import {
     syncDesignerSettings,
     syncReservationState,
     syncServiceSettings,
+    syncStoreInfo,
     syncStoreSettings,
 } from './calendarStoreHelpers';
 import {
@@ -172,6 +173,7 @@ export interface CalendarState {
     setCategoryBaseColorMap: (colorMap: Record<string, string>) => void;
     setDesigners: (designers: Designer[]) => void;
     setStoreInfo: (name: string, type: string | null) => void;
+    updateStoreInfo: (name: string, type: string | null) => void;
     setStoreSettings: (storeSettings: StoreSettings) => void;
     updateStoreBusinessHours: (hours: Partial<StoreSettings['businessHours']>) => void;
     updateStorePointSettings: (pointSettings: Partial<StoreSettings['pointSettings']>) => void;
@@ -408,6 +410,10 @@ export const useCalendarStore = create<CalendarState>((set) => ({
     setCategoryBaseColorMap: (categoryBaseColorMap) => set({categoryBaseColorMap}),
     setDesigners: (designers) => set({designers}),
     setStoreInfo: (storeName, shopType) => set({storeName, shopType}),
+    updateStoreInfo: (storeName, shopType) => {
+        set({storeName, shopType});
+        syncStoreInfo(storeName, shopType);
+    },
     setStoreSettings: (storeSettings) => set({storeSettings}),
 
     updateStoreBusinessHours: (hours) =>

--- a/client/store/calendarStoreHelpers.ts
+++ b/client/store/calendarStoreHelpers.ts
@@ -115,6 +115,19 @@ export function syncStoreSettings(storeSettings: StoreSettings): void {
     syncToServer('/api/store', storeSettings, (c) => ({...c, storeSettings}));
 }
 
+export function syncStoreInfo(storeName: string, shopType: string | null): void {
+    if (shouldUseLocalDb()) {
+        updateLocalDbSnapshot((c) => ({...c, storeName, shopType: shopType ?? undefined}));
+        return;
+    }
+
+    fetch('/api/store', {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({storeName, shopType}),
+    }).catch(() => {});
+}
+
 export function syncReservationState(reservationMap: ReservationMap, history: ReservationHistoryEntry[]): void {
     if (!shouldUseLocalDb()) {
         return;

--- a/server/api/store.ts
+++ b/server/api/store.ts
@@ -106,6 +106,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(200).json(nextData);
     }
 
-    res.setHeader('Allow', ['GET', 'PUT']);
+    if (req.method === 'PATCH') {
+        if (!requireRole(session, 'manager', res)) return;
+
+        const {storeName, shopType} = req.body as {storeName?: unknown; shopType?: unknown};
+
+        if (storeName !== undefined && (typeof storeName !== 'string' || !storeName.trim())) {
+            return res.status(400).json({error: 'Invalid storeName'});
+        }
+        if (shopType !== undefined && shopType !== null && typeof shopType !== 'string') {
+            return res.status(400).json({error: 'Invalid shopType'});
+        }
+
+        await prisma.store.update({
+            where: {id: session.storeId},
+            data: {
+                ...(storeName !== undefined && {name: (storeName as string).trim()}),
+                ...(shopType !== undefined && {shopType: shopType as string | null}),
+            },
+        });
+
+        return res.status(200).json({storeName: storeName ?? undefined, shopType: shopType ?? undefined});
+    }
+
+    res.setHeader('Allow', ['GET', 'PUT', 'PATCH']);
     return res.status(405).end(`Method ${req.method} Not Allowed`);
 }


### PR DESCRIPTION
매장 설정 페이지 상단에 온보딩 때 등록한 매장명·업종을 표시하고, 수정할 수 있는 카드 추가

- `StoreManageSection` 상단에 "매장 정보" 카드 추가
- 매장명 텍스트 입력 + 업종 pill 버튼으로 수정 가능
- 저장 시 인증 사용자 → `PATCH /api/store`, 게스트 → localDb 업데이트
- `server/api/store.ts` PATCH 엔드포인트 추가
- `calendarStore.updateStoreInfo` 액션 및 `syncStoreInfo` 헬퍼 추가

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_