### PR TITLE
feat: 예약 인라인 에러, 온보딩 UX 개선, 알림 레이아웃 수정

### DIFF
--- a/client/components/calendar/overlays/ReservationCreate.tsx
+++ b/client/components/calendar/overlays/ReservationCreate.tsx
@@ -80,13 +80,11 @@ export const ReservationCreate = ({initial, customerMap, onClose, onSave}: Reser
         addCustomer,
         onSave,
     });
-    const customerErrorMessage = (
-        error === '고객을 선택해주세요.'
-        || error === '신규 고객명을 입력해주세요.'
-        || error === '신규 고객 연락처를 입력해주세요.'
-        || error === '신규 고객 연락처 형식을 확인해주세요.'
-    ) ? error : '';
-    const serviceErrorMessage = error === '서비스를 선택해주세요.' ? error : '';
+    const customerErrorMessage = error?.field === 'customer' ? error.message : '';
+    const serviceErrorMessage = error?.field === 'service' ? error.message : '';
+    const designerErrorMessage = error?.field === 'designer' ? error.message : '';
+    const dateErrorMessage = error?.field === 'date' ? error.message : '';
+    const timeErrorMessage = error?.field === 'time' ? error.message : '';
 
     if (!modalRoot) return null;
 
@@ -138,9 +136,12 @@ export const ReservationCreate = ({initial, customerMap, onClose, onSave}: Reser
                         onStartTimeChange={handleStartTimeChange}
                         onEndTimeChange={handleEndTimeChange}
                         serviceErrorMessage={serviceErrorMessage}
+                        designerErrorMessage={designerErrorMessage}
+                        dateErrorMessage={dateErrorMessage}
+                        timeErrorMessage={timeErrorMessage}
                     />
                 </StyledCreateForm>
-                {error && !customerErrorMessage && !serviceErrorMessage && <StyledError>{error}</StyledError>}
+                {error && error.field === 'general' && <StyledError>{error.message}</StyledError>}
             </StyledBodyInner></StyledBody>
 
             <StyledFooter>

--- a/client/components/calendar/overlays/ReservationDetail.tsx
+++ b/client/components/calendar/overlays/ReservationDetail.tsx
@@ -10,7 +10,7 @@ import type {PaymentEntry, PaymentMethod, Reservation, ReservationHistoryEntry, 
 import {findOverlap, hasCompletedPayment} from '../../../utils/reservations';
 import {isNewCustomerVisit} from '../../../utils/customers';
 import type {CustomerMap} from '../../../utils/customers';
-import {buildDesignerNameMap, getDesignerAvailabilityError, getDesignerColor, splitDesignersByStatus} from '../../../utils/designers';
+import {buildDesignerNameMap, getDesignerAvailabilityState, getDesignerColor, splitDesignersByStatus} from '../../../utils/designers';
 import {
     parseServiceString,
     joinServiceNames,
@@ -40,6 +40,7 @@ import {
     ReservationStaticDiffSection,
     ReservationViewSection,
     type ReservationDetailFormState,
+    type ReservationFieldError,
 } from './ReservationDetailSections';
 import {ReservationDetailHeader} from './ReservationDetailHeader';
 import {ReservationDetailFooterActions} from './ReservationDetailFooterActions';
@@ -203,7 +204,7 @@ export const ReservationDetail = ({
     const initialForm = buildReservationFormState(sourceReservation);
     const [form, setForm] = useState<ReservationDetailFormState>(initialForm);
     const [priceInputValue, setPriceInputValue] = useState(initialForm.price === 0 ? '' : String(initialForm.price));
-    const [error, setError] = useState('');
+    const [error, setError] = useState<ReservationFieldError | null>(null);
     const [selectedServices, setSelectedServices] = useState<string[]>(
         () => parseServiceString(sourceReservation.service, knownServiceNames)
     );
@@ -235,7 +236,7 @@ export const ReservationDetail = ({
             enabled: (sourceReservation.pointEarned ?? 0) > 0 || storeSettings.pointSettings.enableServiceRate,
             amount: String(sourceReservation.pointEarned ?? getDefaultPointAwardAmount(nextDisplayPrice)),
         });
-        setError('');
+        setError(null);
     }, [sourceReservation, storeSettings.pointSettings.enableServiceRate, storeSettings.pointSettings.serviceRate]);
 
     const changedFields = getChangedFields(sourceReservation, form, designerNameMap);
@@ -255,7 +256,7 @@ export const ReservationDetail = ({
 
     const handleChange = (field: keyof ReservationDetailFormState, value: string) => {
         setForm((prev) => ({...prev, [field]: value}));
-        setError('');
+        setError(null);
     };
 
     const handleStartTimeChange = (value: string) => {
@@ -272,13 +273,13 @@ export const ReservationDetail = ({
 
             return next;
         });
-        setError('');
+        setError(null);
     };
 
     const handleEndTimeChange = (value: string) => {
         setIsEndTimeManual(true);
         setForm((prev) => ({...prev, endTime: value}));
-        setError('');
+        setError(null);
     };
 
     const handleServiceToggle = (serviceName: string) => {
@@ -310,37 +311,38 @@ export const ReservationDetail = ({
             }
 
             setIsEndTimeManual(false);
-            setError('');
+            setError(null);
 
             return next;
         });
     };
 
-    const validateForm = (): string => {
-        if (activeDesigners.length > 0 && !form.designerId) return '디자이너를 선택해주세요.';
-        if (!form.service.trim()) return '서비스를 선택해주세요.';
-        if (!form.date) return '날짜를 선택해주세요.';
-        if (!form.startTime) return '시작 시간을 입력해주세요.';
-        if (!form.endTime) return '종료 시간을 입력해주세요.';
-        if (form.startTime >= form.endTime) return '시작 시간은 종료 시간보다 앞서야 합니다.';
+    const validateForm = (): ReservationFieldError | null => {
+        if (activeDesigners.length > 0 && !form.designerId) return {field: 'designer', message: '디자이너를 선택해주세요.'};
+        if (!form.service.trim()) return {field: 'service', message: '서비스를 선택해주세요.'};
+        if (!form.date) return {field: 'date', message: '날짜를 선택해주세요.'};
+        if (!form.startTime) return {field: 'time', message: '시작 시간을 입력해주세요.'};
+        if (!form.endTime) return {field: 'time', message: '종료 시간을 입력해주세요.'};
+        if (form.startTime >= form.endTime) return {field: 'time', message: '시작 시간은 종료 시간보다 앞서야 합니다.'};
 
-        const availabilityError = getDesignerAvailabilityError(
+        const availability = getDesignerAvailabilityState(
             designers,
             form.designerId,
             form.date,
             form.startTime,
             form.endTime
         );
-        if (availabilityError) return availabilityError;
+        if (availability.kind === 'off-day') return {field: 'date', message: availability.message};
+        if (availability.kind === 'outside-hours') return {field: 'time', message: availability.message};
 
         const overlap = findOverlap(effectiveReservationMap, form.date, form.startTime, form.endTime, sourceReservation.id);
 
         if (overlap) {
             const name = customerMap[overlap.customerId]?.name ?? '-';
-            return `${name} 예약(${overlap.startTime}~${overlap.endTime})과 시간이 겹칩니다.`;
+            return {field: 'time', message: `${name} 예약(${overlap.startTime}~${overlap.endTime})과 시간이 겹칩니다.`};
         }
 
-        return '';
+        return null;
     };
 
     const isPastTime = () => {
@@ -356,11 +358,11 @@ export const ReservationDetail = ({
             return;
         }
         if (changedFields.length === 0) {
-            setError('');
+            setError(null);
             setMode('view');
             return;
         }
-        setError('');
+        setError(null);
         if (isPastTime()) {
             setMode('pastConfirm');
             return;
@@ -371,7 +373,7 @@ export const ReservationDetail = ({
     const handleConfirmSave = () => {
         if (mode === 'completing') {
             if (!hasCompletedPayment(sourceReservation)) {
-                setError('결제 완료된 예약만 완료 처리할 수 있습니다.');
+                setError({field: 'general', message: '결제 완료된 예약만 완료 처리할 수 있습니다.'});
                 setMode('view');
                 return;
             }
@@ -404,7 +406,7 @@ export const ReservationDetail = ({
     const handlePaymentEntriesChange = (nextEntries: Array<{ method: PaymentMethod | ''; amount: string }>) => {
         setPaymentEntries(nextEntries);
         syncPointAward(nextEntries);
-        setError('');
+        setError(null);
     };
 
     const handlePaymentSave = () => {
@@ -416,7 +418,7 @@ export const ReservationDetail = ({
             .filter((entry): entry is PaymentEntry => !!entry.method && entry.amount > 0);
 
         if (normalizedEntries.length === 0) {
-            setError('결제종류와 금액을 입력해주세요.');
+            setError({field: 'general', message: '결제종류와 금액을 입력해주세요.'});
             return;
         }
 
@@ -424,7 +426,7 @@ export const ReservationDetail = ({
         const expectedAmount = displayPrice - (sourceReservation.naverDeposit ?? 0);
 
         if (paymentTotal !== expectedAmount) {
-            setError(`결제 금액 합계(${formatPrice(paymentTotal)})가 서비스 금액(${formatPrice(expectedAmount)})과 일치하지 않습니다.`);
+            setError({field: 'general', message: `결제 금액 합계(${formatPrice(paymentTotal)})가 서비스 금액(${formatPrice(expectedAmount)})과 일치하지 않습니다.`});
             return;
         }
 
@@ -439,7 +441,7 @@ export const ReservationDetail = ({
         const currentCustomerPoints = customer?.points ?? 0;
 
         if (currentCustomerPoints - pointUsageDiff < 0) {
-            setError('고객 적립금이 부족합니다.');
+            setError({field: 'general', message: '고객 적립금이 부족합니다.'});
             return;
         }
 
@@ -478,7 +480,7 @@ export const ReservationDetail = ({
             }, pointHistories);
         }
 
-        setError('');
+        setError(null);
         setMode('view');
     };
 
@@ -585,11 +587,11 @@ export const ReservationDetail = ({
                         setPriceInputValue(raw);
                         setForm((f) => ({...f, price: num}));
                         setIsPriceManual(true);
-                        setError('');
+                        setError(null);
                     }}
                     onDesignerChange={(designerId) => {
                         setForm((prev) => ({...prev, designerId}));
-                        setError('');
+                        setError(null);
                     }}
                     onFieldChange={handleChange}
                     onStartTimeChange={handleStartTimeChange}
@@ -641,7 +643,7 @@ export const ReservationDetail = ({
                     pointAward={pointAward}
                     customerPoints={customer?.points ?? 0}
                     showPointAward={showPointAward}
-                    error={error}
+                    error={error?.message ?? ''}
                     paymentMethodOptions={PAYMENT_METHOD_OPTIONS}
                     totalPrice={displayPrice}
                     naverDeposit={sourceReservation.naverDeposit ?? 0}
@@ -661,7 +663,7 @@ export const ReservationDetail = ({
                             ...prev,
                             enabled,
                         }));
-                        setError('');
+                        setError(null);
                     }}
                     onChangePointAwardAmount={(value) => {
                         setIsPointAwardManual(true);
@@ -669,7 +671,7 @@ export const ReservationDetail = ({
                             ...prev,
                             amount: value.replace(/[^0-9]/g, ''),
                         }));
-                        setError('');
+                        setError(null);
                     }}
                     onRemoveEntry={(index) => {
                         handlePaymentEntriesChange(
@@ -706,10 +708,10 @@ export const ReservationDetail = ({
                         isNaverBooking={isNaverBooking}
                         onOpenCompleting={() => {
                             if (!hasCompletedPayment(sourceReservation)) {
-                                setError('결제 완료된 예약만 완료 처리할 수 있습니다.');
+                                setError({field: 'general', message: '결제 완료된 예약만 완료 처리할 수 있습니다.'});
                                 return;
                             }
-                            setError('');
+                            setError(null);
                             setMode('completing');
                         }}
                         onOpenCancelling={() => setMode('cancelling')}
@@ -721,7 +723,7 @@ export const ReservationDetail = ({
                                 enabled: (sourceReservation.pointEarned ?? 0) > 0 || storeSettings.pointSettings.enableServiceRate,
                                 amount: String(sourceReservation.pointEarned ?? getDefaultPointAwardAmount(displayPrice)),
                             });
-                            setError('');
+                            setError(null);
                             setMode('payment');
                         }}
                         onOpenEditing={() => setMode('editing')}

--- a/client/components/calendar/overlays/ReservationDetailSections.tsx
+++ b/client/components/calendar/overlays/ReservationDetailSections.tsx
@@ -36,6 +36,13 @@ export interface ReservationDetailFormState {
     channel: ReservationChannel;
 }
 
+export type ReservationErrorField = 'customer' | 'service' | 'designer' | 'date' | 'time' | 'general';
+
+export interface ReservationFieldError {
+    field: ReservationErrorField;
+    message: string;
+}
+
 interface ReservationFormFieldsProps {
     idPrefix: string;
     form: ReservationDetailFormState;
@@ -54,6 +61,9 @@ interface ReservationFormFieldsProps {
     onStartTimeChange: (value: string) => void;
     onEndTimeChange: (value: string) => void;
     serviceErrorMessage?: string;
+    designerErrorMessage?: string;
+    dateErrorMessage?: string;
+    timeErrorMessage?: string;
     children?: ReactNode;
 }
 
@@ -75,6 +85,9 @@ export const ReservationFormFields = ({
     onStartTimeChange,
     onEndTimeChange,
     serviceErrorMessage,
+    designerErrorMessage,
+    dateErrorMessage,
+    timeErrorMessage,
     children,
 }: ReservationFormFieldsProps) => (
     <StyledForm>
@@ -128,6 +141,7 @@ export const ReservationFormFields = ({
                             : ''}
                     </StyledDesignerPolicyNotice>
                 )}
+                {designerErrorMessage && <StyledInlineError>{designerErrorMessage}</StyledInlineError>}
             </label>
         )}
         <label htmlFor={`${idPrefix}-date`}>
@@ -138,6 +152,7 @@ export const ReservationFormFields = ({
                 value={form.date}
                 onChange={(e) => onFieldChange('date', e.target.value)}
             />
+            {dateErrorMessage && <StyledInlineError>{dateErrorMessage}</StyledInlineError>}
         </label>
         <StyledTimeRow>
             <label htmlFor={`${idPrefix}-startTime`}>
@@ -159,6 +174,7 @@ export const ReservationFormFields = ({
                 />
             </label>
         </StyledTimeRow>
+        {timeErrorMessage && <StyledInlineError>{timeErrorMessage}</StyledInlineError>}
         <label htmlFor={`${idPrefix}-channel`}>
             <strong>예약경로</strong>
             <select
@@ -188,7 +204,7 @@ export const ReservationFormFields = ({
 interface ReservationEditSectionProps {
     form: ReservationDetailFormState;
     priceInputValue?: string;
-    error: string;
+    error: ReservationFieldError | null;
     customerMemoTags: CustomerMemoTag[];
     activeDesigners: Designer[];
     onLeaveDesigners: Designer[];
@@ -254,8 +270,12 @@ export const ReservationEditSection = ({
             onFieldChange={onFieldChange}
             onStartTimeChange={onStartTimeChange}
             onEndTimeChange={onEndTimeChange}
+            serviceErrorMessage={error?.field === 'service' ? error.message : ''}
+            designerErrorMessage={error?.field === 'designer' ? error.message : ''}
+            dateErrorMessage={error?.field === 'date' ? error.message : ''}
+            timeErrorMessage={error?.field === 'time' ? error.message : ''}
         />
-        {error && <StyledError>{error}</StyledError>}
+        {error && error.field === 'general' && <StyledError>{error.message}</StyledError>}
     </StyledBodyInner></StyledBody>
 );
 

--- a/client/components/calendar/overlays/useReservationCreateForm.ts
+++ b/client/components/calendar/overlays/useReservationCreateForm.ts
@@ -5,9 +5,9 @@ import type {Reservation, ReservationChannel} from '../../../utils/reservations'
 import {findOverlap} from '../../../utils/reservations';
 import type {Customer, CustomerMap} from '../../../utils/customers';
 import type {Designer} from '../../../utils/designers';
-import {getDesignerAvailabilityError, splitDesignersByStatus} from '../../../utils/designers';
+import {getDesignerAvailabilityState, splitDesignersByStatus} from '../../../utils/designers';
 import {calcEndTime, joinServiceNames, sumDurationMinutes, sumPrice} from '../../../utils/services';
-import type {ReservationDetailFormState} from './ReservationDetailSections';
+import type {ReservationDetailFormState, ReservationFieldError} from './ReservationDetailSections';
 type CustomerMode = 'existing' | 'new';
 
 const KOREAN_MOBILE_PHONE_PATTERN = /^01[016789]\d{7,8}$/;
@@ -64,7 +64,7 @@ export function useReservationCreateForm({
         channel: '전화예약' as ReservationChannel,
     });
     const [isEndTimeManual, setIsEndTimeManual] = useState(false);
-    const [error, setError] = useState('');
+    const [error, setError] = useState<ReservationFieldError | null>(null);
 
     const filteredCustomers = customerQuery.trim()
         ? customers.filter((customer) => customer.name.includes(customerQuery) || customer.tel.includes(customerQuery))
@@ -80,14 +80,14 @@ export function useReservationCreateForm({
             setCustomerQuery(customer.name);
         }
         setShowSuggestions(false);
-        setError('');
+        setError(null);
     };
 
     const handleCustomerInputChange = (value: string) => {
         setCustomerQuery(value);
         setCustomerId(0);
         setShowSuggestions(true);
-        setError('');
+        setError(null);
     };
 
     const handleCustomerFocus = () => {
@@ -112,13 +112,13 @@ export function useReservationCreateForm({
 
             return next;
         });
-        setError('');
+        setError(null);
     };
 
     const handleEndTimeChange = (value: string) => {
         setIsEndTimeManual(true);
         setForm((prev) => ({...prev, endTime: value}));
-        setError('');
+        setError(null);
     };
 
     const handleServiceToggle = (serviceName: string) => {
@@ -143,49 +143,50 @@ export function useReservationCreateForm({
             }
 
             setIsEndTimeManual(false);
-            setError('');
+            setError(null);
             return next;
         });
     };
 
-    const validate = (): string => {
+    const validate = (): ReservationFieldError | null => {
         const normalizedNewCustomerTel = newCustomerTel.replace(/\D/g, '');
 
-        if (activeDesigners.length > 0 && !form.designerId) return '디자이너를 선택해주세요.';
-        if (customerMode === 'existing' && !customerId) return '고객을 선택해주세요.';
-        if (customerMode === 'new' && !newCustomerName.trim()) return '신규 고객명을 입력해주세요.';
-        if (customerMode === 'new' && !newCustomerTel.trim()) return '신규 고객 연락처를 입력해주세요.';
+        if (activeDesigners.length > 0 && !form.designerId) return {field: 'designer', message: '디자이너를 선택해주세요.'};
+        if (customerMode === 'existing' && !customerId) return {field: 'customer', message: '고객을 선택해주세요.'};
+        if (customerMode === 'new' && !newCustomerName.trim()) return {field: 'customer', message: '신규 고객명을 입력해주세요.'};
+        if (customerMode === 'new' && !newCustomerTel.trim()) return {field: 'customer', message: '신규 고객 연락처를 입력해주세요.'};
         if (customerMode === 'new' && !KOREAN_MOBILE_PHONE_PATTERN.test(normalizedNewCustomerTel)) {
-            return '신규 고객 연락처 형식을 확인해주세요.';
+            return {field: 'customer', message: '신규 고객 연락처 형식을 확인해주세요.'};
         }
-        if (selectedServices.length === 0) return '서비스를 선택해주세요.';
-        if (!form.date) return '날짜를 선택해주세요.';
-        if (!form.startTime) return '시작 시간을 입력해주세요.';
-        if (!form.endTime) return '종료 시간을 입력해주세요.';
-        if (form.startTime >= form.endTime) return '시작 시간은 종료 시간보다 앞서야 합니다.';
+        if (selectedServices.length === 0) return {field: 'service', message: '서비스를 선택해주세요.'};
+        if (!form.date) return {field: 'date', message: '날짜를 선택해주세요.'};
+        if (!form.startTime) return {field: 'time', message: '시작 시간을 입력해주세요.'};
+        if (!form.endTime) return {field: 'time', message: '종료 시간을 입력해주세요.'};
+        if (form.startTime >= form.endTime) return {field: 'time', message: '시작 시간은 종료 시간보다 앞서야 합니다.'};
 
-        const availabilityError = getDesignerAvailabilityError(
+        const availability = getDesignerAvailabilityState(
             designers,
             form.designerId,
             form.date,
             form.startTime,
             form.endTime
         );
-        if (availabilityError) return availabilityError;
+        if (availability.kind === 'off-day') return {field: 'date', message: availability.message};
+        if (availability.kind === 'outside-hours') return {field: 'time', message: availability.message};
 
         const overlap = findOverlap(reservationMap, form.date, form.startTime, form.endTime);
         if (overlap) {
             const name = customerMap[overlap.customerId]?.name ?? '-';
-            return `${name} 예약(${overlap.startTime}~${overlap.endTime})과 시간이 겹칩니다.`;
+            return {field: 'time', message: `${name} 예약(${overlap.startTime}~${overlap.endTime})과 시간이 겹칩니다.`};
         }
 
-        return '';
+        return null;
     };
 
     const handleSave = () => {
-        const message = validate();
-        if (message) {
-            setError(message);
+        const validationError = validate();
+        if (validationError) {
+            setError(validationError);
             return;
         }
 
@@ -240,15 +241,15 @@ export function useReservationCreateForm({
         totalPrice,
         setCustomerMode: (mode: CustomerMode) => {
             setCustomerMode(mode);
-            setError('');
+            setError(null);
         },
         setNewCustomerName: (value: string) => {
             setNewCustomerName(value);
-            setError('');
+            setError(null);
         },
         setNewCustomerTel: (value: string) => {
             setNewCustomerTel(value);
-            setError('');
+            setError(null);
         },
         handleCustomerSelect,
         handleCustomerInputChange,
@@ -262,15 +263,15 @@ export function useReservationCreateForm({
             const num = raw === '' ? 0 : parseInt(raw, 10);
             setForm((prev) => ({...prev, price: num}));
             setIsPriceManual(true);
-            setError('');
+            setError(null);
         },
         handleDesignerChange: (nextDesignerId: number) => {
             setForm((prev) => ({...prev, designerId: nextDesignerId}));
-            setError('');
+            setError(null);
         },
         handleFieldChange: (field: keyof ReservationDetailFormState, value: string) => {
             setForm((prev) => ({...prev, [field]: value}));
-            setError('');
+            setError(null);
         },
         handleSave,
     };

--- a/client/components/layout/NaverSyncNotification.tsx
+++ b/client/components/layout/NaverSyncNotification.tsx
@@ -265,6 +265,7 @@ const NotificationModal = ({notifications, designers, reservationMap, markRead, 
     const renderConflictItem = (n: SyncNotification) => (
         <StyledModalItem key={n.id}
                          $unread={n.conflictStatus !== 'confirmed'}
+                         $isConflict
                          onClick={() => handleClick(n)}>
             <StyledConflictItemText>
                 <span className="message">
@@ -641,20 +642,20 @@ const StyledModalBodyInner = styled(StyledBodyInner)`
     padding: 0 0 30px 0;
 `;
 
-const StyledModalItem = styled.div<{ $unread: boolean }>`
+const StyledModalItem = styled.div<{ $unread: boolean; $isConflict?: boolean }>`
     display: grid;
-    grid-template-columns: 1fr 30px;
+    grid-template-columns: ${({$isConflict}) => $isConflict ? '1fr' : '1fr 30px'};
     gap: 4px;
     width: 100%;
     box-sizing: border-box;
     padding: 4px 8px;
-    background-color: ${(props) => props.$unread ? 'var(--notification-unread-bg)' : 'transparent'};
+    background-color: ${({$unread}) => $unread ? 'var(--notification-unread-bg)' : 'transparent'};
     border-bottom: 1px solid var(--gray-color2);
     cursor: pointer;
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            background-color: ${(props) => props.$unread ? 'var(--notification-unread-bg-hover)' : 'var(--gray-color2)'};
+            background-color: ${({$unread}) => $unread ? 'var(--notification-unread-bg-hover)' : 'var(--gray-color2)'};
         }
     }
 

--- a/client/hooks/useNaverBookingSync.ts
+++ b/client/hooks/useNaverBookingSync.ts
@@ -141,8 +141,9 @@ export function useNaverBookingSync() {
         patchNotificationNames();
     }, [customerMap, reservationMap, patchNotificationNames]);
 
-    // 자동 중복 감지 (예약 데이터 로드 시)
+    // 자동 중복 감지 (예약 데이터 로드 시) — 인증된 세션에서만 실행
     useEffect(() => {
+        if (!session) return;
         if (conflictDetectedRef.current) return;
 
         const reservationDates = Object.keys(reservationMap);
@@ -212,7 +213,7 @@ export function useNaverBookingSync() {
 
         setConflictQueue(merged);
         setCurrentIndex(0);
-    }, [reservationMap, addSyncNotifications]);
+    }, [session, reservationMap, addSyncNotifications]);
 
     const isActive =
         session?.user?.provider === 'google'

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -488,6 +488,8 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                             ))}
                         </StyledDesignerList>
 
+                        {!showAddDesigner && <FieldError variant="inline">{step3Error}</FieldError>}
+
                         {showAddDesigner ? (
                             <StyledAddForm>
                                 <StyledAddFormRow>

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -78,6 +78,11 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
         getDesignerColor({id: DEFAULT_DESIGNER_ID_START + 1})
     );
     const [step3Error, setStep3Error] = useState('');
+    const [editingDesignerId, setEditingDesignerId] = useState<number | null>(null);
+    const [editingDesignerName, setEditingDesignerName] = useState('');
+
+    // ── Step 5 ──
+    const [finalError, setFinalError] = useState('');
 
     // ── Step 4 ──
     const [naverChoice, setNaverChoice] = useState<'yes' | 'no' | null>(null);
@@ -179,16 +184,29 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
     };
 
     const handleRemoveDesigner = (id: number) => {
-        if (localDesigners.length <= 1) {
-            setStep3Error('최소 1명의 디자이너가 필요합니다.');
-            return;
-        }
         setLocalDesigners((prev) => prev.filter((d) => d.id !== id));
         setStep3Error('');
     };
 
     const handleUpdateDesignerColor = (id: number, color: string) => {
         setLocalDesigners((prev) => prev.map((d) => d.id === id ? {...d, color} : d));
+    };
+
+    const handleStartEditDesignerName = (d: LocalDesigner) => {
+        setEditingDesignerId(d.id);
+        setEditingDesignerName(d.name);
+        setStep3Error('');
+    };
+
+    const handleSaveDesignerName = (id: number) => {
+        const name = editingDesignerName.trim();
+        if (!name) { setStep3Error('디자이너 이름을 입력해 주세요.'); return; }
+        if (localDesigners.some((d) => d.name === name && d.id !== id)) {
+            setStep3Error(`"${name}" 디자이너는 이미 있습니다.`); return;
+        }
+        setLocalDesigners((prev) => prev.map((d) => d.id === id ? {...d, name} : d));
+        setEditingDesignerId(null);
+        setStep3Error('');
     };
 
     // ── Final submit ──
@@ -233,15 +251,13 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
 
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
-                setStep1Error(data.error ?? '오류가 발생했습니다.');
-                setStep(1);
+                setFinalError(data.error ?? '오류가 발생했습니다.');
                 return;
             }
 
             router.replace('/');
         } catch {
-            setStep1Error('네트워크 오류가 발생했습니다.');
-            setStep(1);
+            setFinalError('네트워크 오류가 발생했습니다.');
         } finally {
             setLoading(false);
         }
@@ -431,7 +447,28 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                             {localDesigners.map((d) => (
                                 <StyledDesignerRow key={d.id}>
                                     <StyledDesignerColorDot style={{background: d.color}} />
-                                    <StyledDesignerName>{d.name}</StyledDesignerName>
+                                    {editingDesignerId === d.id ? (
+                                        <StyledDesignerEditInput
+                                            value={editingDesignerName}
+                                            onChange={(e) => { setEditingDesignerName(e.target.value); setStep3Error(''); }}
+                                            onBlur={() => handleSaveDesignerName(d.id)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') handleSaveDesignerName(d.id);
+                                                if (e.key === 'Escape') { setEditingDesignerId(null); setStep3Error(''); }
+                                            }}
+                                            autoFocus
+                                        />
+                                    ) : (
+                                        <StyledDesignerName
+                                            role="button"
+                                            tabIndex={0}
+                                            onClick={() => handleStartEditDesignerName(d)}
+                                            onKeyDown={(e) => e.key === 'Enter' && handleStartEditDesignerName(d)}
+                                            title="클릭하여 이름 수정"
+                                        >
+                                            {d.name}
+                                        </StyledDesignerName>
+                                    )}
                                     <StyledDesignerColorPicker
                                         type="color"
                                         value={d.color}
@@ -559,7 +596,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                             </StyledCompleteSummary>
                         </StyledCompleteSection>
 
-                        <FieldError>{step1Error}</FieldError>
+                        <FieldError>{finalError}</FieldError>
 
                         <StyledNavRow $centered>
                             <StyledBackBtn type="button" onClick={() => { clearErrors(); setStep(prevStep()); }}>← 이전</StyledBackBtn>
@@ -846,6 +883,27 @@ const StyledDesignerName = styled.span`
     font-size: 14px;
     font-weight: 600;
     color: var(--dark-gray-color);
+    cursor: text;
+    border-radius: var(--radius-sm);
+    padding: 2px 4px;
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover { background: var(--light-gray-color); }
+    }
+`;
+
+const StyledDesignerEditInput = styled.input`
+    flex: 1;
+    height: 28px;
+    padding: 0 8px;
+    border: 1px solid var(--blue-color);
+    border-radius: var(--radius-sm);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
+    background: var(--white-color);
+    outline: none;
+    box-sizing: border-box;
 `;
 
 const StyledDesignerColorPicker = styled.input`


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- 예약 추가/수정 레이어에서 유효성 검사 에러 메시지를 각 입력 필드 아래 인라인으로 표시
- 온보딩 step3 인라인 편집 에러가 디자이너 추가 폼 닫힌 상태에서도 표시되도록 수정
- 전체 알림 모달 충돌 예약 항목의 grid 레이아웃 수정 (30px 빈 컬럼 제거)
- 게스트 로그인 시 중복 예약 자동 감지 알림 비활성화

## Changes
- `ReservationDetailSections`: `ReservationErrorField` 타입 도입, 각 필드별 인라인 에러 표시
- `useReservationCreateForm` / `ReservationDetail`: error 상태를 `string` → `ReservationFieldError | null`로 변경, 필드별 라우팅
- `NaverSyncNotification`: 충돌 아이템 `$isConflict` prop으로 grid 컬럼 조건부 처리
- `useNaverBookingSync`: 세션 없는 경우(게스트) 자동 충돌 감지 effect 스킵
- `onboarding`: step3 에러 표시 위치 수정

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_