### PR TITLE
feat(guest): 온보딩 step 0, 로그아웃 확인 모달, 기기 레이블 변경

### DIFF
--- a/client/components/layout/Aside.tsx
+++ b/client/components/layout/Aside.tsx
@@ -41,6 +41,8 @@ export const Aside = () => {
     const setCreateReservationInitial = useCalendarStore((s) => s.setCreateReservationInitial);
     const [reservationOpen, setReservationOpen] = useState(true);
     const [settingsOpen, setSettingsOpen] = useState(true);
+    const [showGuestLogout, setShowGuestLogout] = useState(false);
+    const isGuest = !session;
 
     const todayMidnight = () => {
         const now = new Date();
@@ -194,10 +196,28 @@ export const Aside = () => {
                     <span>고객센터</span>
                 </StyledInquiryLink>
                 <StyledLogoutButton type="button"
-                                    onClick={() => signOut({callbackUrl: '/login'})}>
+                                    onClick={() => isGuest ? setShowGuestLogout(true) : signOut({callbackUrl: '/login'})}>
                     <AuthActionIcon direction="logout" />
                     <span>로그아웃</span>
                 </StyledLogoutButton>
+                {showGuestLogout && (
+                    <StyledGuestLogoutOverlay onClick={() => setShowGuestLogout(false)}>
+                        <StyledGuestLogoutDialog onClick={(e) => e.stopPropagation()}>
+                            <StyledGuestLogoutMsg>
+                                현재 기기에서 모든 정보(예약, 서비스, 디자이너, 고객명단)가 삭제됩니다.
+                                로그아웃 하시겠습니까?
+                            </StyledGuestLogoutMsg>
+                            <StyledGuestLogoutActions>
+                                <StyledGuestLogoutCancel type="button" onClick={() => setShowGuestLogout(false)}>취소</StyledGuestLogoutCancel>
+                                <StyledGuestLogoutConfirm type="button" onClick={() => {
+                                    localStorage.removeItem('takeaseat.local-db.v1');
+                                    router.push('/login');
+                                }}>확인</StyledGuestLogoutConfirm>
+                            </StyledGuestLogoutActions>
+                            <StyledGuestLogoutLink href="/login">SNS 계정 연동</StyledGuestLogoutLink>
+                        </StyledGuestLogoutDialog>
+                    </StyledGuestLogoutOverlay>
+                )}
                 <StyledAsideAd>
                     <AdBanner adSlot="ASIDE_SLOT_ID"
                               adFormat="vertical" />
@@ -746,6 +766,73 @@ const StyledAsideAd = styled.div`
     @media (max-width: 640px) {
         display: none;
     }
+`;
+
+const StyledGuestLogoutOverlay = styled.div`
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+`;
+
+const StyledGuestLogoutDialog = styled.div`
+    background: var(--white-color);
+    border-radius: var(--radius-lg);
+    padding: 24px 20px 20px;
+    width: 100%;
+    max-width: 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: var(--shadow-md);
+`;
+
+const StyledGuestLogoutMsg = styled.p`
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--dark-gray-color);
+    word-break: keep-all;
+`;
+
+const StyledGuestLogoutActions = styled.div`
+    display: flex;
+    gap: 8px;
+
+    button { flex: 1; }
+`;
+
+const StyledGuestLogoutCancel = styled.button`
+    padding: 9px 0;
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-md);
+    background: var(--white-color);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
+    cursor: pointer;
+`;
+
+const StyledGuestLogoutConfirm = styled.button`
+    padding: 9px 0;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--danger-color);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--white-color);
+    cursor: pointer;
+`;
+
+const StyledGuestLogoutLink = styled(Link)`
+    font-size: 12px;
+    color: var(--blue-color);
+    text-align: center;
+    text-decoration: underline;
 `;
 
 const StyledToggleIcon = styled.span<{ $collapsed: boolean }>`

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -343,7 +343,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProvider}) => {
                             </StyledMetric>
                         </StyledGrid>
                         <StyledHint>
-                            게스트 모드 데이터는 현재 브라우저의 `localStorage`에만 저장됩니다.
+                            게스트 모드 데이터는 현재 사용중인 기기에만 저장됩니다.
                         </StyledHint>
                         <StyledDangerButton type="button" onClick={resetGuestData}>
                             게스트 데이터 초기화

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -15,7 +15,7 @@ import {loadLocalDbSnapshot, saveLocalDbSnapshot} from '../lib/local-db';
 import {buildServiceColorMap, formatDuration, formatPrice, getServiceColor} from '../utils/services';
 import type {ServiceItem} from '../utils/services';
 
-type OnboardingStep = 1 | 2 | 3 | 4 | 5;
+type OnboardingStep = 0 | 1 | 2 | 3 | 4 | 5;
 type ExtShopType = ShopType | 'etc';
 
 interface LocalDesigner {
@@ -42,6 +42,7 @@ const SHOP_TYPES: {type: ExtShopType; label: string; emoji: string; desc: string
 ];
 
 const STEP_LABELS: Record<OnboardingStep, string> = {
+    0: '매장 초기 설정',
     1: '매장 정보',
     2: '서비스 설정',
     3: '디자이너 등록',
@@ -56,7 +57,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
     const [loading, setLoading] = useState(false);
 
     // ── Step navigation ──
-    const [step, setStep] = useState<OnboardingStep>(1);
+    const [step, setStep] = useState<OnboardingStep>(guest ? 0 : 1);
 
     // ── Step 1 ──
     const [shopName, setShopName] = useState('');
@@ -93,6 +94,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
         if (step === 4) return 3;
         if (step === 3) return skipServiceStep ? 1 : 2;
         if (step === 2) return 1;
+        if (step === 1 && guest) return 0;
         return 1;
     };
 
@@ -205,6 +207,13 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
         setLocalDesigners((prev) => prev.map((d) => d.id === id ? {...d, color} : d));
     };
 
+    const handleSkipOnboarding = () => {
+        const snapshot = loadLocalDbSnapshot();
+        snapshot.onboarded = true;
+        saveLocalDbSnapshot(snapshot);
+        router.replace('/');
+    };
+
     // ── Final submit ──
     const handleComplete = async () => {
         setLoading(true);
@@ -281,7 +290,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
     const visibleSteps: OnboardingStep[] = skipServiceStep
         ? [1, 3, 4, 5]
         : [1, 2, 3, 4, 5];
-    const stepIndex = visibleSteps.indexOf(step);
+    const stepIndex = visibleSteps.indexOf(step as (typeof visibleSteps)[number]);
 
     return (
         <StyledPage>
@@ -292,13 +301,29 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                 {/* Header */}
                 <StyledCardHeader>
                     <StyledLogo>TAS</StyledLogo>
-                    <StyledStepRow>
-                        {visibleSteps.map((s, i) => (
-                            <StyledStepDot key={s} $active={i === stepIndex} $done={i < stepIndex} />
-                        ))}
-                    </StyledStepRow>
+                    {step !== 0 && (
+                        <StyledStepRow>
+                            {visibleSteps.map((s, i) => (
+                                <StyledStepDot key={s} $active={i === stepIndex} $done={i < stepIndex} />
+                            ))}
+                        </StyledStepRow>
+                    )}
                     <StyledStepLabel>{STEP_LABELS[step]}</StyledStepLabel>
                 </StyledCardHeader>
+
+                {/* ── Step 0: 초기 설정 시작 여부 ── */}
+                {step === 0 && (
+                    <StyledStepBody>
+                        <StyledStep0Desc>
+                            매장 정보, 서비스, 디자이너를 미리 설정하면<br />
+                            처음부터 편리하게 사용할 수 있습니다.
+                        </StyledStep0Desc>
+                        <StyledStep0Actions>
+                            <StyledNextBtn type="button" onClick={() => setStep(1)}>설정 시작</StyledNextBtn>
+                            <StyledSkipBtn type="button" onClick={handleSkipOnboarding}>건너뛰기</StyledSkipBtn>
+                        </StyledStep0Actions>
+                    </StyledStepBody>
+                )}
 
                 {/* ── Step 1: 매장 정보 ── */}
                 {step === 1 && (
@@ -341,6 +366,7 @@ const OnboardingPage: NextPage<{guest?: boolean}> = ({guest}) => {
                         <FieldError>{step1Error}</FieldError>
 
                         <StyledNavRow>
+                            {guest && <StyledBackBtn type="button" onClick={() => { clearErrors(); setStep(0); }}>← 이전</StyledBackBtn>}
                             <StyledSkipBtn type="button" onClick={handleStep1Skip}>건너뛰기</StyledSkipBtn>
                             <StyledNextBtn type="button" onClick={handleStep1Next}>다음</StyledNextBtn>
                         </StyledNavRow>
@@ -1269,4 +1295,21 @@ const StyledSubmitBtn = styled.button`
     @media (hover: hover) and (pointer: fine) {
         &:hover:not(:disabled) { opacity: 0.88; }
     }
+`;
+
+const StyledStep0Desc = styled.p`
+    margin: 8px 0 0;
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--dark-gray-color);
+    text-align: center;
+`;
+
+const StyledStep0Actions = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 8px;
+
+    button { width: 100%; justify-content: center; text-align: center; }
 `;


### PR DESCRIPTION
게스트 로그인 flow 개선

- 온보딩 step 0 추가: 게스트 진입 시 초기 설정 시작 여부 선택 (설정 시작 / 건너뛰기)
- Aside 로그아웃: 게스트 사용자에게 확인 모달 표시 (데이터 삭제 경고 + SNS 계정 연동 링크)
- mypage: localStorage 기술 용어 → 현재 사용중인 기기

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_