### PR TITLE
refactor: 중복 상수 제거, rgba 하드코딩 CSS 변수화, 인라인 스타일 제거

### DIFF
--- a/client/components/address/AddressCustomerRecharge.tsx
+++ b/client/components/address/AddressCustomerRecharge.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {useCalendarStore} from '../../store/calendarStore';
 import type {Customer, PointHistoryEntry} from '../../utils/customers';
+import {POINT_HISTORY_LABELS} from '../../utils/customers';
 import type {Reservation} from '../../utils/reservations';
 import {formatPrice} from '../../utils/services';
 import {formControlStyle} from '../ui/FormControls';
@@ -19,15 +20,6 @@ import {
 } from '../calendar/overlays/ModalStyles';
 
 const CUSTOM_OPTION = '__custom__';
-
-const POINT_HISTORY_LABELS: Record<PointHistoryEntry['type'], string> = {
-    manual_add: '수동 적립',
-    manual_subtract: '수동 차감',
-    recharge: '충전',
-    payment_use: '결제 사용',
-    payment_earn: '결제 적립',
-    payment_adjust: '적립 조정',
-};
 
 type AddressCustomerRechargeProps = {
     customer: Customer;

--- a/client/components/calendar/overlays/CustomerDetail.tsx
+++ b/client/components/calendar/overlays/CustomerDetail.tsx
@@ -20,7 +20,7 @@ import {
 
 import {buildDesignerColorMap, buildDesignerNameMap} from '../../../utils/designers';
 import {buildServiceColorMap, formatPrice} from '../../../utils/services';
-import {formatTel, toCustomerMap} from '../../../utils/customers';
+import {formatTel, toCustomerMap, POINT_HISTORY_LABELS} from '../../../utils/customers';
 import type {Customer as CustomerType} from '../../../utils/customers';
 import {useCalendarStore} from '../../../store/calendarStore';
 import {CloseIconButton} from '../../ui/CloseIconButton';
@@ -29,15 +29,6 @@ import {ColorTag} from '../../ui/ColorTag';
 import {ColorPickerButton} from '../../ui/ColorPickerButton';
 
 const PAGE_SIZE = 5;
-
-const POINT_HISTORY_LABELS: Record<PointHistoryEntry['type'], string> = {
-    manual_add: '수동 적립',
-    manual_subtract: '수동 차감',
-    recharge: '충전',
-    payment_use: '결제 사용',
-    payment_earn: '결제 적립',
-    payment_adjust: '적립 조정',
-};
 
 interface CustomerDetailProps {
     customer: Customer;

--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -142,7 +142,7 @@ export const StyledDetail = styled.div<{ $width?: number | string }>`
     max-height: 80vh;
     display: flex;
     flex-direction: column;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.98) 100%);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, var(--bg-subtle-98) 100%);
     border: 1px solid var(--modal-border);
     border-radius: var(--modal-radius);
     box-shadow: var(--modal-shadow);
@@ -164,7 +164,7 @@ export const StyledHeader = styled.div`
     gap: var(--modal-header-gap);
     padding: var(--modal-header-padding);
     border-bottom: 1px solid var(--modal-header-border);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(248, 250, 252, 0.92) 100%);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, var(--bg-subtle-92) 100%);
     backdrop-filter: blur(10px);
 
     h3 {
@@ -339,7 +339,7 @@ export const StyledInfoGrid = styled.dl`
         align-items: start;
         padding: var(--info-grid-cell-padding);
         border-radius: var(--info-grid-cell-radius);
-        background: rgba(248, 250, 252, 0.9);
+        background: rgba(248, 250, 252, 0.9); /* --bg-subtle 계열 (0.9 변형은 변수 없음) */
         border: 1px solid rgba(226, 232, 240, 0.9);
         font-size: 13px;
     }
@@ -405,7 +405,7 @@ export const StyledFooter = styled.div`
     gap: var(--modal-footer-gap);
     padding: var(--modal-footer-padding);
     border-top: 1px solid var(--modal-footer-border);
-    background: linear-gradient(180deg, rgba(248, 250, 252, 0.72) 0%, rgba(255, 255, 255, 0.96) 100%);
+    background: linear-gradient(180deg, var(--bg-subtle-72) 0%, rgba(255, 255, 255, 0.96) 100%);
 
     @media (max-width: 640px) {
         flex-wrap: wrap;

--- a/client/components/settings/NaverBookingSection.tsx
+++ b/client/components/settings/NaverBookingSection.tsx
@@ -62,9 +62,9 @@ export function NaverBookingSection() {
                         {lastSync && (
                             <StyledLastSync>마지막 동기화: {formatLastSync(lastSync)}</StyledLastSync>
                         )}
-                        <StyledSaveBtn type="button" onClick={sync} disabled={syncing} style={{flexShrink: 0}}>
+                        <StyledSyncBtn type="button" onClick={sync} disabled={syncing}>
                             {syncing ? '동기화 중...' : '지금 동기화'}
-                        </StyledSaveBtn>
+                        </StyledSyncBtn>
                     </StyledActiveRow>
                 )}
             </StyledSettingsCard>
@@ -91,6 +91,10 @@ export function NaverBookingSection() {
     );
 }
 
+
+const StyledSyncBtn = styled(StyledSaveBtn)`
+    flex-shrink: 0;
+`;
 
 const StyledCheckRow = styled.div`
     display: flex;

--- a/client/components/settings/PointManageSection.tsx
+++ b/client/components/settings/PointManageSection.tsx
@@ -4,21 +4,12 @@ import styled from 'styled-components';
 
 import {useCalendarStore} from '../../store/calendarStore';
 import type {PointHistoryEntry} from '../../utils/customers';
-import {formatTel} from '../../utils/customers';
+import {formatTel, POINT_HISTORY_LABELS} from '../../utils/customers';
 import type {Reservation} from '../../utils/reservations';
 import {formatPrice} from '../../utils/services';
 import {PageHero} from '../ui/PageHero';
 import {formControlStyle} from '../ui/FormControls';
 import {actionButtonStyle, EMPTY_TEXT, StyledEditBtn, StyledSaveBtn, StyledCancelBtn, StyledEmpty} from './settings-styles';
-
-const POINT_HISTORY_LABELS: Record<PointHistoryEntry['type'], string> = {
-    manual_add: '수동 적립',
-    manual_subtract: '수동 차감',
-    recharge: '충전',
-    payment_use: '결제 사용',
-    payment_earn: '결제 적립',
-    payment_adjust: '적립 조정',
-};
 
 type PointManageTab = 'history' | 'adjust' | 'settings';
 

--- a/client/components/settings/SNSLinkingSection.tsx
+++ b/client/components/settings/SNSLinkingSection.tsx
@@ -123,7 +123,7 @@ export function SNSLinkingSection() {
         <div>
             <PageHero eyebrow="SNS" title="계정 연동" subtitle="여러 SNS 계정을 연결하면 어떤 계정으로든 로그인할 수 있습니다." />
 
-            <StyledSettingsCard style={{padding: 0, overflow: 'hidden'}}>
+            <StyledProviderCard>
                 {loading ? (
                     <StyledLoadingRow>불러오는 중...</StyledLoadingRow>
                 ) : (
@@ -163,7 +163,7 @@ export function SNSLinkingSection() {
                         );
                     })
                 )}
-            </StyledSettingsCard>
+            </StyledProviderCard>
 
             {error && <StyledError>{error}</StyledError>}
 
@@ -195,6 +195,11 @@ export function SNSLinkingSection() {
     );
 }
 
+
+const StyledProviderCard = styled(StyledSettingsCard)`
+    padding: 0;
+    overflow: hidden;
+`;
 
 const StyledLoadingRow = styled.div`
     display: flex;

--- a/client/components/settings/revenue/revenue-styles.ts
+++ b/client/components/settings/revenue/revenue-styles.ts
@@ -36,7 +36,7 @@ export const StyledClickableRow = styled.div<{ $accentColor?: string; $showAccen
     border-left-width: ${(props) => props.$showAccentBar ? '4px' : '1px'};
     border-left-color: ${(props) => props.$showAccentBar ? (props.$accentColor || 'rgba(148, 163, 184, 0.42)') : undefined};
     background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, ${(props) => props.$accentColor ? `${props.$accentColor}10` : 'rgba(248, 250, 252, 0.96)'} 100%);
+        linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, ${(props) => props.$accentColor ? `${props.$accentColor}10` : 'var(--bg-subtle-96)'} 100%);
     box-shadow: var(--card-shadow);
     cursor: pointer;
     transition: transform 0.14s ease, box-shadow 0.14s ease, border-color 0.14s ease, background-color 0.14s ease;
