### PR TITLE
feat(settings): SNS 연동 실패(타 계정 충돌) 안내 추가

### DIFF
--- a/client/components/settings/SNSLinkingSection.tsx
+++ b/client/components/settings/SNSLinkingSection.tsx
@@ -37,7 +37,18 @@ export function SNSLinkingSection() {
         try {
             const res = await fetch('/api/account/linked');
             if (res.ok) {
-                setLinked(await res.json());
+                const data: LinkedAccount[] = await res.json();
+                setLinked(data);
+
+                const attempted = sessionStorage.getItem('tas-link-attempt');
+                if (attempted) {
+                    sessionStorage.removeItem('tas-link-attempt');
+                    const linked = new Set(data.map((a) => a.provider));
+                    if (!linked.has(attempted)) {
+                        const label = PROVIDERS.find((p) => p.id === attempted)?.label ?? attempted;
+                        setError(`${label} 계정이 이미 다른 사용자에게 연결되어 있습니다.`);
+                    }
+                }
             }
         } catch {
             /* ignore */
@@ -73,6 +84,7 @@ export function SNSLinkingSection() {
                     return;
                 }
             }
+            if (!isGuest) sessionStorage.setItem('tas-link-attempt', provider);
             await signIn(provider, {callbackUrl: isGuest ? '/' : '/settings/sns'});
         } catch {
             setError('네트워크 오류가 발생했습니다.');


### PR DESCRIPTION
## Summary
- SNS 연결하기 시도 전 `sessionStorage`에 provider 저장
- OAuth 콜백 복귀 후 연결 목록에 해당 provider가 없으면 "이미 다른 사용자에게 연결됨" 오류 표시
- 확인 후 sessionStorage 즉시 삭제하여 중복 표시 방지

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_