### PR TITLE
refactor: validation error UI 공통화 (FieldError 컴포넌트) + UI index 추가

### DIFF
--- a/client/components/account/AccountDeleteModal.tsx
+++ b/client/components/account/AccountDeleteModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '../calendar/overlays/ModalStyles';
 import {CloseIconButton} from '../ui/CloseIconButton';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 interface AccountDeleteModalProps {
     role: string | undefined;
@@ -83,7 +84,7 @@ export const AccountDeleteModal = ({role, onClose}: AccountDeleteModalProps) => 
                                  placeholder={CONFIRM_TEXT}
                                  value={input}
                                  onChange={(e) => setInput(e.target.value)} />
-                    {error && <StyledError>{error}</StyledError>}
+                    <FieldError variant="inline">{error}</FieldError>
                 </StyledModalContent>
                 <StyledFooter>
                     <BaseActionButton type="button" onClick={onClose}>
@@ -126,8 +127,3 @@ const StyledDangerButton = styled(BaseActionButton)`
     }
 `;
 
-const StyledError = styled.p`
-    margin: 8px 0 0;
-    font-size: 12px;
-    color: #be123c;
-`;

--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -3,6 +3,7 @@ import {useEffect, useRef, useState} from 'react';
 import styled, {css} from 'styled-components';
 import {formControlStyle} from '../../ui/FormControls';
 import {LabelBadge} from '../../ui/LabelBadge';
+import {FieldError} from '../../ui/FieldError';
 
 export const OVERLAY_Z_INDEX = {
     base: 100,
@@ -285,24 +286,7 @@ export const StyledFieldRow = styled.div`
     }
 `;
 
-const errorMessageStyle = css`
-    width: 100%;
-    padding: var(--gap-md) var(--gap-lg);
-    background-color: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    border-radius: var(--radius-sm);
-    font-size: var(--small-font);
-    color: var(--danger-color);
-`;
-
-export const StyledError = styled.p`
-    margin: 10px 0 0;
-    ${errorMessageStyle};
-`;
-
-export const StyledInlineError = styled(StyledError)`
-    margin-top: 8px;
-`;
+export {FieldError as StyledError, FieldError as StyledInlineError};
 
 export const StyledPriceRow = styled.div`
     display: flex;

--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {LabelBadge} from '../ui/LabelBadge';
 import {PageHero} from '../ui/PageHero';
 import {StyledEmpty} from './settings-styles';
+import {FieldError} from '../ui/FieldError';
 
 type Invite = {
     id: string;
@@ -172,7 +173,7 @@ export const MemberSection = () => {
                         {creating ? '생성 중...' : '코드 생성'}
                     </StyledPrimaryButton>
                 </StyledCreateRow>
-                {error && <StyledError>{error}</StyledError>}
+                <FieldError>{error}</FieldError>
             </StyledCard>
 
             <StyledCard>
@@ -322,15 +323,6 @@ const StyledPrimaryButton = styled.button`
     }
 `;
 
-const StyledError = styled.p`
-    margin: 8px 0 0;
-    padding: 8px 10px;
-    border-radius: var(--radius-md);
-    background: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    color: var(--danger-color);
-    font-size: 12px;
-`;
 
 const StyledList = styled.div`
     display: flex;

--- a/client/components/settings/ServiceManageSection.tsx
+++ b/client/components/settings/ServiceManageSection.tsx
@@ -16,12 +16,12 @@ import {
     StyledActionButton,
     StyledForm,
     StyledFieldRow,
-    StyledInlineError,
     useDialogAccessibility,
     useLayerInstanceId,
 } from '../calendar/overlays/ModalStyles';
 import {CloseIconButton} from '../ui/CloseIconButton';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 /* ------------------------------------------------------------------ */
 /*  ServiceEditModal                                                   */
@@ -122,7 +122,7 @@ const ServiceEditModal = ({item, serviceCatalog, onSave, onDelete, onClose}: Ser
                                 />
                             </label>
                         </StyledFieldRow>
-                        {error && <StyledInlineError>{error}</StyledInlineError>}
+                        <FieldError>{error}</FieldError>
                     </StyledForm>
                 </StyledModalBody>
                 <StyledFooter>
@@ -265,7 +265,7 @@ const ServiceAddModal = ({categories, serviceCatalog, onAdd, onClose}: ServiceAd
                                 />
                             </label>
                         </StyledFieldRow>
-                        {error && <StyledInlineError>{error}</StyledInlineError>}
+                        <FieldError>{error}</FieldError>
                     </StyledForm>
                 </StyledModalBody>
                 <StyledFooter>
@@ -509,7 +509,7 @@ export const ServiceManageSection = () => {
                     </StyledGroup>
                 ))}
             </StyledServiceBody>
-            {manageError && <StyledManageNotice>{manageError}</StyledManageNotice>}
+            <FieldError variant="inline">{manageError}</FieldError>
 
             <StyledServiceFooter>
                 <StyledAddButton type="button" onClick={() => setShowAddModal(true)}>+ 서비스 추가</StyledAddButton>
@@ -861,10 +861,3 @@ const StyledAddButton = styled.button`
     }
 `;
 
-const StyledManageNotice = styled.p`
-    margin: 0;
-    padding: 8px 16px 0;
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--red-color);
-`;

--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -7,6 +7,7 @@ import {StyledEditBtn, StyledDeleteBtn, StyledSaveBtn, StyledCancelBtn, StyledEm
 import {useCalendarStore} from '../../store/calendarStore';
 import {PageHero} from '../ui/PageHero';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 interface StoreManageSectionProps {
     formatDateLabel: (dateKey: string) => string;
@@ -126,7 +127,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                                 </StyledShopTypeBtn>
                             ))}
                         </StyledShopTypeGrid>
