### PR TITLE
feat: SNS 로그인 사용자 닉네임 수정 기능 추가 (중복체크 + 추천닉네임)

### DIFF
--- a/client/auth.ts
+++ b/client/auth.ts
@@ -89,7 +89,12 @@ export const {handlers, auth, signIn, signOut} = NextAuth({
 
             return true;
         },
-        async jwt({token, account, user}) {
+        async jwt({token, account, user, trigger, session}) {
+            if (trigger === 'update' && session?.name) {
+                token.name = session.name;
+                return token;
+            }
+
             if (account) {
                 token.sub = account.providerAccountId;
                 token.provider = account.provider;

--- a/client/features/local-db/storage.ts
+++ b/client/features/local-db/storage.ts
@@ -22,7 +22,6 @@ export interface LocalDbSnapshot {
     onboarded?: boolean;
     storeName?: string;
     shopType?: string;
-    nickname?: string;
 }
 
 function cloneSnapshot(snapshot: LocalDbSnapshot): LocalDbSnapshot {

--- a/client/pages/api/user/nickname.ts
+++ b/client/pages/api/user/nickname.ts
@@ -1,0 +1,89 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {auth} from '../../../auth';
+import {prisma} from '../../../lib/prisma';
+
+const ADJECTIVES = [
+    '빠른', '조용한', '반짝이는', '든든한', '기민한', '상냥한', '산뜻한', '영리한',
+    '부드러운', '선명한', '고요한', '유연한', '차분한', '활기찬', '단단한', '기쁜',
+];
+
+const NOUNS = [
+    '고래', '사자', '여우', '호랑이', '돌고래', '부엉이', '토끼', '하늘', '바다', '별',
+    '달', '숲', '파도', '바람', '구름', '노을',
+];
+
+function randomItem(arr: string[]): string {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+async function generateSuggestions(base: string, count = 4): Promise<string[]> {
+    const results: string[] = [];
+
+    // Try base + random 3-digit numbers first
+    for (let i = 0; i < 20 && results.length < count; i++) {
+        const num = String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+        const candidate = `${base}${num}`;
+        const exists = await prisma.user.findUnique({where: {nickname: candidate}, select: {id: true}});
+        if (!exists && !results.includes(candidate)) results.push(candidate);
+    }
+
+    // Fill remaining with random adj+noun+num pool
+    for (let i = 0; i < 30 && results.length < count; i++) {
+        const num = String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+        const candidate = `${randomItem(ADJECTIVES)}${randomItem(NOUNS)}${num}`;
+        const exists = await prisma.user.findUnique({where: {nickname: candidate}, select: {id: true}});
+        if (!exists && !results.includes(candidate)) results.push(candidate);
+    }
+
+    return results;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'PATCH') {
+        res.setHeader('Allow', ['PATCH']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+
+    const session = await auth(req, res);
+    if (!session?.user?.id) {
+        return res.status(401).json({error: '로그인이 필요합니다.'});
+    }
+
+    const userId = session.user.id;
+    const {nickname} = req.body as {nickname?: unknown};
+
+    if (typeof nickname !== 'string' || nickname.trim().length < 2 || nickname.trim().length > 20) {
+        return res.status(400).json({error: '닉네임은 2~20자 이내로 입력해 주세요.'});
+    }
+
+    const trimmed = nickname.trim();
+
+    // Same as current — no-op
+    const currentUser = await prisma.user.findUnique({
+        where: {id: userId},
+        select: {nickname: true},
+    });
+
+    if (currentUser?.nickname === trimmed) {
+        return res.status(200).json({nickname: trimmed});
+    }
+
+    // Duplicate check
+    const existing = await prisma.user.findUnique({
+        where: {nickname: trimmed},
+        select: {id: true},
+    });
+
+    if (existing) {
+        const suggestions = await generateSuggestions(trimmed);
+        return res.status(409).json({error: 'duplicate', suggestions});
+    }
+
+    await prisma.user.update({
+        where: {id: userId},
+        data: {nickname: trimmed, name: trimmed},
+    });
+
+    return res.status(200).json({nickname: trimmed});
+}

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -35,7 +35,7 @@ type MyPageProps = {
 };
 
 const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
-    const {data: session, status} = useSession();
+    const {data: session, status, update: updateSession} = useSession();
     const [isLocalMode, setIsLocalMode] = useState(false);
     const storeCustomerMap = useCalendarStore((s) => s.customerMap);
     const storeReservationMap = useCalendarStore((s) => s.reservationMap);
@@ -59,6 +59,9 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [isEditingNickname, setIsEditingNickname] = useState(false);
     const [nicknameInput, setNicknameInput] = useState('');
+    const [nicknameError, setNicknameError] = useState('');
+    const [nicknameSuggestions, setNicknameSuggestions] = useState<string[]>([]);
+    const [nicknameLoading, setNicknameLoading] = useState(false);
 
     useEffect(() => {
         const localMode = status !== 'authenticated' && shouldUseLocalDb();
@@ -74,14 +77,43 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
 
     const effectiveLocalSnapshot = isLocalMode ? localSnapshot : null;
     const storageModeLabel = isLocalMode ? '게스트 회원' : '로그인 회원';
-    const guestNickname = effectiveLocalSnapshot?.nickname ?? '게스트';
 
-    const handleSaveNickname = () => {
-        if (!nicknameInput.trim()) return;
-        const snapshot = loadLocalDbSnapshot();
-        snapshot.nickname = nicknameInput.trim();
-        saveLocalDbSnapshot(snapshot);
-        setIsEditingNickname(false);
+    const handleSaveNickname = async () => {
+        const trimmed = nicknameInput.trim();
+        if (trimmed.length < 2) {
+            setNicknameError('닉네임은 2자 이상 입력해 주세요.');
+            return;
+        }
+        setNicknameLoading(true);
+        setNicknameError('');
+        setNicknameSuggestions([]);
+
+        try {
+            const res = await fetch('/api/user/nickname', {
+                method: 'PATCH',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({nickname: trimmed}),
+            });
+            const data = await res.json() as {nickname?: string; error?: string; suggestions?: string[]};
+
+            if (res.status === 409) {
+                setNicknameError('이미 사용 중인 닉네임입니다.');
+                setNicknameSuggestions(data.suggestions ?? []);
+                return;
+            }
+
+            if (!res.ok) {
+                setNicknameError(data.error ?? '오류가 발생했습니다.');
+                return;
+            }
+
+            await updateSession({name: trimmed});
+            setIsEditingNickname(false);
+        } catch {
+            setNicknameError('네트워크 오류가 발생했습니다.');
+        } finally {
+            setNicknameLoading(false);
+        }
     };
 
     const localSummary = useMemo(() => ({
@@ -110,31 +142,73 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                     </StyledRow>
                     <StyledRow>
                         <StyledLabel>별명</StyledLabel>
-                        {isLocalMode ? (
+                        {!isLocalMode && session?.user ? (
                             isEditingNickname ? (
-                                <StyledNicknameEditRow>
-                                    <StyledNicknameInput
-                                        type="text"
-                                        value={nicknameInput}
-                                        onChange={(e) => setNicknameInput(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') handleSaveNickname();
-                                            if (e.key === 'Escape') setIsEditingNickname(false);
-                                        }}
-                                        placeholder="닉네임 입력"
-                                        autoFocus
-                                        maxLength={20}
-                                    />
-                                    <StyledNicknameBtn type="button" onClick={handleSaveNickname}>저장</StyledNicknameBtn>
-                                    <StyledNicknameBtn type="button" $cancel onClick={() => setIsEditingNickname(false)}>취소</StyledNicknameBtn>
-                                </StyledNicknameEditRow>
+                                <StyledNicknameBlock>
+                                    <StyledNicknameEditRow>
+                                        <StyledNicknameInput
+                                            type="text"
+                                            value={nicknameInput}
+                                            onChange={(e) => {
+                                                setNicknameInput(e.target.value);
+                                                setNicknameError('');
+                                                setNicknameSuggestions([]);
+                                            }}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') handleSaveNickname();
+                                                if (e.key === 'Escape') {
+                                                    setIsEditingNickname(false);
+                                                    setNicknameError('');
+                                                    setNicknameSuggestions([]);
+                                                }
+                                            }}
+                                            placeholder="2~20자"
+                                            autoFocus
+                                            maxLength={20}
+                                            disabled={nicknameLoading}
+                                        />
+                                        <StyledNicknameBtn type="button" onClick={handleSaveNickname} disabled={nicknameLoading}>
+                                            {nicknameLoading ? '...' : '저장'}
+                                        </StyledNicknameBtn>
+                                        <StyledNicknameBtn type="button" $cancel onClick={() => {
+                                            setIsEditingNickname(false);
+                                            setNicknameError('');
+                                            setNicknameSuggestions([]);
+                                        }}>
+                                            취소
+                                        </StyledNicknameBtn>
+                                    </StyledNicknameEditRow>
+                                    {nicknameError && (
+                                        <StyledNicknameError>{nicknameError}</StyledNicknameError>
+                                    )}
+                                    {nicknameSuggestions.length > 0 && (
+                                        <StyledSuggestions>
+                                            <StyledSuggestionsLabel>추천 닉네임</StyledSuggestionsLabel>
+                                            <StyledSuggestionList>
+                                                {nicknameSuggestions.map((s) => (
+                                                    <StyledSuggestionChip
+                                                        key={s}
+                                                        type="button"
+                                                        onClick={() => {
+                                                            setNicknameInput(s);
+                                                            setNicknameError('');
+                                                            setNicknameSuggestions([]);
+                                                        }}
+                                                    >
+                                                        {s}
+                                                    </StyledSuggestionChip>
+                                                ))}
+                                            </StyledSuggestionList>
+                                        </StyledSuggestions>
+                                    )}
+                                </StyledNicknameBlock>
                             ) : (
                                 <StyledNicknameView>
-                                    <StyledValue>{guestNickname}</StyledValue>
+                                    <StyledValue>{session.user.name ?? '-'}</StyledValue>
                                     <StyledNicknameEditTrigger
                                         type="button"
                                         onClick={() => {
-                                            setNicknameInput(effectiveLocalSnapshot?.nickname ?? '');
+                                            setNicknameInput(session.user?.name ?? '');
                                             setIsEditingNickname(true);
                                         }}
                                     >
@@ -143,7 +217,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                                 </StyledNicknameView>
                             )
                         ) : (
-                            <StyledValue>{session?.user?.name ?? '-'}</StyledValue>
+                            <StyledValue>게스트</StyledValue>
                         )}
                     </StyledRow>
                     <StyledRow>
@@ -527,6 +601,14 @@ const StyledNicknameView = styled.div`
     gap: 8px;
 `;
 
+const StyledNicknameBlock = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+    align-items: flex-end;
+`;
+
 const StyledNicknameEditTrigger = styled.button`
     padding: 2px 8px;
     border: 1px solid var(--light-gray-color);
@@ -541,7 +623,7 @@ const StyledNicknameEditRow = styled.div`
     display: flex;
     align-items: center;
     gap: 6px;
-    flex: 1;
+    width: 100%;
     justify-content: flex-end;
 `;
 
@@ -555,6 +637,8 @@ const StyledNicknameInput = styled.input`
     color: var(--black-color);
     outline: none;
     box-sizing: border-box;
+
+    &:disabled { opacity: 0.6; }
 `;
 
 const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
@@ -568,6 +652,54 @@ const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
     font-weight: 600;
     cursor: pointer;
     flex-shrink: 0;
+
+    &:disabled { opacity: 0.6; cursor: default; }
+`;
+
+const StyledNicknameError = styled.p`
+    margin: 0;
+    font-size: 12px;
+    color: var(--danger-color);
+    text-align: right;
+`;
+
+const StyledSuggestions = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-end;
+    width: 100%;
+`;
+
+const StyledSuggestionsLabel = styled.span`
+    font-size: 11px;
+    color: var(--dark-gray-color2);
+`;
+
+const StyledSuggestionList = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: flex-end;
+`;
+
+const StyledSuggestionChip = styled.button`
+    padding: 3px 10px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 999px;
+    background: var(--gray-color2);
+    font-size: 12px;
+    color: var(--dark-gray-color);
+    cursor: pointer;
+    transition: border-color 0.12s, background 0.12s;
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--blue-color);
+            color: var(--blue-color);
+            background: rgba(45, 127, 249, 0.06);
+        }
+    }
 `;
 
 const StyledFooterCs = styled.p`


### PR DESCRIPTION
마이페이지 별명 수정 로직 재설계

- **게스트**: '게스트' 고정 표시, 수정 불가
- **SNS 로그인 사용자**: 인라인 수정 가능
  - 2~20자 유효성 검사
  - `PATCH /api/user/nickname` 중복 확인
  - 중복 시 하단에 추천 닉네임 4개 chip 표시 (클릭하면 입력창에 자동 입력)
  - 저장 성공 시 JWT 세션 즉시 갱신 (`updateSession({name})`)
- `auth.ts` JWT 콜백에 `trigger: "update"` 처리 추가

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_