### PR TITLE
fix: ToastContainer hydration mismatch 수정

### DIFF
--- a/client/components/ui/ToastContainer.tsx
+++ b/client/components/ui/ToastContainer.tsx
@@ -1,12 +1,14 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import styled, {keyframes, css} from 'styled-components';
 import {useToastStore, type Toast} from '../../store/toastStore';
 
 export function ToastContainer() {
+    const [mounted, setMounted] = useState(false);
+    useEffect(() => setMounted(true), []);
     const toasts = useToastStore((s) => s.toasts);
     const dismiss = useToastStore((s) => s.dismiss);
-    const root = typeof document !== 'undefined' ? document.getElementById('modal-root') : null;
+    const root = mounted ? document.getElementById('modal-root') : null;
     if (!root) return null;
     return createPortal(
         <StyledList role="region" aria-live="polite" aria-label="알림">


### PR DESCRIPTION
## 원인

`typeof document !== 'undefined'` 체크는 서버에서 `false`여서 `null`을 반환하지만, 클라이언트 첫 렌더(hydration) 시점에 `true`가 되어 포탈을 렌더 → 서버 HTML과 불일치 발생.

## 수정

`useState(false)` + `useEffect(() => setMounted(true), [])` 패턴으로 변경.
- 서버 렌더: `mounted = false` → `null` 반환
- 클라이언트 hydration 첫 렌더: `mounted = false` → 동일하게 `null` 반환 (mismatch 없음)
- `useEffect` 실행 후: `mounted = true` → 포탈 렌더

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_