-                        {storeInfoError && <StyledAddNotice>{storeInfoError}</StyledAddNotice>}
+                        <FieldError variant="inline">{storeInfoError}</FieldError>
                         <StyledStoreActionRow>
                             <StyledCancelBtn
                                 type="button"
@@ -214,7 +215,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                             />
                             <StyledSaveBtn type="button" onClick={handleAddClosedDate}>추가</StyledSaveBtn>
                         </StyledClosedDateAddRow>
-                        {closedDateError && <StyledAddNotice>{closedDateError}</StyledAddNotice>}
+                        <FieldError variant="inline">{closedDateError}</FieldError>
                     </>
                 )}
                 {closedDates.length === 0 ? (
@@ -398,10 +399,4 @@ const StyledDateInput = styled.input`
     padding: 0 8px;
 `;
 
-const StyledAddNotice = styled.p`
-    margin: 0;
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--red-color);
-`;
 

--- a/client/components/ui/FieldError.tsx
+++ b/client/components/ui/FieldError.tsx
@@ -1,0 +1,34 @@
+import type {ReactNode} from 'react';
+
+import styled from 'styled-components';
+
+interface FieldErrorProps {
+    children?: ReactNode;
+    variant?: 'box' | 'inline';
+    className?: string;
+}
+
+export const FieldError = ({children, variant = 'box', className}: FieldErrorProps) => {
+    if (!children) return null;
+    return variant === 'inline'
+        ? <StyledInline className={className}>{children}</StyledInline>
+        : <StyledBox className={className}>{children}</StyledBox>;
+};
+
+const StyledBox = styled.p`
+    margin: 8px 0 0;
+    padding: var(--gap-md) var(--gap-lg);
+    background: var(--danger-bg);
+    border: 1px solid var(--danger-border);
+    border-radius: var(--radius-sm);
+    font-size: var(--small-font);
+    color: var(--danger-color);
+    line-height: 1.5;
+`;
+
+const StyledInline = styled.p`
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--danger-color);
+`;

--- a/client/components/ui/index.ts
+++ b/client/components/ui/index.ts
@@ -1,0 +1,14 @@
+export {AuthActionIcon} from './AuthActionIcon';
+export {ButtonText} from './ButtonText';
+export {ButtonSquare, ButtonCircle, ButtonReserve, ButtonAdd} from './Buttons';
+export {CloseIconButton} from './CloseIconButton';
+export {ColorPickerButton} from './ColorPickerButton';
+export {ColorTag} from './ColorTag';
+export {DesignerLabel} from './DesignerLabel';
+export {Dot} from './Dot';
+export {FieldError} from './FieldError';
+export {formControlStyle} from './FormControls';
+export {LabelBadge} from './LabelBadge';
+export {NewCustomerBadge} from './NewCustomerBadge';
+export {PageHero} from './PageHero';
+export {ServiceChipList} from './ServiceChip';

--- a/client/pages/inquiry.tsx
+++ b/client/pages/inquiry.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {PageHero} from '../components/ui/PageHero';
 import {actionButtonStyle} from '../components/settings/settings-styles';
+import {FieldError} from '../components/ui/FieldError';
 
 type InquiryTab = 'form' | 'history';
 
@@ -147,7 +148,7 @@ const InquiryPage: NextPage = () => {
                                             onChange={(e) => setContent(e.target.value)}
                                         />
                                     </StyledFieldGroup>
-                                    {error && <StyledError>{error}</StyledError>}
+                                    <FieldError>{error}</FieldError>
                                     <StyledSubmitButton type="submit" disabled={submitting}>
                                         {submitting ? '전송 중...' : '문의 전송'}
                                     </StyledSubmitButton>
@@ -295,14 +296,6 @@ const StyledTextarea = styled.textarea`
     }
 `;
 
-const StyledError = styled.div`
-    padding: 10px 12px;
-    border: 1px solid #fecaca;
-    border-radius: var(--radius-md);
-    background: #fff1f2;
-    color: #9f1239;
-    font-size: 13px;
-`;
 
 const StyledSubmitButton = styled.button`
     display: flex;

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -7,6 +7,7 @@ import {signIn, signOut, useSession} from 'next-auth/react';
 import styled from 'styled-components';
 
 import {AuthActionIcon} from '../components/ui/AuthActionIcon';
+import {FieldError} from '../components/ui/FieldError';
 import {PageHero} from '../components/ui/PageHero';
 import {AccountDeleteModal} from '../components/account/AccountDeleteModal';
 import {CustomerDetail} from '../components/calendar/overlays/CustomerDetail';
@@ -178,9 +179,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                                             취소
                                         </StyledNicknameBtn>
                                     </StyledNicknameEditRow>
-                                    {nicknameError && (
-                                        <StyledNicknameError>{nicknameError}</StyledNicknameError>
-                                    )}
+                                    <FieldError variant="inline">{nicknameError}</FieldError>
                                     {nicknameSuggestions.length > 0 && (
                                         <StyledSuggestions>
                                             <StyledSuggestionsLabel>추천 닉네임</StyledSuggestionsLabel>
@@ -656,12 +655,6 @@ const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
     &:disabled { opacity: 0.6; cursor: default; }
 `;
 
-const StyledNicknameError = styled.p`
-    margin: 0;
-    font-size: 12px;
-    color: var(--danger-color);
-    text-align: right;
-`;
 
 const StyledSuggestions = styled.div`
     display: flex;

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -7,6 +7,7 @@ import Head from 'next/head';
 import styled from 'styled-components';
 
 import {getPageSession} from '../lib/page-data';
+import {FieldError} from '../components/ui/FieldError';
 import {DEFAULT_SERVICES, SHOP_CATEGORY_COLOR_MAP} from '../features/services/default-services';
 import type {ShopType} from '../features/services/default-services';
 import {createDefaultSchedule, getDesignerColor} from '../utils/designers';
@@ -139,7 +140,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                     </StyledTypeGrid>
                 </StyledSection>
 
-                {error && <StyledError>{error}</StyledError>}
+                <FieldError>{error}</FieldError>
 
                 <StyledSubmitBtn
                     type="button"
@@ -306,15 +307,6 @@ const StyledTypeDesc = styled.span`
     line-height: 1.4;
 `;
 
-const StyledError = styled.p`
-    margin: 0;
-    padding: 10px 14px;
-    font-size: 13px;
-    color: var(--danger-color);
-    background: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    border-radius: var(--radius-md);
-`;
 
 const StyledSubmitBtn = styled.button`
     height: 48px;


### PR DESCRIPTION
## Summary

- `FieldError` 공통 컴포넌트 생성 (`client/components/ui/FieldError.tsx`)
  - `variant="box"` (기본): 배경+테두리 스타일 (모달, 페이지 폼)
  - `variant="inline"`: 텍스트만 (설정 섹션 필드 옆)
  - `children` 없으면 자동으로 `null` 반환 — 조건부 렌더링 불필요
- 기존 중복 에러 styled-components 제거 및 `FieldError`로 교체
  - `StyledError` / `StyledInlineError` (ModalStyles.ts)
  - `StyledAddNotice` (StoreManageSection)
  - `StyledManageNotice` (ServiceManageSection)
  - `StyledError` (MemberSection, AccountDeleteModal)
  - `StyledError` (onboarding, inquiry, mypage)
- `client/components/ui/index.ts` 생성 — UI 컴포넌트 디자인 시스템 진입점

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_