### PR TITLE
refactor: 설정 공통 스타일 추출, SEO 상수 분리, 네이버예약 연동 안내

### DIFF
--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -5,7 +5,7 @@ import {useSession} from 'next-auth/react';
 import styled from 'styled-components';
 import {LabelBadge} from '../ui/LabelBadge';
 import {PageHero} from '../ui/PageHero';
-import {EMPTY_TEXT, StyledEmpty} from './settings-styles';
+import {EMPTY_TEXT, StyledEmpty, StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint} from './settings-styles';
 import {FieldError} from '../ui/FieldError';
 
 type Invite = {
@@ -149,7 +149,7 @@ export const MemberSection = () => {
         return (
             <StyledContainer>
                 <PageHero eyebrow="MEMBER" title="멤버 관리" subtitle="초대코드를 생성하고 매장 멤버를 관리합니다." />
-                <StyledHint>멤버 관리는 오너 또는 매니저만 가능합니다.</StyledHint>
+                <StyledSettingsHint>멤버 관리는 오너 또는 매니저만 가능합니다.</StyledSettingsHint>
             </StyledContainer>
         );
     }
@@ -158,8 +158,8 @@ export const MemberSection = () => {
         <StyledContainer>
             <PageHero eyebrow="MEMBER" title="멤버 관리" subtitle="초대코드를 생성하고 매장 멤버를 관리합니다." />
 
-            <StyledCard>
-                <StyledCardTitle>초대코드 생성</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>초대코드 생성</StyledSettingsCardTitle>
                 <StyledCreateRow>
                     <StyledSelect
                         id="member-role"
@@ -176,10 +176,10 @@ export const MemberSection = () => {
                     </StyledPrimaryButton>
                 </StyledCreateRow>
                 <FieldError>{error}</FieldError>
-            </StyledCard>
+            </StyledSettingsCard>
 
-            <StyledCard>
-                <StyledCardTitle>사용 가능한 초대코드</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>사용 가능한 초대코드</StyledSettingsCardTitle>
                 {activeInvites.length > 0 ? (
                     <StyledList>
                         {activeInvites.map((inv) => (
@@ -201,10 +201,10 @@ export const MemberSection = () => {
                 ) : (
                     <StyledEmpty>{EMPTY_TEXT}</StyledEmpty>
                 )}
-            </StyledCard>
+            </StyledSettingsCard>
 
-            <StyledCard>
-                <StyledCardTitle>현재 멤버</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>현재 멤버</StyledSettingsCardTitle>
                 {members.length > 0 ? (
                     <StyledList>
                         {members.map((m) => (
@@ -220,11 +220,11 @@ export const MemberSection = () => {
                 ) : (
                     <StyledEmpty>{EMPTY_TEXT}</StyledEmpty>
                 )}
-            </StyledCard>
+            </StyledSettingsCard>
 
             {usedOrExpiredInvites.length > 0 && (
-                <StyledCard>
-                    <StyledCardTitle>사용/만료된 코드</StyledCardTitle>
+                <StyledSettingsCard>
+                    <StyledSettingsCardTitle>사용/만료된 코드</StyledSettingsCardTitle>
                     <StyledList>
                         {usedOrExpiredInvites.map((inv) => (
                             <StyledInviteItem key={inv.id} $dimmed>
@@ -240,7 +240,7 @@ export const MemberSection = () => {
                             </StyledInviteItem>
                         ))}
                     </StyledList>
-                </StyledCard>
+                </StyledSettingsCard>
             )}
         </StyledContainer>
     );
@@ -253,20 +253,6 @@ const StyledContainer = styled.div`
 `;
 
 
-const StyledCard = styled.div`
-    padding: 14px;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    background: var(--white-color);
-    box-shadow: var(--shadow-sm);
-`;
-
-const StyledCardTitle = styled.h3`
-    margin: 0 0 10px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--dark-gray-color);
-`;
 
 const StyledCreateRow = styled.div`
     display: flex;
@@ -459,11 +445,6 @@ const StyledMemberEmail = styled.span`
     color: var(--dark-gray-color2);
 `;
 
-const StyledHint = styled.p`
-    margin: 0;
-    font-size: 13px;
-    color: var(--dark-gray-color2);
-`;
 
 const StyledGuestCard = styled.div`
     padding: 14px;

--- a/client/components/settings/NaverBookingSection.tsx
+++ b/client/components/settings/NaverBookingSection.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import {useNaverBookingSync} from '../../hooks/useNaverBookingSync';
 import {PageHero} from '../ui/PageHero';
+import {StyledSettingsCard, StyledSettingsCardTitle, StyledSaveBtn} from './settings-styles';
 
 function formatLastSync(ts: number): string {
     const d = new Date(ts);
@@ -32,8 +33,8 @@ export function NaverBookingSection() {
         <div>
             <PageHero eyebrow="설정" title="네이버예약 연동" subtitle="Gmail을 통해 네이버 예약을 자동으로 일정표에 반영합니다." />
 
-            <StyledCard>
-                <StyledCardTitle>연동 상태</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>연동 상태</StyledSettingsCardTitle>
 
                 <StyledCheckRow>
                     <StyledIcon $ok={isGoogle}>{isGoogle ? '✅' : '❌'}</StyledIcon>
@@ -61,15 +62,15 @@ export function NaverBookingSection() {
                         {lastSync && (
                             <StyledLastSync>마지막 동기화: {formatLastSync(lastSync)}</StyledLastSync>
                         )}
-                        <StyledSyncBtn type="button" onClick={sync} disabled={syncing}>
+                        <StyledSaveBtn type="button" onClick={sync} disabled={syncing} style={{flexShrink: 0}}>
                             {syncing ? '동기화 중...' : '지금 동기화'}
-                        </StyledSyncBtn>
+                        </StyledSaveBtn>
                     </StyledActiveRow>
                 )}
-            </StyledCard>
+            </StyledSettingsCard>
 
-            <StyledCard>
-                <StyledCardTitle>동작 방식</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>동작 방식</StyledSettingsCardTitle>
                 <StyledGuideList>
                     <li>Google 계정으로 로그인하면 Gmail에서 네이버 예약 이메일을 자동으로 읽어옵니다.</li>
                     <li>예약 확정·취소 이메일을 파싱해 일정표에 자동 반영합니다.</li>
@@ -77,36 +78,19 @@ export function NaverBookingSection() {
                     <li>디자이너 이름이 일치하지 않으면 자동으로 새 디자이너를 생성합니다.</li>
                     <li>등록되지 않은 서비스명은 자동으로 서비스에 추가됩니다.</li>
                 </StyledGuideList>
-            </StyledCard>
+            </StyledSettingsCard>
 
-            <StyledCard>
-                <StyledCardTitle>주의사항</StyledCardTitle>
+            <StyledSettingsCard>
+                <StyledSettingsCardTitle>주의사항</StyledSettingsCardTitle>
                 <StyledGuideList>
                     <li>네이버예약 알림 이메일을 Google 계정으로 수신하도록 설정해야 합니다.</li>
                     <li>Gmail 읽기 권한이 필요합니다 (Google 로그인 시 동의).</li>
                 </StyledGuideList>
-            </StyledCard>
+            </StyledSettingsCard>
         </div>
     );
 }
 
-const StyledCard = styled.div`
-    border: 1px solid var(--light-gray-color);
-    border-radius: var(--radius-lg);
-    background: var(--white-color);
-    box-shadow: var(--shadow-sm);
-    padding: 20px;
-    margin-bottom: 16px;
-`;
-
-const StyledCardTitle = styled.h3`
-    font-size: 13px;
-    font-weight: 700;
-    color: var(--dark-gray-color2);
-    margin: 0 0 14px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-`;
 
 const StyledCheckRow = styled.div`
     display: flex;
@@ -162,25 +146,6 @@ const StyledLastSync = styled.span`
     flex: 1;
 `;
 
-const StyledSyncBtn = styled.button`
-    height: 32px;
-    padding: 0 14px;
-    border: 1px solid var(--blue-color);
-    border-radius: var(--radius-md);
-    background: var(--blue-color);
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--white-color);
-    cursor: pointer;
-    transition: opacity 0.15s;
-    flex-shrink: 0;
-
-    &:disabled { opacity: 0.5; cursor: default; }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover:not(:disabled) { opacity: 0.85; }
-    }
-`;
 
 const StyledGuideList = styled.ol`
     margin: 0;

--- a/client/components/settings/SNSLinkingSection.tsx
+++ b/client/components/settings/SNSLinkingSection.tsx
@@ -3,7 +3,10 @@ import {useCallback, useEffect, useState} from 'react';
 import {signIn, useSession} from 'next-auth/react';
 
 import styled from 'styled-components';
+
+import {StyledConfirmOverlay, StyledConfirmModal, StyledHeader, StyledFooter, StyledActionButton} from '../calendar/overlays/ModalStyles';
 import {PageHero} from '../ui/PageHero';
+import {StyledSettingsCard, StyledSettingsHint, StyledSaveBtn, StyledCancelBtn, StyledEditBtn} from './settings-styles';
 
 type LinkedAccount = {
     provider: string;
@@ -120,7 +123,7 @@ export function SNSLinkingSection() {
         <div>
             <PageHero eyebrow="SNS" title="계정 연동" subtitle="여러 SNS 계정을 연결하면 어떤 계정으로든 로그인할 수 있습니다." />
 
-            <StyledCard>
+            <StyledSettingsCard style={{padding: 0, overflow: 'hidden'}}>
                 {loading ? (
                     <StyledLoadingRow>불러오는 중...</StyledLoadingRow>
                 ) : (
@@ -138,43 +141,45 @@ export function SNSLinkingSection() {
                                 </StyledProviderInfo>
                                 <StyledProviderAction>
                                     {isLinked ? (
-                                        <StyledUnlinkBtn
+                                        <StyledEditBtn
                                             type="button"
                                             onClick={() => setUnlinkTarget(p.id)}
                                             disabled={isLastAccount || isProcessing}
                                             title={isLastAccount ? '최소 1개의 계정은 연결을 유지해야 합니다' : ''}
                                         >
                                             {isProcessing ? '처리 중...' : '연결 해제'}
-                                        </StyledUnlinkBtn>
+                                        </StyledEditBtn>
                                     ) : (
-                                        <StyledLinkBtn
+                                        <StyledSaveBtn
                                             type="button"
                                             onClick={() => handleLink(p.id)}
                                             disabled={!!actionLoading}
                                         >
                                             {isProcessing ? '처리 중...' : '연결하기'}
-                                        </StyledLinkBtn>
+                                        </StyledSaveBtn>
                                     )}
                                 </StyledProviderAction>
                             </StyledProviderRow>
                         );
                     })
                 )}
-            </StyledCard>
+            </StyledSettingsCard>
 
             {error && <StyledError>{error}</StyledError>}
 
-            <StyledHint>최소 1개의 계정은 연결을 유지해야 합니다.</StyledHint>
+            <StyledSettingsHint>최소 1개의 계정은 연결을 유지해야 합니다.</StyledSettingsHint>
 
             {unlinkTarget && (
-                <StyledUnlinkOverlay onClick={() => setUnlinkTarget(null)}>
-                    <StyledUnlinkDialog onClick={(e) => e.stopPropagation()}>
-                        <StyledUnlinkTitle>연결 해제</StyledUnlinkTitle>
+                <StyledConfirmOverlay onClick={() => setUnlinkTarget(null)}>
+                    <StyledConfirmModal onClick={(e) => e.stopPropagation()}>
+                        <StyledHeader>
+                            <h3>연결 해제</h3>
+                        </StyledHeader>
                         <StyledUnlinkMsg>
                             <strong>{PROVIDERS.find((p) => p.id === unlinkTarget)?.label}</strong> 연결을 해제하면 해당 계정으로 로그인할 수 없게 됩니다. 계속하시겠습니까?
                         </StyledUnlinkMsg>
-                        <StyledUnlinkActions>
-                            <StyledUnlinkCancel type="button" onClick={() => setUnlinkTarget(null)}>취소</StyledUnlinkCancel>
+                        <StyledFooter>
+                            <StyledActionButton type="button" onClick={() => setUnlinkTarget(null)}>취소</StyledActionButton>
                             <StyledUnlinkConfirm
                                 type="button"
                                 disabled={!!actionLoading}
@@ -182,21 +187,14 @@ export function SNSLinkingSection() {
                             >
                                 {actionLoading ? '처리 중...' : '연결 해제'}
                             </StyledUnlinkConfirm>
-                        </StyledUnlinkActions>
-                    </StyledUnlinkDialog>
-                </StyledUnlinkOverlay>
+                        </StyledFooter>
+                    </StyledConfirmModal>
+                </StyledConfirmOverlay>
             )}
         </div>
     );
 }
 
-const StyledCard = styled.div`
-    border: 1px solid var(--light-gray-color);
-    border-radius: var(--radius-lg);
-    background: var(--white-color);
-    box-shadow: var(--shadow-sm);
-    overflow: hidden;
-`;
 
 const StyledLoadingRow = styled.div`
     display: flex;
@@ -254,46 +252,6 @@ const StyledProviderAction = styled.div`
     flex-shrink: 0;
 `;
 
-const StyledLinkBtn = styled.button`
-    height: 32px;
-    padding: 0 14px;
-    border: 1px solid var(--blue-color);
-    border-radius: var(--radius-md);
-    background: var(--blue-color);
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--white-color);
-    cursor: pointer;
-    transition: opacity 0.15s;
-
-    &:disabled { opacity: 0.5; cursor: default; }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover:not(:disabled) { opacity: 0.85; }
-    }
-`;
-
-const StyledUnlinkBtn = styled.button`
-    height: 32px;
-    padding: 0 14px;
-    border: 1px solid var(--light-gray-color);
-    border-radius: var(--radius-md);
-    background: none;
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--dark-gray-color);
-    cursor: pointer;
-    transition: opacity 0.15s, border-color 0.15s;
-
-    &:disabled { opacity: 0.4; cursor: default; }
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover:not(:disabled) {
-            border-color: var(--danger-border);
-            color: var(--danger-color);
-        }
-    }
-`;
 
 const StyledError = styled.p`
     margin: 12px 0 0;
@@ -302,37 +260,6 @@ const StyledError = styled.p`
     font-weight: 500;
 `;
 
-const StyledHint = styled.p`
-    margin: 12px 0 0;
-    font-size: 12px;
-    color: var(--dark-gray-color2);
-`;
-
-const StyledUnlinkOverlay = styled.div`
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1000;
-`;
-
-const StyledUnlinkDialog = styled.div`
-    background: var(--white-color);
-    border-radius: var(--radius-lg);
-    padding: 24px;
-    width: 320px;
-    max-width: calc(100vw - 32px);
-    box-shadow: var(--shadow-lg);
-`;
-
-const StyledUnlinkTitle = styled.h3`
-    margin: 0 0 12px;
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--dark-gray-color);
-`;
 
 const StyledUnlinkMsg = styled.p`
     margin: 0 0 20px;
@@ -343,37 +270,16 @@ const StyledUnlinkMsg = styled.p`
     strong { color: var(--dark-gray-color); font-weight: 700; }
 `;
 
-const StyledUnlinkActions = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-`;
-
-const StyledUnlinkCancel = styled.button`
-    height: 36px;
-    padding: 0 16px;
-    border: 1px solid var(--light-gray-color);
-    border-radius: var(--radius-md);
-    background: none;
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--dark-gray-color);
-    cursor: pointer;
-
-    @media (hover: hover) and (pointer: fine) {
-        &:hover { background: var(--light-gray-color); }
-    }
-`;
 
 const StyledUnlinkConfirm = styled.button`
     height: 36px;
     padding: 0 16px;
-    border: 1px solid var(--danger-border, #fca5a5);
+    border: 1px solid var(--danger-border);
     border-radius: var(--radius-md);
-    background: var(--danger-color, #dc2626);
+    background: var(--danger-color);
     font-size: 13px;
     font-weight: 600;
-    color: #fff;
+    color: var(--white-color);
     cursor: pointer;
     transition: opacity 0.15s;
 

--- a/client/components/settings/settings-styles.ts
+++ b/client/components/settings/settings-styles.ts
@@ -55,6 +55,28 @@ export const StyledDeleteBtn = styled.button`
     color: var(--danger-color);
 `;
 
+export const StyledSettingsCard = styled.div`
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-lg);
+    background: var(--white-color);
+    box-shadow: var(--shadow-sm);
+    padding: 16px;
+    margin-bottom: 16px;
+`;
+
+export const StyledSettingsCardTitle = styled.h3`
+    margin: 0 0 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
+`;
+
+export const StyledSettingsHint = styled.p`
+    margin: 12px 0 0;
+    font-size: 12px;
+    color: var(--dark-gray-color2);
+`;
+
 export const EMPTY_TEXT = '등록된 데이터가 없습니다';
 
 export const StyledEmpty = styled.div`

--- a/client/components/ui/PageHero.tsx
+++ b/client/components/ui/PageHero.tsx
@@ -25,18 +25,18 @@ const StyledEyebrow = styled.p`
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.18em;
-    color: #2d7ff9;
+    color: var(--blue-color);
 `;
 
 const StyledTitle = styled.h1`
     margin: 0;
     font-size: 32px;
     line-height: 1.1;
-    color: #111827;
+    color: var(--dark-gray-color);
 `;
 
 const StyledSubtitle = styled.p`
     margin: 10px 0 0;
-    color: #4b5563;
+    color: var(--dark-gray-color2);
     font-size: 15px;
 `;

--- a/client/components/ui/SeoHead.tsx
+++ b/client/components/ui/SeoHead.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+import {SITE_NAME} from '../../lib/seo';
+
+interface SeoHeadProps {
+    title: string;
+}
+
+export function SeoHead({title}: SeoHeadProps) {
+    return (
+        <Head>
+            <title>{SITE_NAME} | {title}</title>
+        </Head>
+    );
+}

--- a/client/lib/seo.ts
+++ b/client/lib/seo.ts
@@ -1,0 +1,8 @@
+export const SITE_URL = 'https://takeaseat.co.kr';
+export const SITE_NAME = 'TAS';
+export const SITE_TITLE = 'TAS | 네이버 예약까지 한 번에 관리';
+export const SITE_DESCRIPTION = '예약 관리, 네이버 예약, 고객관리까지 한 번에!';
+export const SITE_OG_DESCRIPTION = '네이버 예약 + 자체 예약을 한 화면에서. 예약 관리의 새로운 기준 Take a Seat';
+export const SITE_TWITTER_DESCRIPTION = '예약 관리, 네이버 예약, 고객관리까지 한 번에 확인!';
+export const SITE_OG_IMAGE = `${SITE_URL}/og-image.jpg`;
+export const SITE_KEYWORDS = '예약관리, 네이버 예약, 고객관리, 예약 시스템, 미용실, 네일샵, 뷰티 CRM, 예약 캘린더, 헤어샵 예약, 네일샵 예약, Take a seat, TAS';

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
 
-import Head from 'next/head';
 import Link from 'next/link';
 import Router, {useRouter} from 'next/router';
 
@@ -261,9 +260,6 @@ function AppContent({Component, pageProps}: AppContentProps) {
 
     return (
         <>
-            <Head>
-                <title>TAS | Take a seat</title>
-            </Head>
             <GlobalStyle/>
             <LayoutComponent>
                 <Component {...pageProps} />

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -2,6 +2,8 @@ import Document, {Html, Head, Main, NextScript, DocumentContext} from 'next/docu
 
 import {ServerStyleSheet} from 'styled-components';
 
+import {SITE_DESCRIPTION, SITE_KEYWORDS, SITE_OG_DESCRIPTION, SITE_OG_IMAGE, SITE_TITLE, SITE_TWITTER_DESCRIPTION, SITE_URL} from '../lib/seo';
+
 class ReservationDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
         const sheet = new ServerStyleSheet();
@@ -33,32 +35,19 @@ class ReservationDocument extends Document {
         return (
             <Html lang="ko">
                 <Head>
-                    <link rel="canonical"
-                          href="https://takeaseat.co.kr" />
-                    <meta name="description"
-                          content="예약 관리, 네이버 예약, 고객관리까지 한 번에!" />
-                    <meta name="keywords"
-                          content="예약관리, 네이버 예약, 고객관리, 예약 시스템, 미용실, 네일샵, 뷰티 CRM, 예약 캘린더, 헤어샵 예약, 네일샵 예약, Take a seat, TAS" />
-                    <meta name="author"
-                          content="TAS" />
-                    <meta property="og:type"
-                          content="website" />
-                    <meta property="og:title"
-                          content="TAS | 네이버 예약까지 한 번에 관리" />
-                    <meta property="og:description"
-                          content="네이버 예약 + 자체 예약을 한 화면에서. 예약 관리의 새로운 기준 Take a Seat" />
-                    <meta property="og:image"
-                          content="https://takeaseat.co.kr/og-image.jpg" />
-                    <meta property="og:url"
-                          content="https://takeaseat.co.kr" />
-                    <meta name="twitter:title"
-                          content="TAS | 네이버 예약까지 한 번에 관리" />
-                    <meta name="twitter:description"
-                          content="예약 관리, 네이버 예약, 고객관리까지 한 번에 확인!" />
-                    <meta name="twitter:card"
-                          content="summary" />
-                    <meta name="twitter:image"
-                          content="https://takeaseat.co.kr/og-image.jpg" />
+                    <link rel="canonical" href={SITE_URL} />
+                    <meta name="description" content={SITE_DESCRIPTION} />
+                    <meta name="keywords" content={SITE_KEYWORDS} />
+                    <meta name="author" content="TAS" />
+                    <meta property="og:type" content="website" />
+                    <meta property="og:title" content={SITE_TITLE} />
+                    <meta property="og:description" content={SITE_OG_DESCRIPTION} />
+                    <meta property="og:image" content={SITE_OG_IMAGE} />
+                    <meta property="og:url" content={SITE_URL} />
+                    <meta name="twitter:title" content={SITE_TITLE} />
+                    <meta name="twitter:description" content={SITE_TWITTER_DESCRIPTION} />
+                    <meta name="twitter:card" content="summary" />
+                    <meta name="twitter:image" content={SITE_OG_IMAGE} />
                     <link rel="shortcut icon"
                           href="/favicon/favicon.ico" />
                     <script async

--- a/client/pages/address.tsx
+++ b/client/pages/address.tsx
@@ -2,8 +2,6 @@ import React, {useState, useMemo, useRef, useEffect, useCallback} from 'react';
 
 import type {GetServerSideProps, NextPage} from 'next';
 
-import Head from 'next/head';
-
 import styled from 'styled-components';
 
 import type {Customer} from '../utils/customers';
@@ -22,6 +20,7 @@ import {useCalendarStore} from '../store/calendarStore';
 
 import {loadLocalDbSnapshot, subscribeLocalDb, type LocalDbSnapshot} from '../lib/local-db';
 import {getPageSession, loadPageData} from '../lib/page-data';
+import {SeoHead} from '../components/ui/SeoHead';
 
 type AddressProps = {
     customers: Customer[];
@@ -298,9 +297,7 @@ const Address: NextPage<AddressProps> = ({customers, reservations, history, stor
 
     return (
         <StyledSection>
-            <Head>
-                <title>TAS | 고객명단</title>
-            </Head>
+            <SeoHead title="고객명단" />
             <PageHero eyebrow="CUSTOMER" title="고객 명단" subtitle="고객 정보, 예약 이력, 메모 태그를 관리합니다." />
             <AddressContent
                 filteredCustomers={filteredCustomers}

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -2,8 +2,6 @@ import {useEffect, useMemo} from 'react';
 
 import type {GetServerSideProps, NextPage} from 'next';
 
-import Head from 'next/head';
-
 import styled from 'styled-components';
 
 import {useCalendarStore} from '../store/calendarStore';
@@ -25,6 +23,7 @@ import {CustomerDetail} from '../components/calendar/overlays/CustomerDetail';
 import {ServiceLegend} from '../components/calendar/service/ServiceLegend';
 
 import {getPageSession, loadPageData} from '../lib/page-data';
+import {SeoHead} from '../components/ui/SeoHead';
 
 type HomeProps = {
     reservations: Reservation[];
@@ -85,9 +84,7 @@ const Home: NextPage<HomeProps> = (props) => {
     }, [selectedReservations, setCreateReservationInitial]);
 
     return (<>
-            <Head>
-                <title>TAS | Take a seat</title>
-            </Head>
+            <SeoHead title="Take a seat" />
             <StyledSection $isVisible={aside.isVisible}>
                 {curr && <Calendar/>}
             </StyledSection>

--- a/client/pages/inquiry.tsx
+++ b/client/pages/inquiry.tsx
@@ -5,6 +5,7 @@ import {useSession} from 'next-auth/react';
 import styled from 'styled-components';
 
 import {PageHero} from '../components/ui/PageHero';
+import {SeoHead} from '../components/ui/SeoHead';
 import {actionButtonStyle, EMPTY_TEXT, StyledEmpty as StyledEmptyBase} from '../components/settings/settings-styles';
 import {FieldError} from '../components/ui/FieldError';
 
@@ -88,6 +89,7 @@ const InquiryPage: NextPage = () => {
 
     return (
         <StyledSection>
+            <SeoHead title="고객센터" />
             <StyledContainer>
                 <PageHero eyebrow="SUPPORT" title="고객센터" />
                 <StyledStickyHeader>

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -9,6 +9,7 @@ import type {GetServerSideProps} from 'next';
 import styled from 'styled-components';
 
 import {AuthActionIcon} from '../components/ui/AuthActionIcon';
+import {SeoHead} from '../components/ui/SeoHead';
 
 type ProviderInfo = {id: string; label: string; bg: string; color: string; border: string};
 type LoginPageProps = {
@@ -84,6 +85,7 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
 
     return (
         <StyledWrapper>
+            <SeoHead title="로그인" />
             {status === 'loading' && (
                 <StyledLoadingOverlay>
                     <StyledLoadingCard>

--- a/client/pages/mypage.tsx
+++ b/client/pages/mypage.tsx
@@ -25,6 +25,7 @@ import {
     subscribeLocalDb,
     type LocalDbSnapshot,
 } from '../lib/local-db';
+import {SeoHead} from '../components/ui/SeoHead';
 
 const PROVIDER_LABELS: Record<string, string> = {
     google: 'Google',
@@ -134,6 +135,7 @@ const MyPage: NextPage<MyPageProps> = ({linkedProviders}) => {
 
     return (
         <StyledSection>
+            <SeoHead title="계정 관리" />
             <StyledContainer>
                 <PageHero eyebrow="MY PAGE" title="계정 관리" subtitle={storageModeLabel} />
 

--- a/client/pages/onboarding.tsx
+++ b/client/pages/onboarding.tsx
@@ -2,7 +2,6 @@ import {useEffect, useMemo, useState} from 'react';
 
 import type {NextPage} from 'next';
 import {useRouter} from 'next/router';
-import Head from 'next/head';
 import {useSession} from 'next-auth/react';
 
 import styled from 'styled-components';
@@ -14,6 +13,7 @@ import {createDefaultSchedule, getDesignerColor} from '../utils/designers';
 import {loadLocalDbSnapshot, saveLocalDbSnapshot} from '../lib/local-db';
 import {buildServiceColorMap, formatDuration, formatPrice, getServiceColor} from '../utils/services';
 import type {ServiceItem} from '../utils/services';
+import {SeoHead} from '../components/ui/SeoHead';
 
 type OnboardingStep = 0 | 1 | 2 | 3 | 4 | 5;
 type ExtShopType = ShopType | 'etc';
@@ -308,9 +308,7 @@ const OnboardingPage: NextPage = () => {
 
     return (
         <StyledPage>
-            <Head>
-                <title>TAS | 초기 설정</title>
-            </Head>
+            <SeoHead title="초기 설정" />
             <StyledCard>
                 {/* Header */}
                 <StyledCardHeader>

--- a/client/pages/settings.tsx
+++ b/client/pages/settings.tsx
@@ -2,7 +2,6 @@ import {useEffect, useMemo, useState} from 'react';
 
 import type {GetServerSideProps, NextPage} from 'next';
 
-import Head from 'next/head';
 import {useRouter} from 'next/router';
 
 import styled from 'styled-components';
@@ -28,6 +27,7 @@ import {StoreManageSection} from '../components/settings/StoreManageSection';
 
 import {loadLocalDbSnapshot, subscribeLocalDb, type LocalDbSnapshot} from '../lib/local-db';
 import {getPageSession, loadPageData} from '../lib/page-data';
+import {SeoHead} from '../components/ui/SeoHead';
 
 type SettingsProps = {
     reservations: Reservation[];
@@ -233,9 +233,7 @@ const Settings: NextPage<SettingsProps> = ({reservations, customers, history, st
 
     return (
         <StyledSection>
-            <Head>
-                <title>TAS | 설정</title>
-            </Head>
+            <SeoHead title="설정" />
             <StyledContent>
                 {tab === 'revenue' && <RevenueSection reservationMap={reservationMap}
                                                       designers={designers}


### PR DESCRIPTION
## Summary

- `StyledSettingsCard`, `StyledSettingsCardTitle`, `StyledSettingsHint` 공통 컴포넌트 추출 (`settings-styles.ts`)
- `PageHero` 하드코딩 색상값 → CSS 변수 교체
- `MemberSection`, `SNSLinkingSection` 공통 스타일 적용
- SNS 연결 해제 확인 모달 추가 (케이스 C: 타 계정 충돌 안내 포함)
- `NaverBookingSection` 신규: Google 연동 상태, 역할 체크, 동작 방식·주의사항 안내
- `client/lib/seo.ts` 신규: SITE_URL, SITE_TITLE 등 SEO 상수 모음
- `client/components/ui/SeoHead.tsx` 신규: 페이지별 타이틀 주입 컴포넌트
- 전체 페이지 `<Head><title>` 인라인 → `<SeoHead>` 컴포넌트로 통일
- `_document.tsx` 하드코딩 메타 문자열 → seo.ts 상수 참조

## Test plan

- [ ] `/settings/naver` — 연동 상태(Google 미연동 ❌, 권한 없음 ❌) 노출 확인
- [ ] `/settings/sns` — 연결하기/연결 해제 버튼, 해제 확인 모달 동작 확인
- [ ] `/settings/member` — 카드 스타일 일관성 확인
- [ ] 각 페이지 브라우저 탭 타이틀 (`TAS | ...`) 정상 노출 확인
- [ ] OG 메타 태그 (`og:title`, `og:image`, `og:url`) 확인

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_