### PR TITLE
feat: SNS 닉네임 수정 + FieldError UI 공통화

### DIFF
--- a/client/auth.ts
+++ b/client/auth.ts
@@ -89,7 +89,12 @@ export const {handlers, auth, signIn, signOut} = NextAuth({
 
             return true;
         },
-        async jwt({token, account, user}) {
+        async jwt({token, account, user, trigger, session}) {
+            if (trigger === 'update' && session?.name) {
+                token.name = session.name;
+                return token;
+            }
+
             if (account) {
                 token.sub = account.providerAccountId;
                 token.provider = account.provider;

--- a/client/components/account/AccountDeleteModal.tsx
+++ b/client/components/account/AccountDeleteModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '../calendar/overlays/ModalStyles';
 import {CloseIconButton} from '../ui/CloseIconButton';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 interface AccountDeleteModalProps {
     role: string | undefined;
@@ -83,7 +84,7 @@ export const AccountDeleteModal = ({role, onClose}: AccountDeleteModalProps) => 
                                  placeholder={CONFIRM_TEXT}
                                  value={input}
                                  onChange={(e) => setInput(e.target.value)} />
-                    {error && <StyledError>{error}</StyledError>}
+                    <FieldError variant="inline">{error}</FieldError>
                 </StyledModalContent>
                 <StyledFooter>
                     <BaseActionButton type="button" onClick={onClose}>
@@ -126,8 +127,3 @@ const StyledDangerButton = styled(BaseActionButton)`
     }
 `;
 
-const StyledError = styled.p`
-    margin: 8px 0 0;
-    font-size: 12px;
-    color: #be123c;
-`;

--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -3,6 +3,7 @@ import {useEffect, useRef, useState} from 'react';
 import styled, {css} from 'styled-components';
 import {formControlStyle} from '../../ui/FormControls';
 import {LabelBadge} from '../../ui/LabelBadge';
+import {FieldError} from '../../ui/FieldError';
 
 export const OVERLAY_Z_INDEX = {
     base: 100,
@@ -285,24 +286,7 @@ export const StyledFieldRow = styled.div`
     }
 `;
 
-const errorMessageStyle = css`
-    width: 100%;
-    padding: var(--gap-md) var(--gap-lg);
-    background-color: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    border-radius: var(--radius-sm);
-    font-size: var(--small-font);
-    color: var(--danger-color);
-`;
-
-export const StyledError = styled.p`
-    margin: 10px 0 0;
-    ${errorMessageStyle};
-`;
-
-export const StyledInlineError = styled(StyledError)`
-    margin-top: 8px;
-`;
+export {FieldError as StyledError, FieldError as StyledInlineError};
 
 export const StyledPriceRow = styled.div`
     display: flex;

--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import {LabelBadge} from '../ui/LabelBadge';
 import {PageHero} from '../ui/PageHero';
 import {StyledEmpty} from './settings-styles';
+import {FieldError} from '../ui/FieldError';
 
 type Invite = {
     id: string;
@@ -172,7 +173,7 @@ export const MemberSection = () => {
                         {creating ? '생성 중...' : '코드 생성'}
                     </StyledPrimaryButton>
                 </StyledCreateRow>
-                {error && <StyledError>{error}</StyledError>}
+                <FieldError>{error}</FieldError>
             </StyledCard>
 
             <StyledCard>
@@ -322,15 +323,6 @@ const StyledPrimaryButton = styled.button`
     }
 `;
 
-const StyledError = styled.p`
-    margin: 8px 0 0;
-    padding: 8px 10px;
-    border-radius: var(--radius-md);
-    background: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    color: var(--danger-color);
-    font-size: 12px;
-`;
 
 const StyledList = styled.div`
     display: flex;

--- a/client/components/settings/ServiceManageSection.tsx
+++ b/client/components/settings/ServiceManageSection.tsx
@@ -16,12 +16,12 @@ import {
     StyledActionButton,
     StyledForm,
     StyledFieldRow,
-    StyledInlineError,
     useDialogAccessibility,
     useLayerInstanceId,
 } from '../calendar/overlays/ModalStyles';
 import {CloseIconButton} from '../ui/CloseIconButton';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 /* ------------------------------------------------------------------ */
 /*  ServiceEditModal                                                   */
@@ -122,7 +122,7 @@ const ServiceEditModal = ({item, serviceCatalog, onSave, onDelete, onClose}: Ser
                                 />
                             </label>
                         </StyledFieldRow>
-                        {error && <StyledInlineError>{error}</StyledInlineError>}
+                        <FieldError>{error}</FieldError>
                     </StyledForm>
                 </StyledModalBody>
                 <StyledFooter>
@@ -265,7 +265,7 @@ const ServiceAddModal = ({categories, serviceCatalog, onAdd, onClose}: ServiceAd
                                 />
                             </label>
                         </StyledFieldRow>
-                        {error && <StyledInlineError>{error}</StyledInlineError>}
+                        <FieldError>{error}</FieldError>
                     </StyledForm>
                 </StyledModalBody>
                 <StyledFooter>
@@ -509,7 +509,7 @@ export const ServiceManageSection = () => {
                     </StyledGroup>
                 ))}
             </StyledServiceBody>
-            {manageError && <StyledManageNotice>{manageError}</StyledManageNotice>}
+            <FieldError variant="inline">{manageError}</FieldError>
 
             <StyledServiceFooter>
                 <StyledAddButton type="button" onClick={() => setShowAddModal(true)}>+ 서비스 추가</StyledAddButton>
@@ -861,10 +861,3 @@ const StyledAddButton = styled.button`
     }
 `;
 
-const StyledManageNotice = styled.p`
-    margin: 0;
-    padding: 8px 16px 0;
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--red-color);
-`;

--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -7,6 +7,7 @@ import {StyledEditBtn, StyledDeleteBtn, StyledSaveBtn, StyledCancelBtn, StyledEm
 import {useCalendarStore} from '../../store/calendarStore';
 import {PageHero} from '../ui/PageHero';
 import {formControlStyle} from '../ui/FormControls';
+import {FieldError} from '../ui/FieldError';
 
 interface StoreManageSectionProps {
     formatDateLabel: (dateKey: string) => string;
@@ -126,7 +127,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                                 </StyledShopTypeBtn>
                             ))}
                         </StyledShopTypeGrid>
-                        {storeInfoError && <StyledAddNotice>{storeInfoError}</StyledAddNotice>}
+                        <FieldError variant="inline">{storeInfoError}</FieldError>
                         <StyledStoreActionRow>
                             <StyledCancelBtn
                                 type="button"
@@ -214,7 +215,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                             />
                             <StyledSaveBtn type="button" onClick={handleAddClosedDate}>추가</StyledSaveBtn>
                         </StyledClosedDateAddRow>
-                        {closedDateError && <StyledAddNotice>{closedDateError}</StyledAddNotice>}
+                        <FieldError variant="inline">{closedDateError}</FieldError>
                     </>
                 )}
                 {closedDates.length === 0 ? (
@@ -398,10 +399,4 @@ const StyledDateInput = styled.input`
     padding: 0 8px;
 `;
 
-const StyledAddNotice = styled.p`
-    margin: 0;
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--red-color);
-`;
 

--- a/client/components/ui/FieldError.tsx
+++ b/client/components/ui/FieldError.tsx
@@ -1,0 +1,34 @@
+import type {ReactNode} from 'react';
+
+import styled from 'styled-components';
+
+interface FieldErrorProps {
+    children?: ReactNode;
+    variant?: 'box' | 'inline';
+    className?: string;
+}
+
+export const FieldError = ({children, variant = 'box', className}: FieldErrorProps) => {
+    if (!children) return null;
+    return variant === 'inline'
+        ? <StyledInline className={className}>{children}</StyledInline>
+        : <StyledBox className={className}>{children}</StyledBox>;
+};
+
+const StyledBox = styled.p`
+    margin: 8px 0 0;
+    padding: var(--gap-md) var(--gap-lg);
+    background: var(--danger-bg);
+    border: 1px solid var(--danger-border);
+    border-radius: var(--radius-sm);
+    font-size: var(--small-font);
+    color: var(--danger-color);
+    line-height: 1.5;
+`;
+
+const StyledInline = styled.p`
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--danger-color);
+`;

--- a/client/components/ui/index.ts
+++ b/client/components/ui/index.ts
@@ -1,0 +1,14 @@
+export {AuthActionIcon} from './AuthActionIcon';
+export {ButtonText} from './ButtonText';
+export {ButtonSquare, ButtonCircle, ButtonReserve, ButtonAdd} from './Buttons';
+export {CloseIconButton} from './CloseIconButton';
+export {ColorPickerButton} from './ColorPickerButton';
+export {ColorTag} from './ColorTag';
+export {DesignerLabel} from './DesignerLabel';
+export {Dot} from './Dot';
+export {FieldError} from './FieldError';
+export {formControlStyle} from './FormControls';
+export {LabelBadge} from './LabelBadge';
+export {NewCustomerBadge} from './NewCustomerBadge';
+export {PageHero} from './PageHero';
+export {ServiceChipList} from './ServiceChip';

--- a/client/features/local-db/storage.ts
+++ b/client/features/local-db/storage.ts
@@ -22,7 +22,6 @@ export interface LocalDbSnapshot {
     onboarded?: boolean;
     storeName?: string;
     shopType?: string;
-    nickname?: string;
 }
 
 function cloneSnapshot(snapshot: LocalDbSnapshot): LocalDbSnapshot {

--- a/client/pages/api/user/nickname.ts
+++ b/client/pages/api/user/nickname.ts
@@ -1,0 +1,89 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {auth} from '../../../auth';
+import {prisma} from '../../../lib/prisma';
+
+const ADJECTIVES = [
+    '빠른', '조용한', '반짝이는', '든든한', '기민한', '상냥한', '산뜻한', '영리한',
+    '부드러운', '선명한', '고요한', '유연한', '차분한', '활기찬', '단단한', '기쁜',
+];
+
+const NOUNS = [
+    '고래', '사자', '여우', '호랑이', '돌고래', '부엉이', '토끼', '하늘', '바다', '별',
+    '달', '숲', '파도', '바람', '구름', '노을',
+];
+
+function randomItem(arr: string[]): string {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+async function generateSuggestions(base: string, count = 4): Promise<string[]> {
+    const results: string[] = [];
+
+    // Try base + random 3-digit numbers first
+    for (let i = 0; i < 20 && results.length < count; i++) {
+        const num = String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+        const candidate = `${base}${num}`;
+        const exists = await prisma.user.findUnique({where: {nickname: candidate}, select: {id: true}});
+        if (!exists && !results.includes(candidate)) results.push(candidate);
+    }
+
+    // Fill remaining with random adj+noun+num pool
+    for (let i = 0; i < 30 && results.length < count; i++) {
+        const num = String(Math.floor(Math.random() * 1000)).padStart(3, '0');
+        const candidate = `${randomItem(ADJECTIVES)}${randomItem(NOUNS)}${num}`;
+        const exists = await prisma.user.findUnique({where: {nickname: candidate}, select: {id: true}});
+        if (!exists && !results.includes(candidate)) results.push(candidate);
+    }
+
+    return results;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'PATCH') {
+        res.setHeader('Allow', ['PATCH']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+
+    const session = await auth(req, res);
+    if (!session?.user?.id) {
+        return res.status(401).json({error: '로그인이 필요합니다.'});
+    }
+
+    const userId = session.user.id;
+    const {nickname} = req.body as {nickname?: unknown};
+
+    if (typeof nickname !== 'string' || nickname.trim().length < 2 || nickname.trim().length > 20) {
+        return res.status(400).json({error: '닉네임은 2~20자 이내로 입력해 주세요.'});
+    }
+
+    const trimmed = nickname.trim();
+
+    // Same as current — no-op
+    const currentUser = await prisma.user.findUnique({
+        where: {id: userId},
+        select: {nickname: true},
+    });
+
+    if (currentUser?.nickname === trimmed) {
+        return res.status(200).json({nickname: trimmed});
+    }
+
+    // Duplicate check
+    const existing = await prisma.user.findUnique({
+        where: {nickname: trimmed},
+        select: {id: true},
+    });
+
+    if (existing) {
+        const suggestions = await generateSuggestions(trimmed);
+        return res.status(409).json({error: 'duplicate', suggestions});
+    }
+
+    await prisma.user.update({
+        where: {id: userId},
+        data: {nickname: trimmed, name: trimmed},
+    });
+
+    return res.status(200).json({nickname: trimmed});
+}

--- a/client/pages/inquiry.tsx
+++ b/client/pages/inquiry.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {PageHero} from '../components/ui/PageHero';
 import {actionButtonStyle} from '../components/settings/settings-styles';
+import {FieldError} from '../components/ui/FieldError';
 
 type InquiryTab = 'form' | 'history';
 
@@ -147,7 +148,7 @@ const InquiryPage: NextPage = () => {
                                             onChange={(e) => setContent(e.target.value)}
                                         />
                                     </StyledFieldGroup>
-                                    {error && <StyledError>{error}</StyledError>}
+                                    <FieldError>{error}</FieldError>
                                     <StyledSubmitButton type="submit" disabled={submitting}>
                                         {submitting ? '전송 중...' : '문의 전송'}
                                     </StyledSubmitButton>
@@ -295,14 +296,6 @@ const StyledTextarea = styled.textarea`
     }
 `;
 
-const StyledError = styled.div`
-    padding: 10px 12px;
-    border: 1px solid #fecaca;
-    border-radius: var(--radius-md);
-    background: #fff1f2;
-    color: #9f1239;
-    font-size: 13px;
-`;
 
 const StyledSubmitButton = styled.button`
     display: flex;

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -35,7 +35,7 @@ type MyPageProps = {
 };
 
 const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
-    const {data: session, status} = useSession();
+    const {data: session, status, update: updateSession} = useSession();
     const [isLocalMode, setIsLocalMode] = useState(false);
     const storeCustomerMap = useCalendarStore((s) => s.customerMap);
     const storeReservationMap = useCalendarStore((s) => s.reservationMap);
@@ -59,6 +59,9 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [isEditingNickname, setIsEditingNickname] = useState(false);
     const [nicknameInput, setNicknameInput] = useState('');
+    const [nicknameError, setNicknameError] = useState('');
+    const [nicknameSuggestions, setNicknameSuggestions] = useState<string[]>([]);
+    const [nicknameLoading, setNicknameLoading] = useState(false);
 
     useEffect(() => {
         const localMode = status !== 'authenticated' && shouldUseLocalDb();
@@ -74,14 +77,43 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
 
     const effectiveLocalSnapshot = isLocalMode ? localSnapshot : null;
     const storageModeLabel = isLocalMode ? '게스트 회원' : '로그인 회원';
-    const guestNickname = effectiveLocalSnapshot?.nickname ?? '게스트';
 
-    const handleSaveNickname = () => {
-        if (!nicknameInput.trim()) return;
-        const snapshot = loadLocalDbSnapshot();
-        snapshot.nickname = nicknameInput.trim();
-        saveLocalDbSnapshot(snapshot);
-        setIsEditingNickname(false);
+    const handleSaveNickname = async () => {
+        const trimmed = nicknameInput.trim();
+        if (trimmed.length < 2) {
+            setNicknameError('닉네임은 2자 이상 입력해 주세요.');
+            return;
+        }
+        setNicknameLoading(true);
+        setNicknameError('');
+        setNicknameSuggestions([]);
+
+        try {
+            const res = await fetch('/api/user/nickname', {
+                method: 'PATCH',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({nickname: trimmed}),
+            });
+            const data = await res.json() as {nickname?: string; error?: string; suggestions?: string[]};
+
+            if (res.status === 409) {
+                setNicknameError('이미 사용 중인 닉네임입니다.');
+                setNicknameSuggestions(data.suggestions ?? []);
+                return;
+            }
+
+            if (!res.ok) {
+                setNicknameError(data.error ?? '오류가 발생했습니다.');
+                return;
+            }
+
+            await updateSession({name: trimmed});
+            setIsEditingNickname(false);
+        } catch {
+            setNicknameError('네트워크 오류가 발생했습니다.');
+        } finally {
+            setNicknameLoading(false);
+        }
     };
 
     const localSummary = useMemo(() => ({
@@ -110,31 +142,73 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                     </StyledRow>
                     <StyledRow>
                         <StyledLabel>별명</StyledLabel>
-                        {isLocalMode ? (
+                        {!isLocalMode && session?.user ? (
                             isEditingNickname ? (
-                                <StyledNicknameEditRow>
-                                    <StyledNicknameInput
-                                        type="text"
-                                        value={nicknameInput}
-                                        onChange={(e) => setNicknameInput(e.target.value)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') handleSaveNickname();
-                                            if (e.key === 'Escape') setIsEditingNickname(false);
-                                        }}
-                                        placeholder="닉네임 입력"
-                                        autoFocus
-                                        maxLength={20}
-                                    />
-                                    <StyledNicknameBtn type="button" onClick={handleSaveNickname}>저장</StyledNicknameBtn>
-                                    <StyledNicknameBtn type="button" $cancel onClick={() => setIsEditingNickname(false)}>취소</StyledNicknameBtn>
-                                </StyledNicknameEditRow>
+                                <StyledNicknameBlock>
+                                    <StyledNicknameEditRow>
+                                        <StyledNicknameInput
+                                            type="text"
+                                            value={nicknameInput}
+                                            onChange={(e) => {
+                                                setNicknameInput(e.target.value);
+                                                setNicknameError('');
+                                                setNicknameSuggestions([]);
+                                            }}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') handleSaveNickname();
+                                                if (e.key === 'Escape') {
+                                                    setIsEditingNickname(false);
+                                                    setNicknameError('');
+                                                    setNicknameSuggestions([]);
+                                                }
+                                            }}
+                                            placeholder="2~20자"
+                                            autoFocus
+                                            maxLength={20}
+                                            disabled={nicknameLoading}
+                                        />
+                                        <StyledNicknameBtn type="button" onClick={handleSaveNickname} disabled={nicknameLoading}>
+                                            {nicknameLoading ? '...' : '저장'}
+                                        </StyledNicknameBtn>
+                                        <StyledNicknameBtn type="button" $cancel onClick={() => {
+                                            setIsEditingNickname(false);
+                                            setNicknameError('');
+                                            setNicknameSuggestions([]);
+                                        }}>
+                                            취소
+                                        </StyledNicknameBtn>
+                                    </StyledNicknameEditRow>
+                                    {nicknameError && (
+                                        <StyledNicknameError>{nicknameError}</StyledNicknameError>
+                                    )}
+                                    {nicknameSuggestions.length > 0 && (
+                                        <StyledSuggestions>
+                                            <StyledSuggestionsLabel>추천 닉네임</StyledSuggestionsLabel>
+                                            <StyledSuggestionList>
+                                                {nicknameSuggestions.map((s) => (
+                                                    <StyledSuggestionChip
+                                                        key={s}
+                                                        type="button"
+                                                        onClick={() => {
+                                                            setNicknameInput(s);
+                                                            setNicknameError('');
+                                                            setNicknameSuggestions([]);
+                                                        }}
+                                                    >
+                                                        {s}
+                                                    </StyledSuggestionChip>
+                                                ))}
+                                            </StyledSuggestionList>
+                                        </StyledSuggestions>
+                                    )}
+                                </StyledNicknameBlock>
                             ) : (
                                 <StyledNicknameView>
-                                    <StyledValue>{guestNickname}</StyledValue>
+                                    <StyledValue>{session.user.name ?? '-'}</StyledValue>
                                     <StyledNicknameEditTrigger
                                         type="button"
                                         onClick={() => {
-                                            setNicknameInput(effectiveLocalSnapshot?.nickname ?? '');
+                                            setNicknameInput(session.user?.name ?? '');
                                             setIsEditingNickname(true);
                                         }}
                                     >
@@ -143,7 +217,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                                 </StyledNicknameView>
                             )
                         ) : (
-                            <StyledValue>{session?.user?.name ?? '-'}</StyledValue>
+                            <StyledValue>게스트</StyledValue>
                         )}
                     </StyledRow>
                     <StyledRow>
@@ -527,6 +601,14 @@ const StyledNicknameView = styled.div`
     gap: 8px;
 `;
 
+const StyledNicknameBlock = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+    align-items: flex-end;
+`;
+
 const StyledNicknameEditTrigger = styled.button`
     padding: 2px 8px;
     border: 1px solid var(--light-gray-color);
@@ -541,7 +623,7 @@ const StyledNicknameEditRow = styled.div`
     display: flex;
     align-items: center;
     gap: 6px;
-    flex: 1;
+    width: 100%;
     justify-content: flex-end;
 `;
 
@@ -555,6 +637,8 @@ const StyledNicknameInput = styled.input`
     color: var(--black-color);
     outline: none;
     box-sizing: border-box;
+
+    &:disabled { opacity: 0.6; }
 `;
 
 const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
@@ -568,6 +652,54 @@ const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
     font-weight: 600;
     cursor: pointer;
     flex-shrink: 0;
+
+    &:disabled { opacity: 0.6; cursor: default; }
+`;
+
+const StyledNicknameError = styled.p`
+    margin: 0;
+    font-size: 12px;
+    color: var(--danger-color);
+    text-align: right;
+`;
+
+const StyledSuggestions = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    align-items: flex-end;
+    width: 100%;
+`;
+
+const StyledSuggestionsLabel = styled.span`
+    font-size: 11px;
+    color: var(--dark-gray-color2);
+`;
+
+const StyledSuggestionList = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: flex-end;
+`;
+
+const StyledSuggestionChip = styled.button`
+    padding: 3px 10px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 999px;
+    background: var(--gray-color2);
+    font-size: 12px;
+    color: var(--dark-gray-color);
+    cursor: pointer;
+    transition: border-color 0.12s, background 0.12s;
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover {
+            border-color: var(--blue-color);
+            color: var(--blue-color);
+            background: rgba(45, 127, 249, 0.06);
+        }
+    }
 `;
 
 const StyledFooterCs = styled.p`

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -7,6 +7,7 @@ import {signIn, signOut, useSession} from 'next-auth/react';
 import styled from 'styled-components';
 
 import {AuthActionIcon} from '../components/ui/AuthActionIcon';
+import {FieldError} from '../components/ui/FieldError';
 import {PageHero} from '../components/ui/PageHero';
 import {AccountDeleteModal} from '../components/account/AccountDeleteModal';
 import {CustomerDetail} from '../components/calendar/overlays/CustomerDetail';
@@ -178,9 +179,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                                             취소
                                         </StyledNicknameBtn>
                                     </StyledNicknameEditRow>
-                                    {nicknameError && (
-                                        <StyledNicknameError>{nicknameError}</StyledNicknameError>
-                                    )}
+                                    <FieldError variant="inline">{nicknameError}</FieldError>
                                     {nicknameSuggestions.length > 0 && (
                                         <StyledSuggestions>
                                             <StyledSuggestionsLabel>추천 닉네임</StyledSuggestionsLabel>
@@ -656,12 +655,6 @@ const StyledNicknameBtn = styled.button<{$cancel?: boolean}>`
     &:disabled { opacity: 0.6; cursor: default; }
 `;
 
-const StyledNicknameError = styled.p`
-    margin: 0;
-    font-size: 12px;
-    color: var(--danger-color);
-    text-align: right;
-`;
 
 const StyledSuggestions = styled.div`
     display: flex;

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -7,6 +7,7 @@ import Head from 'next/head';
 import styled from 'styled-components';
 
 import {getPageSession} from '../lib/page-data';
+import {FieldError} from '../components/ui/FieldError';
 import {DEFAULT_SERVICES, SHOP_CATEGORY_COLOR_MAP} from '../features/services/default-services';
 import type {ShopType} from '../features/services/default-services';
 import {createDefaultSchedule, getDesignerColor} from '../utils/designers';
@@ -139,7 +140,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                     </StyledTypeGrid>
                 </StyledSection>
 
-                {error && <StyledError>{error}</StyledError>}
+                <FieldError>{error}</FieldError>
 
                 <StyledSubmitBtn
                     type="button"
@@ -306,15 +307,6 @@ const StyledTypeDesc = styled.span`
     line-height: 1.4;
 `;
 
-const StyledError = styled.p`
-    margin: 0;
-    padding: 10px 14px;
-    font-size: 13px;
-    color: var(--danger-color);
-    background: var(--danger-bg);
-    border: 1px solid var(--danger-border);
-    border-radius: var(--radius-md);
-`;
 
 const StyledSubmitBtn = styled.button`
     height: 48px;


### PR DESCRIPTION
## Summary
- SNS 로그인 사용자 닉네임 수정 기능 (중복체크 + 추천닉네임 제안)
- `FieldError` 공통 컴포넌트 신규 생성 (`box` / `inline` variant, children 없으면 null)
- 기존 각 페이지·모달의 개별 error styled-component → `FieldError`로 일괄 교체
- `client/components/ui/index.ts` 디자인 시스템 barrel 파일 추가

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_