@@ -45,7 +45,7 @@ export const StyledClickableRow = styled.div<{ $accentColor?: string; $showAccen
         &:hover {
             border-color: ${(props) => props.$accentColor ? `${props.$accentColor}66` : 'rgba(66, 133, 244, 0.28)'};
             box-shadow: var(--card-shadow-hover);
-            background-color: ${(props) => props.$accentColor ? `${props.$accentColor}14` : 'rgba(248, 250, 252, 0.98)'};
+            background-color: ${(props) => props.$accentColor ? `${props.$accentColor}14` : 'var(--bg-subtle-98)'};
         }
     }
 
@@ -131,7 +131,7 @@ export const StyledCustomerName = styled.span`
     max-width: 100%;
     font-size: var(--small-font);
     border-radius: var(--chip-radius);
-    background: rgba(248, 250, 252, 0.92);
+    background: var(--bg-subtle-92);
 `;
 
 export const StyledInlineCustomerButton = styled.button`
@@ -176,7 +176,7 @@ export const StyledRevenueEmpty = styled.div`
     padding: 54px 24px;
     border: 1px dashed rgba(148, 163, 184, 0.32);
     border-radius: 10px;
-    background: rgba(248, 250, 252, 0.78);
+    background: var(--bg-subtle-78);
     font-size: 13px;
     color: var(--dark-gray-color2);
 `;
@@ -189,7 +189,7 @@ export const StyledSummary = styled.div`
     padding: 10px 14px;
     border: 1px solid rgba(148, 163, 184, 0.18);
     border-radius: var(--info-grid-cell-radius);
