### PR TITLE
feat(ux): 토스트 시스템 구축 및 UX 전반 개선

### DIFF
--- a/client/components/calendar/overlays/CustomerDetail.tsx
+++ b/client/components/calendar/overlays/CustomerDetail.tsx
@@ -27,6 +27,7 @@ import {CloseIconButton} from '../../ui/CloseIconButton';
 import {CustomerReservationCards} from '../../ui/CustomerReservationCards';
 import {ColorTag} from '../../ui/ColorTag';
 import {ColorPickerButton} from '../../ui/ColorPickerButton';
+import {useToastStore} from '../../../store/toastStore';
 
 const PAGE_SIZE = 5;
 
@@ -69,6 +70,7 @@ export const CustomerDetail = ({customer, reservationMap, onClose, onReservation
     const designers = useCalendarStore((s) => s.designers);
     const updateCustomer = useCalendarStore((s) => s.updateCustomer);
     const setCustomerMap = useCalendarStore((s) => s.setCustomerMap);
+    const toast = useToastStore((s) => s.show);
     const modalRoot = document.getElementById('modal-root');
     const {layerId, layerDataId} = useLayerInstanceId('customer-detail');
     const dialogRef = useDialogAccessibility<HTMLDivElement>(onClose);
@@ -136,7 +138,7 @@ export const CustomerDetail = ({customer, reservationMap, onClose, onReservation
 
             if (!resp.ok) {
                 const err = await resp.json().catch(() => null);
-                alert(err?.error || '분리에 실패했습니다.');
+                toast(err?.error || '분리에 실패했습니다.', 'error');
                 return;
             }
 
@@ -149,7 +151,7 @@ export const CustomerDetail = ({customer, reservationMap, onClose, onReservation
 
             onClose();
         } catch {
-            alert('분리 중 오류가 발생했습니다.');
+            toast('분리 중 오류가 발생했습니다.', 'error');
         } finally {
             setIsUnmerging(false);
             setIsUnmergeConfirm(false);

--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -7,6 +7,8 @@ import {LabelBadge} from '../ui/LabelBadge';
 import {PageHero} from '../ui/PageHero';
 import {EMPTY_TEXT, StyledEmpty, StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint} from './settings-styles';
 import {FieldError} from '../ui/FieldError';
+import {StyledConfirmOverlay, StyledConfirmModal, StyledHeader, StyledFooter, StyledActionButton} from '../calendar/overlays/ModalStyles';
+import {useToastStore} from '../../store/toastStore';
 
 type Invite = {
     id: string;
@@ -65,11 +67,13 @@ function CopyButton({text}: {text: string}) {
 
 export const MemberSection = () => {
     const {data: session} = useSession();
+    const toast = useToastStore((s) => s.show);
     const [invites, setInvites] = useState<Invite[]>([]);
     const [members, setMembers] = useState<Member[]>([]);
     const [newRole, setNewRole] = useState<string>('staff');
     const [creating, setCreating] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
     const loadInvites = useCallback(async () => {
         try {
@@ -106,6 +110,7 @@ export const MemberSection = () => {
             }
 
             await loadInvites();
+            toast('초대코드가 생성되었습니다.');
         } catch (err) {
             setError(err instanceof Error ? err.message : '초대코드 생성에 실패했습니다.');
         } finally {
@@ -114,13 +119,17 @@ export const MemberSection = () => {
     };
 
     const deleteInvite = async (id: string) => {
+        setDeleteTarget(null);
         try {
             const res = await fetch('/api/invites', {
                 method: 'DELETE',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({id}),
             });
-            if (res.ok) await loadInvites();
+            if (res.ok) {
+                await loadInvites();
+                toast('초대코드가 취소되었습니다.', 'info');
+            }
         } catch { /* ignore */ }
     };
 
@@ -154,7 +163,7 @@ export const MemberSection = () => {
         );
     }
 
-    return (
+    return (<>
         <StyledContainer>
             <PageHero eyebrow="MEMBER" title="멤버 관리" subtitle="초대코드를 생성하고 매장 멤버를 관리합니다." />
 
@@ -191,7 +200,7 @@ export const MemberSection = () => {
                                 <StyledInviteActions>
                                     <StyledExpiry>{formatExpiry(inv.expiresAt)}</StyledExpiry>
                                     <CopyButton text={inv.code} />
-                                    <StyledDeleteButton type="button" onClick={() => deleteInvite(inv.id)}>
+                                    <StyledDeleteButton type="button" onClick={() => setDeleteTarget(inv.id)}>
                                         취소
                                     </StyledDeleteButton>
                                 </StyledInviteActions>
@@ -243,6 +252,20 @@ export const MemberSection = () => {
                 </StyledSettingsCard>
             )}
         </StyledContainer>
+
+        {deleteTarget && (
+            <StyledConfirmOverlay onClick={() => setDeleteTarget(null)}>
+                <StyledConfirmModal onClick={(e) => e.stopPropagation()}>
+                    <StyledHeader><h3>초대코드 취소</h3></StyledHeader>
+                    <StyledConfirmText>초대코드를 취소하면 더 이상 사용할 수 없습니다. 계속하시겠습니까?</StyledConfirmText>
+                    <StyledFooter>
+                        <StyledActionButton type="button" onClick={() => setDeleteTarget(null)}>닫기</StyledActionButton>
+                        <StyledActionButton type="button" $danger onClick={() => deleteInvite(deleteTarget)}>취소하기</StyledActionButton>
+                    </StyledFooter>
+                </StyledConfirmModal>
+            </StyledConfirmOverlay>
+        )}
+    </>
     );
 };
 
@@ -466,4 +489,11 @@ const StyledGuestDesc = styled.p`
     font-size: 13px;
     line-height: 1.7;
     color: var(--dark-gray-color2);
+`;
+
+const StyledConfirmText = styled.p`
+    margin: 0 0 20px;
+    font-size: 14px;
+    color: var(--dark-gray-color);
+    line-height: 1.6;
 `;

--- a/client/components/settings/ServiceManageSection.tsx
+++ b/client/components/settings/ServiceManageSection.tsx
@@ -1,4 +1,5 @@
 import {useMemo, useState, type DragEvent} from 'react';
+import {useToastStore} from '../../store/toastStore';
 import {createPortal} from 'react-dom';
 
 import styled from 'styled-components';
@@ -14,6 +15,8 @@ import {
     StyledHeader,
     StyledFooter,
     StyledActionButton,
+    StyledConfirmOverlay,
+    StyledConfirmModal,
     StyledForm,
     StyledFieldRow,
     useDialogAccessibility,
@@ -43,6 +46,7 @@ const ServiceEditModal = ({item, serviceCatalog, onSave, onDelete, onClose}: Ser
     const [name, setName] = useState(item.name);
     const [durationMinutes, setDurationMinutes] = useState(String(item.durationMinutes));
     const [price, setPrice] = useState(String(item.price));
+    const [confirmDelete, setConfirmDelete] = useState(false);
     const [error, setError] = useState('');
 
     const handleSave = () => {
@@ -63,11 +67,8 @@ const ServiceEditModal = ({item, serviceCatalog, onSave, onDelete, onClose}: Ser
         });
     };
 
-    const handleDelete = () => {
-        if (confirm(`"${item.name}" 항목을 삭제하시겠습니까?`)) {
-            onDelete(item.name);
-        }
-    };
+    const handleDelete = () => setConfirmDelete(true);
+    const handleDeleteConfirm = () => { onDelete(item.name); };
 
     if (!modalRoot) return null;
 
@@ -131,6 +132,21 @@ const ServiceEditModal = ({item, serviceCatalog, onSave, onDelete, onClose}: Ser
                     <StyledActionButton type="button" $primary onClick={handleSave}>저장</StyledActionButton>
                 </StyledFooter>
             </StyledServiceModal>
+            {confirmDelete && (
+                <StyledConfirmOverlay onClick={() => setConfirmDelete(false)}>
+                    <StyledConfirmModal onClick={(e) => e.stopPropagation()}>
+                        <StyledHeader><h3>서비스 삭제</h3></StyledHeader>
+                        <StyledDeleteMsg>
+                            <strong>"{item.name}"</strong> 서비스를 삭제하시겠습니까?<br />
+                            이 작업은 되돌릴 수 없습니다.
+                        </StyledDeleteMsg>
+                        <StyledFooter>
+                            <StyledActionButton type="button" onClick={() => setConfirmDelete(false)}>취소</StyledActionButton>
+                            <StyledActionButton type="button" $danger onClick={handleDeleteConfirm}>삭제</StyledActionButton>
+                        </StyledFooter>
+                    </StyledConfirmModal>
+                </StyledConfirmOverlay>
+            )}
         </StyledServiceOverlay>,
         modalRoot
     );
@@ -283,6 +299,7 @@ const ServiceAddModal = ({categories, serviceCatalog, onAdd, onClose}: ServiceAd
 /* ------------------------------------------------------------------ */
 
 export const ServiceManageSection = () => {
+    const toast = useToastStore((s) => s.show);
     const serviceCatalog = useCalendarStore((s) => s.serviceCatalog);
     const categoryBaseColorMap = useCalendarStore((s) => s.categoryBaseColorMap);
     const addService = useCalendarStore((s) => s.addService);
@@ -313,16 +330,19 @@ export const ServiceManageSection = () => {
     const handleSaveEdit = (original: ServiceItem, updated: ServiceItem) => {
         updateService(original.name, updated);
         setEditingItem(null);
+        toast('서비스가 저장되었습니다.');
     };
 
     const handleDelete = (name: string) => {
         deleteService(name);
         setEditingItem(null);
+        toast(`"${name}" 서비스가 삭제되었습니다.`, 'info');
     };
 
     const handleAdd = (item: ServiceItem) => {
         addService(item);
         setShowAddModal(false);
+        toast('서비스가 추가되었습니다.');
     };
 
     const handleDragStart = (e: DragEvent<HTMLDivElement>, name: string) => {
@@ -861,3 +881,12 @@ const StyledAddButton = styled.button`
     }
 `;
 
+
+
+const StyledDeleteMsg = styled.p`
+    margin: 0 0 20px;
+    font-size: 14px;
+    color: var(--dark-gray-color);
+    line-height: 1.6;
+    strong { font-weight: 700; }
+`;

--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -8,6 +8,7 @@ import {useCalendarStore} from '../../store/calendarStore';
 import {PageHero} from '../ui/PageHero';
 import {formControlStyle} from '../ui/FormControls';
 import {FieldError} from '../ui/FieldError';
+import {useToastStore} from '../../store/toastStore';
 
 interface StoreManageSectionProps {
     formatDateLabel: (dateKey: string) => string;
@@ -15,6 +16,7 @@ interface StoreManageSectionProps {
 
 
 export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) => {
+    const toast = useToastStore((s) => s.show);
     const storeName = useCalendarStore((s) => s.storeName);
     const storeSettings = useCalendarStore((s) => s.storeSettings);
     const updateStoreInfo = useCalendarStore((s) => s.updateStoreInfo);
@@ -47,6 +49,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
         updateStoreInfo(editStoreName.trim(), null);
         setIsEditingStoreInfo(false);
         setStoreInfoError('');
+        toast('매장 정보가 저장되었습니다.');
     };
 
     const isBusinessHoursDirty = businessHours.start !== storeSettings.businessHours.start
@@ -56,6 +59,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
     const handleSaveBusinessHours = () => {
         updateStoreBusinessHours(businessHours);
         setIsEditingBusinessHours(false);
+        toast('영업시간이 저장되었습니다.');
     };
 
     const handleAddClosedDate = () => {
@@ -77,6 +81,7 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
     const handleSaveClosedDates = () => {
         updateStoreClosedDates(closedDates);
         setIsEditingClosedDates(false);
+        toast('휴업일이 저장되었습니다.');
     };
 
     return (

--- a/client/components/ui/Buttons.tsx
+++ b/client/components/ui/Buttons.tsx
@@ -46,6 +46,14 @@ const StyledCircleButton = styled.button <Props>`
     box-shadow: var(--shadow-sm);
     font-size: 14px;
     color: var(--dark-gray-color);
+
+    @media (max-width: 640px) {
+        &::after {
+            content: '';
+            position: absolute;
+            inset: -12px;
+        }
+    }
 `;
 
 export const ButtonCircle: React.FC<Props> = ({children, ...props}) => {

--- a/client/components/ui/CloseIconButton.tsx
+++ b/client/components/ui/CloseIconButton.tsx
@@ -27,6 +27,12 @@ const StyledCloseIconButton = styled.button`
     background: var(--white-color);
     color: var(--dark-gray-color);
 
+    @media (max-width: 640px) {
+        width: 44px;
+        height: 44px;
+        border-radius: var(--radius-lg);
+    }
+
     @media (hover: hover) and (pointer: fine) {
         &:hover {
         background-color: var(--black-color-10);

--- a/client/components/ui/ToastContainer.tsx
+++ b/client/components/ui/ToastContainer.tsx
@@ -1,0 +1,96 @@
+import {useEffect, useRef} from 'react';
+import {createPortal} from 'react-dom';
+import styled, {keyframes, css} from 'styled-components';
+import {useToastStore, type Toast} from '../../store/toastStore';
+
+export function ToastContainer() {
+    const toasts = useToastStore((s) => s.toasts);
+    const dismiss = useToastStore((s) => s.dismiss);
+    const root = typeof document !== 'undefined' ? document.getElementById('modal-root') : null;
+    if (!root) return null;
+    return createPortal(
+        <StyledList role="region" aria-live="polite" aria-label="알림">
+            {toasts.map((t) => (
+                <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
+            ))}
+        </StyledList>,
+        root
+    );
+}
+
+function ToastItem({toast, onDismiss}: {toast: Toast; onDismiss: (id: string) => void}) {
+    const ref = useRef<HTMLLIElement>(null);
+
+    useEffect(() => {
+        ref.current?.focus();
+    }, []);
+
+    return (
+        <StyledItem ref={ref} $type={toast.type} tabIndex={-1} role="alert">
+            <StyledMsg>{toast.message}</StyledMsg>
+            <StyledClose
+                type="button"
+                onClick={() => onDismiss(toast.id)}
+                aria-label="닫기"
+            >×</StyledClose>
+        </StyledItem>
+    );
+}
+
+const slideIn = keyframes`
+    from { transform: translateY(8px); opacity: 0; }
+    to   { transform: translateY(0);   opacity: 1; }
+`;
+
+const StyledList = styled.ul`
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    z-index: 9999;
+    pointer-events: none;
+    width: max-content;
+    max-width: calc(100vw - 32px);
+`;
+
+const typeStyles = {
+    success: css`background: #1a7f3c; color: #fff;`,
+    error:   css`background: var(--danger-color); color: #fff;`,
+    info:    css`background: var(--toast-bg); color: #fff;`,
+};
+
+const StyledItem = styled.li<{$type: Toast['type']}>`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    font-size: 13px;
+    font-weight: 500;
+    pointer-events: all;
+    animation: ${slideIn} 0.18s ease;
+    ${(p) => typeStyles[p.$type]}
+`;
+
+const StyledMsg = styled.span`flex: 1;`;
+
+const StyledClose = styled.button`
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 2px;
+    opacity: 0.7;
+    cursor: pointer;
+    flex-shrink: 0;
+
+    &:hover { opacity: 1; }
+`;

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -21,6 +21,7 @@ import {toCustomerMap} from '../utils/customers';
 import {loadLocalDbSnapshot, saveLocalDbSnapshot, setAuthenticated, shouldUseLocalDb} from '../lib/local-db';
 
 import LayoutComponent from '../components/layout/LayoutComponent';
+import {ToastContainer} from '../components/ui/ToastContainer';
 
 type AppContentProps = Pick<AppProps, 'Component' | 'pageProps'>;
 
@@ -264,6 +265,7 @@ function AppContent({Component, pageProps}: AppContentProps) {
             <LayoutComponent>
                 <Component {...pageProps} />
             </LayoutComponent>
+            <ToastContainer />
             {sessionExpired && (
                 <StyledSessionExpiredToast>
                     <span>로그인 세션이 만료되었습니다.</span>

--- a/client/store/toastStore.ts
+++ b/client/store/toastStore.ts
@@ -1,0 +1,27 @@
+import {create} from 'zustand';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export interface Toast {
+    id: string;
+    message: string;
+    type: ToastType;
+}
+
+interface ToastStore {
+    toasts: Toast[];
+    show: (message: string, type?: ToastType) => void;
+    dismiss: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+    toasts: [],
+    show: (message, type = 'success') => {
+        const id = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        set((s) => ({toasts: [...s.toasts, {id, message, type}]}));
+        setTimeout(() => {
+            set((s) => ({toasts: s.toasts.filter((t) => t.id !== id)}));
+        }, 3000);
+    },
+    dismiss: (id) => set((s) => ({toasts: s.toasts.filter((t) => t.id !== id)})),
+}));


### PR DESCRIPTION
## Summary

- `toastStore.ts` 신규: Zustand 기반 전역 토스트 (success/error/info, 3초 자동 닫기)
- `ToastContainer.tsx` 신규: 하단 중앙 고정, slideIn 애니메이션, 수동 닫기 지원
- `_app.tsx`: ToastContainer 전역 마운트
- `ServiceManageSection`: `confirm()` → 스타일 확인 모달, 저장·추가·삭제 시 토스트
- `MemberSection`: 초대코드 취소 시 확인 모달 추가, 생성·취소 토스트
- `StoreManageSection`: 매장정보·영업시간·휴업일 저장 성공 토스트
- `CustomerDetail`: `alert()` → 토스트 (분리 오류)
- `CloseIconButton`: 모바일 44×44px 터치 타겟
- `Buttons.tsx ButtonCircle`: 모바일 `::after` 44px 터치 영역 확장

## Test plan

- [ ] 서비스 수정 → 저장 시 하단에 "서비스가 저장되었습니다." 토스트 노출
- [ ] 서비스 삭제 → confirm() 대신 스타일 모달 노출, 확인 시 "삭제되었습니다." 토스트
- [ ] 초대코드 취소 버튼 → 확인 모달 노출, 확인 시 "취소되었습니다." 토스트
- [ ] 매장정보 저장 → "매장 정보가 저장되었습니다." 토스트
- [ ] 토스트 3초 후 자동 닫힘, × 버튼으로 수동 닫힘

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_