### PR TITLE
feat(members): 멤버 역할 변경 및 제거 기능 추가

### DIFF
--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -24,6 +24,7 @@ type Member = {
     id: string;
     role: string;
     user: {
+        id: string;
         nickname: string;
         email: string | null;
     };
@@ -80,6 +81,9 @@ export const MemberSection = () => {
     const [creating, setCreating] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const [kickTarget, setKickTarget] = useState<Member | null>(null);
+    const [kicking, setKicking] = useState(false);
+    const [roleSaving, setRoleSaving] = useState<string | null>(null);
 
     const loadInvites = useCallback(async () => {
         try {
@@ -139,10 +143,57 @@ export const MemberSection = () => {
         } catch { /* ignore */ }
     };
 
+    const kickMember = async (member: Member) => {
+        setKicking(true);
+        try {
+            const res = await fetch('/api/members', {
+                method: 'DELETE',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({membershipId: member.id}),
+            });
+            if (res.ok) {
+                await loadMembers();
+                toast(`${member.user.nickname}님을 멤버에서 제거했습니다.`, 'info');
+            } else {
+                const data = await res.json().catch(() => null);
+                toast(data?.error ?? '멤버 제거에 실패했습니다.', 'error');
+            }
+        } catch {
+            toast('멤버 제거에 실패했습니다.', 'error');
+        } finally {
+            setKicking(false);
+            setKickTarget(null);
+        }
+    };
+
+    const changeRole = async (membershipId: string, role: string) => {
+        setRoleSaving(membershipId);
+        try {
+            const res = await fetch('/api/members', {
+                method: 'PATCH',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({membershipId, role}),
+            });
+            if (res.ok) {
+                await loadMembers();
+                toast('역할이 변경되었습니다.');
+            } else {
+                const data = await res.json().catch(() => null);
+                toast(data?.error ?? '역할 변경에 실패했습니다.', 'error');
+            }
+        } catch {
+            toast('역할 변경에 실패했습니다.', 'error');
+        } finally {
+            setRoleSaving(null);
+        }
+    };
+
     const activeInvites = invites.filter((inv) => !inv.usedAt && new Date(inv.expiresAt) > new Date());
     const usedOrExpiredInvites = invites.filter((inv) => inv.usedAt || new Date(inv.expiresAt) <= new Date());
     const isGuest = !session?.user;
-    const isManager = session?.user?.role === 'owner' || session?.user?.role === 'manager';
+    const isOwner = session?.user?.role === 'owner';
+    const isManager = isOwner || session?.user?.role === 'manager';
+    const myUserId = session?.user?.id;
 
     if (isGuest) {
         return (
@@ -222,15 +273,49 @@ export const MemberSection = () => {
                 <StyledSettingsCardTitle>현재 멤버</StyledSettingsCardTitle>
                 {members.length > 0 ? (
                     <StyledList>
-                        {members.map((m) => (
-                            <StyledMemberItem key={m.id}>
-                                <StyledMemberName>{m.user.nickname}</StyledMemberName>
-                                <StyledMemberMeta>
-                                    {m.user.email && <StyledMemberEmail>{m.user.email}</StyledMemberEmail>}
-                                    <StyledBadge $tone={ROLE_TONE[m.role] ?? 'neutral'}>{ROLE_LABELS[m.role] ?? m.role}</StyledBadge>
-                                </StyledMemberMeta>
-                            </StyledMemberItem>
-                        ))}
+                        {members.map((m) => {
+                            const isSelf = m.user.id === myUserId;
+                            const isTargetOwner = m.role === 'owner';
+                            const canManage = isOwner && !isSelf && !isTargetOwner;
+                            const saving = roleSaving === m.id;
+                            return (
+                                <StyledMemberItem key={m.id}>
+                                    <StyledMemberInfo>
+                                        <StyledMemberName>
+                                            {m.user.nickname}
+                                            {isSelf && <StyledSelfTag>나</StyledSelfTag>}
+                                        </StyledMemberName>
+                                        {m.user.email && <StyledMemberEmail>{m.user.email}</StyledMemberEmail>}
+                                    </StyledMemberInfo>
+                                    <StyledMemberActions>
+                                        {canManage ? (
+                                            <StyledRoleSelect
+                                                value={m.role}
+                                                disabled={saving}
+                                                onChange={(e) => changeRole(m.id, e.target.value)}
+                                                aria-label={`${m.user.nickname} 역할 변경`}
+                                            >
+                                                <option value="manager">멤버</option>
+                                                <option value="staff">스태프</option>
+                                            </StyledRoleSelect>
+                                        ) : (
+                                            <StyledBadge $tone={ROLE_TONE[m.role] ?? 'neutral'}>
+                                                {ROLE_LABELS[m.role] ?? m.role}
+                                            </StyledBadge>
+                                        )}
+                                        {canManage && (
+                                            <StyledKickButton
+                                                type="button"
+                                                disabled={saving}
+                                                onClick={() => setKickTarget(m)}
+                                            >
+                                                제거
+                                            </StyledKickButton>
+                                        )}
+                                    </StyledMemberActions>
+                                </StyledMemberItem>
+                            );
+                        })}
                     </StyledList>
                 ) : (
                     <StyledEmpty>{EMPTY_TEXT}</StyledEmpty>
@@ -267,6 +352,26 @@ export const MemberSection = () => {
                     <StyledFooter>
                         <StyledActionButton type="button" onClick={() => setDeleteTarget(null)}>닫기</StyledActionButton>
                         <StyledActionButton type="button" $danger onClick={() => deleteInvite(deleteTarget)}>취소하기</StyledActionButton>
+                    </StyledFooter>
+                </StyledConfirmModal>
+            </StyledConfirmOverlay>
+        )}
+
+        {kickTarget && (
+            <StyledConfirmOverlay onClick={() => !kicking && setKickTarget(null)}>
+                <StyledConfirmModal onClick={(e) => e.stopPropagation()}>
+                    <StyledHeader><h3>멤버 제거</h3></StyledHeader>
+                    <StyledConfirmText>
+                        <strong>{kickTarget.user.nickname}</strong>님을 매장에서 제거하면
+                        더 이상 이 매장에 접근할 수 없습니다. 계속하시겠습니까?
+                    </StyledConfirmText>
+                    <StyledFooter>
+                        <StyledActionButton type="button" disabled={kicking} onClick={() => setKickTarget(null)}>
+                            취소
+                        </StyledActionButton>
+                        <StyledActionButton type="button" $danger disabled={kicking} onClick={() => kickMember(kickTarget)}>
+                            {kicking ? '제거 중...' : '제거하기'}
+                        </StyledActionButton>
                     </StyledFooter>
                 </StyledConfirmModal>
             </StyledConfirmOverlay>
@@ -414,21 +519,85 @@ const StyledMemberItem = styled.div`
     }
 `;
 
+const StyledMemberInfo = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+`;
+
 const StyledMemberName = styled.span`
+    display: flex;
+    align-items: center;
+    gap: 6px;
     font-size: 14px;
     font-weight: 600;
     color: var(--black-color);
 `;
 
-const StyledMemberMeta = styled.div`
+const StyledSelfTag = styled.span`
+    font-size: 11px;
+    font-weight: 500;
+    padding: 1px 6px;
+    border-radius: var(--chip-radius);
+    background: var(--black-color-10);
+    color: var(--dark-gray-color2);
+`;
+
+const StyledMemberActions = styled.div`
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-shrink: 0;
+
+    @media (max-width: 640px) {
+        width: 100%;
+        justify-content: flex-end;
+    }
 `;
 
 const StyledMemberEmail = styled.span`
     font-size: 12px;
     color: var(--dark-gray-color2);
+`;
+
+const StyledRoleSelect = styled.select`
+    height: 26px;
+    padding: 0 8px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--white-color);
+    color: var(--dark-gray-color);
+    font-size: 12px;
+    cursor: pointer;
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+`;
+
+const StyledKickButton = styled.button`
+    height: 26px;
+    padding: 0 10px;
+    border: 1px solid var(--danger-border);
+    border-radius: var(--radius-md);
+    background: var(--danger-bg);
+    color: var(--danger-color);
+    font-size: 11px;
+    font-weight: 600;
+    transition: opacity 0.15s;
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+        &:not(:disabled):hover {
+            opacity: 0.8;
+        }
+    }
 `;
 
 

--- a/client/pages/api/members.ts
+++ b/client/pages/api/members.ts
@@ -2,34 +2,84 @@ import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {auth} from '../../auth';
 import {prisma} from '../../lib/prisma';
+import {hasRequiredRole} from '../../../server/auth/roles';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-    if (req.method !== 'GET') {
-        res.setHeader('Allow', 'GET');
-        res.status(405).json({error: 'Method Not Allowed'});
-        return;
-    }
-
     const session = await auth(req, res);
     if (!session?.user?.id || !session.user.storeId) {
         res.status(401).json({error: 'Unauthorized'});
         return;
     }
 
-    const members = await prisma.membership.findMany({
-        where: {storeId: session.user.storeId},
-        orderBy: {createdAt: 'asc'},
-        select: {
-            id: true,
-            role: true,
-            user: {
-                select: {
-                    nickname: true,
-                    email: true,
-                },
-            },
-        },
-    });
+    const storeId = session.user.storeId;
+    const userId = session.user.id;
+    const userRole = session.user.role as 'owner' | 'manager' | 'staff' | undefined;
 
-    res.status(200).json(members);
+    if (req.method === 'GET') {
+        const members = await prisma.membership.findMany({
+            where: {storeId},
+            orderBy: {createdAt: 'asc'},
+            select: {
+                id: true,
+                role: true,
+                user: {select: {id: true, nickname: true, email: true}},
+            },
+        });
+        return res.status(200).json(members);
+    }
+
+    // 역할 변경: owner만 가능
+    if (req.method === 'PATCH') {
+        if (!hasRequiredRole(userRole, 'owner')) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const {membershipId, role} = req.body ?? {};
+        if (!membershipId || (role !== 'manager' && role !== 'staff')) {
+            return res.status(400).json({error: '잘못된 요청입니다.'});
+        }
+
+        const membership = await prisma.membership.findUnique({where: {id: membershipId}});
+        if (!membership || membership.storeId !== storeId) {
+            return res.status(404).json({error: '멤버를 찾을 수 없습니다.'});
+        }
+        if (membership.role === 'owner') {
+            return res.status(400).json({error: '오너 역할은 변경할 수 없습니다.'});
+        }
+        if (membership.userId === userId) {
+            return res.status(400).json({error: '자신의 역할은 변경할 수 없습니다.'});
+        }
+
+        await prisma.membership.update({where: {id: membershipId}, data: {role}});
+        return res.status(200).json({ok: true});
+    }
+
+    // 멤버 제거: owner만 가능
+    if (req.method === 'DELETE') {
+        if (!hasRequiredRole(userRole, 'owner')) {
+            return res.status(403).json({error: 'Forbidden'});
+        }
+
+        const {membershipId} = req.body ?? {};
+        if (!membershipId) {
+            return res.status(400).json({error: '잘못된 요청입니다.'});
+        }
+
+        const membership = await prisma.membership.findUnique({where: {id: membershipId}});
+        if (!membership || membership.storeId !== storeId) {
+            return res.status(404).json({error: '멤버를 찾을 수 없습니다.'});
+        }
+        if (membership.role === 'owner') {
+            return res.status(400).json({error: '오너는 제거할 수 없습니다.'});
+        }
+        if (membership.userId === userId) {
+            return res.status(400).json({error: '자기 자신을 제거할 수 없습니다.'});
+        }
+
+        await prisma.membership.delete({where: {id: membershipId}});
+        return res.status(200).json({ok: true});
+    }
+
+    res.setHeader('Allow', ['GET', 'PATCH', 'DELETE']);
+    return res.status(405).json({error: 'Method Not Allowed'});
 }


### PR DESCRIPTION
## Summary

- `PATCH /api/members`: owner가 멤버 역할 변경 (manager ↔ staff)
- `DELETE /api/members`: owner가 멤버 제거 (Membership 삭제 → 매장 접근 차단)
- `MemberSection.tsx`: 역할 셀렉트 + 제거 버튼 UI, confirm 모달, '나' 태그 추가

## Test plan

- [ ] owner 로그인 → 설정 > 멤버 → 멤버 행에 역할 셀렉트 + 제거 버튼 표시 확인
- [ ] 역할 셀렉트 변경 → 즉시 반영 + 토스트 확인
- [ ] 제거 버튼 클릭 → confirm 모달 → 제거 완료 후 목록에서 사라짐 확인
- [ ] 자기 자신 행 / owner 행 → 배지만 표시, 제거 불가 확인
- [ ] manager 로그인 → 역할 셀렉트 / 제거 버튼 미표시 확인

https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnsPnbe2Kb9e26qyse477A)_