-    background: rgba(248, 250, 252, 0.88);
+    background: var(--bg-subtle-88);
     font-size: 13px;
     color: var(--dark-gray-color2);
 
@@ -211,7 +211,7 @@ export const StyledCustomerInfoGrid = styled.div`
         display: flex;
         gap: 6px;
         border-radius: 10px;
-        background: rgba(248, 250, 252, 0.92);
+        background: var(--bg-subtle-92);
         font-size: 12px;
         color: var(--dark-gray-color);
     }

--- a/client/components/ui/GuestNotice.tsx
+++ b/client/components/ui/GuestNotice.tsx
@@ -23,9 +23,9 @@ const StyledWrapper = styled.div`
     margin: 0;
     padding: 14px 16px;
     box-sizing: border-box;
-    border: 1px solid rgba(101, 38, 217, 0.2);
+    border: 1px solid var(--brand-color-border);
     border-radius: var(--radius-md);
-    background: rgba(101, 38, 217, 0.04);
+    background: var(--brand-color-bg);
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -54,7 +54,7 @@ const StyledList = styled.ul`
 const StyledDivider = styled.hr`
     margin: 0;
     border: none;
-    border-top: 1px dashed rgba(101, 38, 217, 0.2);
+    border-top: 1px dashed var(--brand-color-border);
 `;
 
 const StyledCta = styled.p`

--- a/client/features/customers/model.ts
+++ b/client/features/customers/model.ts
@@ -2,6 +2,15 @@ import type {ReservationMap} from '../reservations/model';
 
 export type PointHistoryType = 'manual_add' | 'manual_subtract' | 'recharge' | 'payment_use' | 'payment_earn' | 'payment_adjust';
 
+export const POINT_HISTORY_LABELS: Record<PointHistoryType, string> = {
+    manual_add: '수동 적립',
+    manual_subtract: '수동 차감',
+    recharge: '충전',
+    payment_use: '결제 사용',
+    payment_earn: '결제 적립',
+    payment_adjust: '적립 조정',
+};
+
 export interface PointHistoryEntry {
     id: string;
     type: PointHistoryType;

--- a/client/styles/globalStyle.ts
+++ b/client/styles/globalStyle.ts
@@ -24,6 +24,8 @@ export const GlobalStyle = createGlobalStyle`
         --white-color-40: hsla(0, 0%, 100%, .4);
 
         --brand-color: #6526d9;
+        --brand-color-bg: rgba(101, 38, 217, 0.04);
+        --brand-color-border: rgba(101, 38, 217, 0.2);
 
         --danger-color: #c93a30;
         --danger-bg: #fef2f2;
@@ -132,6 +134,12 @@ export const GlobalStyle = createGlobalStyle`
         --chip-padding: 4px 8px;
         --chip-radius: 999px;
         --bg-subtle: rgba(248, 250, 252, 0.6);
+        --bg-subtle-72: rgba(248, 250, 252, 0.72);
+        --bg-subtle-78: rgba(248, 250, 252, 0.78);
+        --bg-subtle-88: rgba(248, 250, 252, 0.88);
+        --bg-subtle-92: rgba(248, 250, 252, 0.92);
+        --bg-subtle-96: rgba(248, 250, 252, 0.96);
+        --bg-subtle-98: rgba(248, 250, 252, 0.98);
     }
 
     @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- `POINT_HISTORY_LABELS` 3곳 중복 → `features/customers/model.ts`로 통합
- `globalStyle.ts`: `--brand-color-bg/border`, `--bg-subtle-72/78/88/92/96/98` 변수 추가
- `revenue-styles.ts`, `ModalStyles.ts`: `rgba(248,250,252,*)` → `--bg-subtle-*` 참조
- `GuestNotice.tsx`: `rgba(101,38,217,*)` → `--brand-color-bg/border` 참조
- `SNSLinkingSection`: `style={{padding:0}}` 인라인 → `StyledProviderCard`
- `NaverBookingSection`: `style={{flexShrink:0}}` 인라인 → `StyledSyncBtn`

## Test plan

- [ ] `/settings/sns` — SNS 카드 스타일 정상 렌더 확인
- [ ] `/settings/naver` — 동기화 버튼 flex-shrink 정상 확인
- [ ] 게스트 모드 GuestNotice 배경·테두리 색상 확인
- [ ] 매출 카드 배경 그라디언트 정상 확인

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_