### PR TITLE
feat: 게스트 → 계정 전체 데이터 마이그레이션

### DIFF
--- a/client/components/layout/GuestMigrationLayer.tsx
+++ b/client/components/layout/GuestMigrationLayer.tsx
@@ -1,0 +1,393 @@
+import React, {useCallback, useState} from 'react';
+
+import styled, {keyframes} from 'styled-components';
+
+import type {LocalDbSnapshot} from '../../lib/local-db';
+import {createDefaultLocalDbSnapshot, saveLocalDbSnapshot} from '../../lib/local-db';
+import type {Designer} from '../../features/designers/model';
+import {
+    StyledConfirmOverlay,
+    StyledConfirmModal,
+    StyledHeader,
+    StyledFooter,
+    StyledActionButton,
+} from '../calendar/overlays/ModalStyles';
+
+interface Props {
+    snapshot: LocalDbSnapshot;
+    storeName: string;
+    onFinish: () => void;
+}
+
+type Phase = 'confirm' | 'merging' | 'designer-merge' | 'error';
+
+interface MergePair {
+    newDesigner: Designer;
+    existingDesigner: Designer;
+}
+
+function clearLocalAndReload(snapshot: LocalDbSnapshot): void {
+    const clean = createDefaultLocalDbSnapshot();
+    clean.onboarded = false;
+    saveLocalDbSnapshot(clean);
+    // 마이그레이션된 데이터는 서버에 있으므로 로컬 스냅샷 내 고객 병합 기록도 초기화
+    if (typeof window !== 'undefined') {
+        window.localStorage.removeItem('customer-merge-reviewed');
+    }
+    // onboarded 플래그가 false이므로 재진입 시 마이그레이션이 재실행되지 않음
+    void snapshot; // suppress unused warning
+    window.location.reload();
+}
+
+export function GuestMigrationLayer({snapshot, storeName, onFinish}: Props) {
+    const [phase, setPhase] = useState<Phase>('confirm');
+    const [errorMsg, setErrorMsg] = useState('');
+    const [mergePairs, setMergePairs] = useState<MergePair[]>([]);
+    const [decisions, setDecisions] = useState<Map<number, 'merge' | 'keep'>>(new Map());
+    const [processing, setProcessing] = useState(false);
+
+    const handleDiscard = useCallback(() => {
+        clearLocalAndReload(snapshot);
+        onFinish();
+    }, [snapshot, onFinish]);
+
+    const handleMerge = useCallback(async () => {
+        setPhase('merging');
+        try {
+            const res = await fetch('/api/migrate-local', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    shopName: snapshot.storeName ?? '',
+                    shopType: snapshot.shopType ?? null,
+                    services: snapshot.services,
+                    designers: snapshot.designers.map((d) => ({id: d.id, name: d.name, color: d.color ?? null})),
+                    customers: snapshot.customers,
+                    reservations: snapshot.reservations,
+                    confirm: true,
+                }),
+            });
+
+            if (!res.ok) throw new Error('migration_failed');
+
+            const data = await res.json() as {ok: boolean; newDesignerLegacyIds: number[]};
+
+            // 디자이너 목록 로드 → 이름 중복 쌍 감지
+            const designersRes = await fetch('/api/designers');
+            if (!designersRes.ok) throw new Error('designers_failed');
+            const designersData = await designersRes.json() as {designers: Designer[]};
+
+            const newIdSet = new Set(data.newDesignerLegacyIds);
+            const newDesigners = designersData.designers.filter((d) => newIdSet.has(d.id));
+            const existingDesigners = designersData.designers.filter((d) => !newIdSet.has(d.id));
+
+            const pairs: MergePair[] = [];
+            for (const nd of newDesigners) {
+                const match = existingDesigners.find((ed) => ed.name === nd.name);
+                if (match) pairs.push({newDesigner: nd, existingDesigner: match});
+            }
+
+            if (pairs.length > 0) {
+                const initialDecisions = new Map<number, 'merge' | 'keep'>(
+                    pairs.map((p) => [p.newDesigner.id, 'merge']),
+                );
+                setMergePairs(pairs);
+                setDecisions(initialDecisions);
+                setPhase('designer-merge');
+            } else {
+                clearLocalAndReload(snapshot);
+                onFinish();
+            }
+        } catch {
+            setErrorMsg('병합에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            setPhase('error');
+        }
+    }, [snapshot, onFinish]);
+
+    const handleDesignerMergeComplete = useCallback(async () => {
+        setProcessing(true);
+        try {
+            for (const pair of mergePairs) {
+                if (decisions.get(pair.newDesigner.id) !== 'merge') continue;
+                await fetch('/api/designers/merge', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        sourceId: pair.newDesigner.id,
+                        targetId: pair.existingDesigner.id,
+                    }),
+                });
+            }
+            clearLocalAndReload(snapshot);
+            onFinish();
+        } catch {
+            setProcessing(false);
+            setErrorMsg('디자이너 병합에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            setPhase('error');
+        }
+    }, [mergePairs, decisions, snapshot, onFinish]);
+
+    const toggleDecision = useCallback((designerId: number) => {
+        setDecisions((prev) => {
+            const next = new Map(prev);
+            next.set(designerId, prev.get(designerId) === 'merge' ? 'keep' : 'merge');
+            return next;
+        });
+    }, []);
+
+    if (phase === 'merging') {
+        return (
+            <StyledConfirmOverlay>
+                <StyledConfirmModal>
+                    <StyledSpinnerWrap>
+                        <StyledSpinner />
+                        <p>데이터를 병합하는 중...</p>
+                    </StyledSpinnerWrap>
+                </StyledConfirmModal>
+            </StyledConfirmOverlay>
+        );
+    }
+
+    if (phase === 'error') {
+        return (
+            <StyledConfirmOverlay>
+                <StyledConfirmModal>
+                    <StyledHeader><h3>오류</h3></StyledHeader>
+                    <StyledBody>
+                        <StyledErrorText>{errorMsg}</StyledErrorText>
+                    </StyledBody>
+                    <StyledFooter>
+                        <StyledActionButton type="button" onClick={handleDiscard}>
+                            게스트 데이터 삭제
+                        </StyledActionButton>
+                        <StyledActionButton
+                            type="button"
+                            $primary
+                            onClick={() => setPhase('confirm')}
+                        >
+                            다시 시도
+                        </StyledActionButton>
+                    </StyledFooter>
+                </StyledConfirmModal>
+            </StyledConfirmOverlay>
+        );
+    }
+
+    if (phase === 'designer-merge') {
+        return (
+            <StyledConfirmOverlay>
+                <StyledWiderModal>
+                    <StyledHeader>
+                        <h3>디자이너 병합</h3>
+                    </StyledHeader>
+                    <StyledBody>
+                        <StyledDesc>
+                            게스트 데이터에 기존 디자이너와 이름이 같은 디자이너가 있습니다.
+                            같은 디자이너라면 <strong>병합</strong>을 선택해 예약을 합쳐주세요.
+                        </StyledDesc>
+                        <StyledPairList>
+                            {mergePairs.map((pair) => {
+                                const decision = decisions.get(pair.newDesigner.id) ?? 'merge';
+                                return (
+                                    <StyledPairRow key={pair.newDesigner.id}>
+                                        <StyledPairNames>
+                                            <strong>{pair.existingDesigner.name}</strong>
+                                            <StyledPairArrow>+</StyledPairArrow>
+                                            <span>{pair.newDesigner.name} (게스트)</span>
+                                        </StyledPairNames>
+                                        <StyledToggleGroup>
+                                            <StyledToggleBtn
+                                                type="button"
+                                                $active={decision === 'merge'}
+                                                onClick={() => toggleDecision(pair.newDesigner.id)}
+                                            >
+                                                병합
+                                            </StyledToggleBtn>
+                                            <StyledToggleBtn
+                                                type="button"
+                                                $active={decision === 'keep'}
+                                                onClick={() => toggleDecision(pair.newDesigner.id)}
+                                            >
+                                                따로 유지
+                                            </StyledToggleBtn>
+                                        </StyledToggleGroup>
+                                    </StyledPairRow>
+                                );
+                            })}
+                        </StyledPairList>
+                    </StyledBody>
+                    <StyledFooter>
+                        <StyledActionButton
+                            type="button"
+                            $primary
+                            disabled={processing}
+                            onClick={handleDesignerMergeComplete}
+                        >
+                            {processing ? '처리 중...' : '완료'}
+                        </StyledActionButton>
+                    </StyledFooter>
+                </StyledWiderModal>
+            </StyledConfirmOverlay>
+        );
+    }
+
+    // phase === 'confirm'
+    const {customers, reservations, designers} = snapshot;
+    return (
+        <StyledConfirmOverlay>
+            <StyledConfirmModal>
+                <StyledHeader>
+                    <h3>로컬 데이터 병합</h3>
+                </StyledHeader>
+                <StyledBody>
+                    <StyledDesc>
+                        <strong>{storeName}</strong> 매장에 이미 데이터가 있습니다.
+                        게스트 모드에서 만든 데이터를 어떻게 하시겠습니까?
+                    </StyledDesc>
+                    <StyledStats>
+                        {designers.length > 0 && <li>디자이너 {designers.length}명</li>}
+                        {customers.length > 0 && <li>고객 {customers.length}명</li>}
+                        {reservations.length > 0 && <li>예약 {reservations.length}건</li>}
+                    </StyledStats>
+                </StyledBody>
+                <StyledFooter>
+                    <StyledActionButton type="button" $dangerOutline onClick={handleDiscard}>
+                        삭제
+                    </StyledActionButton>
+                    <StyledActionButton type="button" $primary onClick={handleMerge}>
+                        병합
+                    </StyledActionButton>
+                </StyledFooter>
+            </StyledConfirmModal>
+        </StyledConfirmOverlay>
+    );
+}
+
+const spin = keyframes`
+    to { transform: rotate(360deg); }
+`;
+
+const StyledSpinnerWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 40px 24px;
+
+    p {
+        margin: 0;
+        font-size: 13px;
+        color: var(--dark-gray-color2);
+    }
+`;
+
+const StyledSpinner = styled.div`
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--light-gray-color);
+    border-top-color: var(--brand-color);
+    border-radius: 50%;
+    animation: ${spin} 0.6s linear infinite;
+`;
+
+const StyledBody = styled.div`
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+`;
+
+const StyledDesc = styled.p`
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--dark-gray-color);
+`;
+
+const StyledErrorText = styled.p`
+    margin: 0;
+    font-size: 13px;
+    color: var(--danger-color);
+    line-height: 1.5;
+`;
+
+const StyledStats = styled.ul`
+    margin: 0;
+    padding: 12px 16px;
+    background: var(--black-color-10);
+    border-radius: var(--radius-md);
+    list-style: disc;
+    list-style-position: inside;
+
+    li {
+        font-size: 13px;
+        color: var(--dark-gray-color);
+        line-height: 1.8;
+    }
+`;
+
+const StyledWiderModal = styled(StyledConfirmModal)`
+    width: min(480px, 92vw);
+`;
+
+const StyledPairList = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
+
+const StyledPairRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--black-color-10);
+    border-radius: var(--radius-md);
+
+    @media (max-width: 480px) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+`;
+
+const StyledPairNames = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--dark-gray-color);
+    min-width: 0;
+    flex: 1;
+
+    strong {
+        font-weight: 600;
+        color: var(--black-color);
+    }
+`;
+
+const StyledPairArrow = styled.span`
+    flex-shrink: 0;
+    font-size: 14px;
+    color: var(--brand-color);
+    font-weight: 600;
+`;
+
+const StyledToggleGroup = styled.div`
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+`;
+
+const StyledToggleBtn = styled.button<{$active: boolean}>`
+    height: 28px;
+    padding: 0 10px;
+    border-radius: var(--radius-md);
+    font-size: 12px;
+    font-weight: ${(p) => (p.$active ? 600 : 400)};
+    border: 1px solid ${(p) => (p.$active ? 'var(--brand-color)' : 'var(--light-gray-color)')};
+    background: ${(p) => (p.$active ? 'var(--brand-color)' : 'var(--white-color)')};
+    color: ${(p) => (p.$active ? 'var(--white-color)' : 'var(--dark-gray-color)')};
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+`;

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -18,10 +18,11 @@ import type {Designer} from '../utils/designers';
 import type {StoreSettings} from '../utils/storeSettings';
 import {groupByDate} from '../utils/reservations';
 import {toCustomerMap} from '../utils/customers';
-import {loadLocalDbSnapshot, saveLocalDbSnapshot, setAuthenticated, shouldUseLocalDb} from '../lib/local-db';
+import {createDefaultLocalDbSnapshot, loadLocalDbSnapshot, saveLocalDbSnapshot, setAuthenticated, shouldUseLocalDb} from '../lib/local-db';
 
 import LayoutComponent from '../components/layout/LayoutComponent';
 import {ToastContainer} from '../components/ui/ToastContainer';
+import {GuestMigrationLayer} from '../components/layout/GuestMigrationLayer';
 
 type AppContentProps = Pick<AppProps, 'Component' | 'pageProps'>;
 
@@ -41,6 +42,10 @@ function AppContent({Component, pageProps}: AppContentProps) {
     const hasApiAccess = status === 'authenticated' && !!session?.user?.role && !!session.user?.storeId;
 
     const [sessionExpired, setSessionExpired] = useState(false);
+    const [migrationData, setMigrationData] = useState<{
+        snapshot: ReturnType<typeof loadLocalDbSnapshot>;
+        storeName: string;
+    } | null>(null);
     const [servicesReady, setServicesReady] = useState(false);
     const [designersReady, setDesignersReady] = useState(false);
     const [reservationsReady, setReservationsReady] = useState(false);
@@ -75,34 +80,48 @@ function AppContent({Component, pageProps}: AppContentProps) {
         setAuthenticated(hasApiAccess);
     }, [hasApiAccess]);
 
-    // 게스트 → SNS 연동 시 로컬 온보딩 데이터를 서버로 마이그레이션
+    // 게스트 → SNS 연동 시 로컬 데이터를 서버로 전체 마이그레이션
     const localSyncDone = useRef(false);
     useEffect(() => {
         if (!hasApiAccess || localSyncDone.current) return;
-        // 온보딩(데이터 마이그레이션)은 매장 오너만 가능 → 비-owner는 403 방지 위해 스킵
         if (session?.user?.role !== 'owner') return;
 
         const snapshot = loadLocalDbSnapshot();
         if (!snapshot.onboarded) return;
-        if (snapshot.services.length === 0 && snapshot.designers.length === 0) return;
+        const hasLocalData =
+            snapshot.services.length > 0 ||
+            snapshot.designers.length > 0 ||
+            snapshot.customers.length > 0 ||
+            snapshot.reservations.length > 0;
+        if (!hasLocalData) return;
 
         localSyncDone.current = true;
 
-        fetch('/api/onboarding', {
+        fetch('/api/migrate-local', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
                 shopName: snapshot.storeName ?? '',
                 shopType: snapshot.shopType ?? null,
                 services: snapshot.services,
-                designers: snapshot.designers.map((d) => ({name: d.name, color: d.color})),
+                designers: snapshot.designers.map((d) => ({id: d.id, name: d.name, color: d.color ?? null})),
+                customers: snapshot.customers,
+                reservations: snapshot.reservations,
             }),
         })
-            .then((res) => {
-                // 성공(ok) 또는 이미 데이터가 있는 매장(409 ALREADY_SETUP) → 마이그레이션 완료 처리하여 재시도 방지
-                if (res.ok || res.status === 409) {
-                    snapshot.onboarded = false;
-                    saveLocalDbSnapshot(snapshot);
+            .then(async (res) => {
+                if (res.ok) {
+                    // 빈 매장: 전체 생성 완료 → 로컬 정리 후 리로드
+                    const clean = createDefaultLocalDbSnapshot();
+                    clean.onboarded = false;
+                    saveLocalDbSnapshot(clean);
+                    window.location.reload();
+                } else if (res.status === 409) {
+                    // 기존 데이터 있는 매장 → 병합/삭제 레이어 표시
+                    const data = await res.json() as {storeName?: string};
+                    setMigrationData({snapshot, storeName: data.storeName ?? ''});
+                } else {
+                    localSyncDone.current = false;
                 }
             })
             .catch(() => {
@@ -291,6 +310,13 @@ function AppContent({Component, pageProps}: AppContentProps) {
                 </StyledBootOverlay>
             )}
             <ToastContainer />
+            {migrationData && (
+                <GuestMigrationLayer
+                    snapshot={migrationData.snapshot}
+                    storeName={migrationData.storeName}
+                    onFinish={() => setMigrationData(null)}
+                />
+            )}
             {sessionExpired && (
                 <StyledSessionExpiredToast>
                     <span>로그인 세션이 만료되었습니다.</span>

--- a/client/pages/api/designers/merge.ts
+++ b/client/pages/api/designers/merge.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../../server/api/designers-merge';

--- a/client/pages/api/migrate-local.ts
+++ b/client/pages/api/migrate-local.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../server/api/migrate-local';

--- a/server/api/designers-merge.ts
+++ b/server/api/designers-merge.ts
@@ -1,0 +1,54 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {prisma} from '../db/prisma';
+import {getApiSession, requireRole} from '../auth/api-session';
+import {dbDesignerToFrontend} from '../db/mappers';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).end();
+    }
+
+    const session = await getApiSession(req, res);
+    if (!requireRole(session, 'owner', res)) return;
+
+    const {sourceId, targetId} = req.body as {sourceId: number; targetId: number};
+
+    if (!sourceId || !targetId || sourceId === targetId) {
+        return res.status(400).json({error: '잘못된 요청입니다.'});
+    }
+
+    const storeId = session!.storeId;
+
+    const [source, target] = await Promise.all([
+        prisma.designer.findUnique({
+            where: {storeId_legacyId: {storeId, legacyId: sourceId}},
+            select: {id: true},
+        }),
+        prisma.designer.findUnique({
+            where: {storeId_legacyId: {storeId, legacyId: targetId}},
+            select: {id: true},
+        }),
+    ]);
+
+    if (!source || !target) {
+        return res.status(404).json({error: '디자이너를 찾을 수 없습니다.'});
+    }
+
+    await prisma.$transaction(async (tx) => {
+        await tx.reservation.updateMany({
+            where: {storeId, designerId: source.id},
+            data: {designerId: target.id},
+        });
+        await tx.designer.delete({where: {id: source.id}});
+    });
+
+    const dbDesigners = await prisma.designer.findMany({
+        where: {storeId},
+        include: {schedules: true},
+        orderBy: {legacyId: 'asc'},
+    });
+
+    return res.json({ok: true, designers: dbDesigners.map(dbDesignerToFrontend)});
+}

--- a/server/api/migrate-local.ts
+++ b/server/api/migrate-local.ts
@@ -1,0 +1,239 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {prisma} from '../db/prisma';
+import {getApiSession} from '../auth/api-session';
+import {frontendReservationStatusToDb, frontendPaymentMethodToDb, frontendChannelToDb} from '../db/mappers';
+import type {Designer} from '../../client/features/designers/model';
+import type {Customer} from '../../client/features/customers/model';
+import type {Reservation} from '../../client/features/reservations/model';
+import type {ServiceItem} from '../../client/features/services/model';
+
+const VALID_SHOP_TYPES = ['hair', 'nail', 'waxing', 'lash', 'skin'];
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).end();
+    }
+
+    const session = await getApiSession(req, res);
+    if (!session?.storeId) return res.status(401).json({error: '인증 필요'});
+    if (session.role !== 'owner') return res.status(403).json({error: '권한 없음'});
+
+    const {shopName, shopType, services, designers, customers, reservations, confirm = false} = req.body ?? {};
+
+    const storeId = session.storeId;
+
+    const [designerCount, serviceCount] = await Promise.all([
+        prisma.designer.count({where: {storeId}}),
+        prisma.service.count({where: {storeId}}),
+    ]);
+    const hasExistingData = designerCount > 0 || serviceCount > 0;
+
+    if (hasExistingData && !confirm) {
+        const store = await prisma.store.findUnique({where: {id: storeId}, select: {name: true}});
+        return res.status(409).json({
+            error: '이미 설정된 매장입니다.',
+            code: 'ALREADY_SETUP',
+            storeName: store?.name ?? '',
+        });
+    }
+
+    const name = typeof shopName === 'string' ? shopName.trim() : '';
+    const type = typeof shopType === 'string' && VALID_SHOP_TYPES.includes(shopType) ? shopType : null;
+    const servicesList: ServiceItem[] = Array.isArray(services) ? services : [];
+    const designersList: Designer[] = Array.isArray(designers) && designers.length > 0
+        ? designers
+        : [{id: 1, name: '원장', color: undefined, schedule: []}];
+    const customersList: Customer[] = Array.isArray(customers) ? customers : [];
+    const reservationsList: Reservation[] = Array.isArray(reservations) ? reservations : [];
+
+    const newDesignerLegacyIds: number[] = [];
+
+    try {
+        await prisma.$transaction(async (tx) => {
+            if (!hasExistingData) {
+                // 빈 매장: 처음부터 생성
+                if (name) {
+                    await tx.store.update({
+                        where: {id: storeId},
+                        data: {name, shopType: type, onboarded: true},
+                    });
+                }
+
+                if (servicesList.length > 0) {
+                    await tx.service.createMany({
+                        data: servicesList.map((s) => ({
+                            storeId,
+                            name: String(s.name ?? '').trim(),
+                            category: String(s.category ?? '').trim(),
+                            duration: Number(s.durationMinutes) || 0,
+                            price: Number(s.price) || 0,
+                        })).filter((s) => s.name && s.category),
+                        skipDuplicates: true,
+                    });
+                }
+
+                // 디자이너 생성 (legacyId = 순번)
+                const designerCuidMap = new Map<number, string>();
+                await tx.designer.deleteMany({where: {storeId}});
+                for (let i = 0; i < designersList.length; i++) {
+                    const d = designersList[i];
+                    const legacyId = i + 1;
+                    const created = await tx.designer.create({
+                        data: {
+                            storeId,
+                            legacyId,
+                            name: String(d.name ?? '').trim() || '원장',
+                            status: 'active',
+                            color: d.color ?? null,
+                        },
+                    });
+                    designerCuidMap.set(d.id, created.id);
+                }
+
+                // 고객 생성
+                const customerCuidMap = new Map<number, string>();
+                for (let i = 0; i < customersList.length; i++) {
+                    const c = customersList[i];
+                    const created = await tx.customer.create({
+                        data: {
+                            storeId,
+                            legacyId: i + 1,
+                            name: c.name,
+                            tel: c.tel ?? '',
+                            points: c.points ?? 0,
+                            firstVisitDate: c.firstVisitDate ? new Date(`${c.firstVisitDate}T00:00:00`) : null,
+                            allergyNote: c.allergyNote ?? null,
+                            claimNote: c.claimNote ?? null,
+                            preferenceNote: c.preferenceNote ?? null,
+                        },
+                    });
+                    customerCuidMap.set(c.id, created.id);
+                }
+
+                // 예약 생성
+                for (let i = 0; i < reservationsList.length; i++) {
+                    const r = reservationsList[i];
+                    const customerCuid = customerCuidMap.get(r.customerId);
+                    if (!customerCuid) continue;
+
+                    const designerCuid = r.designerId != null ? (designerCuidMap.get(r.designerId) ?? null) : null;
+                    const paymentEntries = (r.paymentEntries ?? []).map((e) => ({
+                        method: frontendPaymentMethodToDb(e.method),
+                        amount: e.amount,
+                    }));
+
+                    await tx.reservation.create({
+                        data: {
+                            storeId,
+                            legacyId: i + 1,
+                            customerId: customerCuid,
+                            designerId: designerCuid,
+                            date: new Date(`${r.date}T00:00:00`),
+                            startTime: r.startTime,
+                            endTime: r.endTime,
+                            serviceSummary: r.service,
+                            status: frontendReservationStatusToDb(r.status),
+                            price: r.price ?? 0,
+                            memo: r.memo ?? null,
+                            paymentCompleted: r.paymentCompleted ?? false,
+                            pointEarned: r.pointEarned ?? 0,
+                            ...(r.channel && {channel: frontendChannelToDb(r.channel)}),
+                            ...(paymentEntries.length > 0 && {
+                                paymentEntries: {createMany: {data: paymentEntries}},
+                            }),
+                        },
+                    });
+                }
+            } else {
+                // 기존 매장 (confirm=true): legacyId remap 후 append
+                const [maxDesignerRow, maxCustomerRow, maxReservationRow] = await Promise.all([
+                    tx.designer.findFirst({where: {storeId}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}}),
+                    tx.customer.findFirst({where: {storeId}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}}),
+                    tx.reservation.findFirst({where: {storeId}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}}),
+                ]);
+
+                let nextDesignerLegacyId = (maxDesignerRow?.legacyId ?? 0) + 1;
+                let nextCustomerLegacyId = (maxCustomerRow?.legacyId ?? 0) + 1;
+                let nextReservationLegacyId = (maxReservationRow?.legacyId ?? 0) + 1;
+
+                const designerCuidMap = new Map<number, string>();
+                for (const d of designersList) {
+                    const legacyId = nextDesignerLegacyId++;
+                    const created = await tx.designer.create({
+                        data: {
+                            storeId,
+                            legacyId,
+                            name: String(d.name ?? '').trim() || '원장',
+                            status: 'active',
+                            color: d.color ?? null,
+                        },
+                    });
+                    designerCuidMap.set(d.id, created.id);
+                    newDesignerLegacyIds.push(legacyId);
+                }
+
+                const customerCuidMap = new Map<number, string>();
+                for (const c of customersList) {
+                    const created = await tx.customer.create({
+                        data: {
+                            storeId,
+                            legacyId: nextCustomerLegacyId++,
+                            name: c.name,
+                            tel: c.tel ?? '',
+                            points: c.points ?? 0,
+                            firstVisitDate: c.firstVisitDate ? new Date(`${c.firstVisitDate}T00:00:00`) : null,
+                            allergyNote: c.allergyNote ?? null,
+                            claimNote: c.claimNote ?? null,
+                            preferenceNote: c.preferenceNote ?? null,
+                        },
+                    });
+                    customerCuidMap.set(c.id, created.id);
+                }
+
+                for (const r of reservationsList) {
+                    const customerCuid = customerCuidMap.get(r.customerId);
+                    if (!customerCuid) continue;
+
+                    const designerCuid = r.designerId != null ? (designerCuidMap.get(r.designerId) ?? null) : null;
+                    const paymentEntries = (r.paymentEntries ?? []).map((e) => ({
+                        method: frontendPaymentMethodToDb(e.method),
+                        amount: e.amount,
+                    }));
+
+                    await tx.reservation.create({
+                        data: {
+                            storeId,
+                            legacyId: nextReservationLegacyId++,
+                            customerId: customerCuid,
+                            designerId: designerCuid,
+                            date: new Date(`${r.date}T00:00:00`),
+                            startTime: r.startTime,
+                            endTime: r.endTime,
+                            serviceSummary: r.service,
+                            status: frontendReservationStatusToDb(r.status),
+                            price: r.price ?? 0,
+                            memo: r.memo ?? null,
+                            paymentCompleted: r.paymentCompleted ?? false,
+                            pointEarned: r.pointEarned ?? 0,
+                            ...(r.channel && {channel: frontendChannelToDb(r.channel)}),
+                            ...(paymentEntries.length > 0 && {
+                                paymentEntries: {createMany: {data: paymentEntries}},
+                            }),
+                        },
+                    });
+                }
+            }
+        });
+
+        return res.json({
+            ok: true,
+            status: hasExistingData ? 'merged' : 'created',
+            newDesignerLegacyIds,
+        });
+    } catch (error) {
+        console.error('[migrate-local] 마이그레이션 실패:', error);
+        return res.status(500).json({error: '마이그레이션에 실패했습니다.'});
+    }
+}


### PR DESCRIPTION
## 구현 내용

### 서버
- **`POST /api/migrate-local`** — 서비스·디자이너·고객·예약 전체 수신
  - 빈 매장: 트랜잭션으로 전체 생성 (기존 `/api/onboarding` 대체)
  - 기존 매장(`confirm=false`): `409 ALREADY_SETUP` + `storeName` 반환
  - 기존 매장(`confirm=true`): 기존 최대 legacyId 이후로 remap 후 append, `newDesignerLegacyIds` 반환
- **`POST /api/designers/merge`** — 중복 디자이너 병합
  - source 디자이너의 모든 예약을 target으로 재배정 후 source 삭제

### 클라이언트
- **`GuestMigrationLayer`** — 409 응답 시 "병합/삭제" 오버레이
  - 게스트 데이터 통계(고객 N명, 예약 M건 등) 표시
  - 병합 선택 시: `confirm=true`로 재호출 → 동명 디자이너 있으면 병합 선택 UI
  - 삭제 선택 시: 로컬 데이터 초기화 + 리로드
- **`_app.tsx`** — 마이그레이션 effect를 `/api/migrate-local`로 교체
  - 빈 매장(200): 로컬 초기화 + `window.location.reload()`
  - 기존 매장(409): `GuestMigrationLayer` 표시

## 수정된 버그
- 기존 코드는 서비스·디자이너만 전송, 고객·예약 누락
- `onboarded = false`만 세팅해 로컬 데이터를 정리하지 않던 문제 → 마이그레이션 완료 시 전체 초기화

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_