### PR TITLE
feat: 로그인 안정화(초대 링크·인앱 브라우저) + AdSense 적용 (v0.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+> 이 저장소에서 Claude가 항상 따라야 할 지시사항. 세션 시작 시 `index.md`·`plan.md`와 함께 읽는다.
+
+## Priority Order
+1. Core Principles
+2. Session Startup Rules
+3. Development Workflow
+4. Front-End Standards
+5. Documentation Maintenance
+
+## Core Principles
+- If unsure, say so instead of guessing.
+- Point out problems with my approach directly.
+- If something fails, investigate the root cause before retrying.
+
+## Session Startup Rules
+- At the start of a new session, read `index.md` and `plan.md` first.
+- Do not begin implementation until `index.md` and `plan.md` have been reviewed.
+- Use `index.md` as the source of truth for the project structure and current status.
+- Use `plan.md` as the source of truth for current tasks and future work.
+- If the documentation and implementation differ, report the discrepancy and request confirmation before proceeding.
+
+## Development Workflow
+- Before starting any task, create a `plan.md` file (or add a section to it).
+- Document requirements, implementation approach, affected files, and expected outcomes in `plan.md`.
+- Review and finalize the plan before making code changes.
+- Update `plan.md` if the implementation scope changes during development.
+- When merging, bump the version in `package.json`. Determine the appropriate semver bump (patch / minor / major) based on the changes in the PR.
+
+## Front-End Standards
+- Do not use tag selectors. Use IDs or class names only.
+- Follow web standards and accessibility (WCAG) guidelines.
+- Prefer semantic HTML elements.
+- Use native HTML features before implementing custom JavaScript solutions.
+- Use native radio buttons, checkboxes, select boxes, and buttons whenever possible.
+- Avoid unnecessary custom UI components that replace built-in browser functionality.
+
+## Documentation Maintenance
+- After completing a task, update `index.md` and `plan.md` to reflect the changes.
+
+## On Commit
+- Split commits into minimal units of work.
+- Write commit messages in Korean.
+- Use conventional prefixes: `feat:`, `fix:`, `refactor:`, `style:`, `chore:`, etc.
+- Always push after committing.
+
+## Recurring Tasks
+- Around 4 PM KST daily, if work is in progress, ask whether to organize and commit changes.
+  - 주의: 시간 기반 자동 트리거는 Claude 자체로는 보장되지 않음(일회성 컨테이너). 자동화하려면 `.claude/settings.json` 훅 또는 외부 스케줄러가 필요.

--- a/client/.env.example
+++ b/client/.env.example
@@ -23,7 +23,9 @@ AUTH_NAVER_SECRET="REPLACE_NAVER_SECRET"
 SEED_OWNER_EMAIL="owner@example.com"
 SEED_OWNER_NAME="Salon Owner"
 
-# Google AdSense (선택) — 둘 다 설정해야 광고가 로드됨. 미설정 시 광고 비활성(400 없음)
+# Google AdSense
+# 퍼블리셔 ID는 client/lib/ads.ts에 기본값(ca-pub-5655041057903258)이 있어 미설정이어도 동작.
+# 다른 계정으로 바꿀 때만 아래로 오버라이드. 개별 광고 유닛(<ins>)은 슬롯 ID가 있어야 렌더됨.
 NEXT_PUBLIC_ADSENSE_CLIENT=""
 NEXT_PUBLIC_ADSENSE_FOOTER_SLOT=""
 NEXT_PUBLIC_ADSENSE_AUTH_SLOT=""

--- a/client/components/ad/AdBanner.tsx
+++ b/client/components/ad/AdBanner.tsx
@@ -2,14 +2,13 @@ import {useEffect, useRef} from 'react';
 
 import styled from 'styled-components';
 
+import {ADSENSE_CLIENT} from '../../lib/ads';
+
 declare global {
     interface Window {
         adsbygoogle: Array<Record<string, unknown>>;
     }
 }
-
-// 실제 AdSense 퍼블리셔 ID가 설정된 경우에만 광고를 로드 (미설정 시 400 방지)
-const ADSENSE_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT;
 
 interface AdBannerProps {
     adSlot: string;

--- a/client/components/settings/MemberSection.tsx
+++ b/client/components/settings/MemberSection.tsx
@@ -74,7 +74,12 @@ function formatExpiry(expiresAt: string): string {
     return `${minutes}분 남음`;
 }
 
-function CopyButton({text}: {text: string}) {
+function buildInviteLink(code: string): string {
+    const origin = typeof window !== 'undefined' ? window.location.origin : '';
+    return `${origin}/login?invite=${code}`;
+}
+
+function CopyButton({text, label = '복사'}: {text: string; label?: string}) {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = async () => {
@@ -84,8 +89,8 @@ function CopyButton({text}: {text: string}) {
     };
 
     return (
-        <StyledCopyButton type="button" onClick={handleCopy} aria-label="코드 복사">
-            {copied ? '복사됨' : '복사'}
+        <StyledCopyButton type="button" onClick={handleCopy} aria-label={`${label} 복사`}>
+            {copied ? '복사됨' : label}
         </StyledCopyButton>
     );
 }
@@ -263,6 +268,9 @@ export const MemberSection = () => {
 
             <StyledSettingsCard>
                 <StyledSettingsCardTitle>사용 가능한 초대코드</StyledSettingsCardTitle>
+                <StyledSettingsHint>
+                    &lsquo;링크&rsquo;를 복사해 전달하면 받는 사람이 코드를 입력하지 않아도 자동으로 매장에 합류합니다.
+                </StyledSettingsHint>
                 {activeInvites.length > 0 ? (
                     <StyledList>
                         {activeInvites.map((inv) => (
@@ -273,7 +281,8 @@ export const MemberSection = () => {
                                 </StyledCodeBlock>
                                 <StyledInviteActions>
                                     <StyledExpiry>{formatExpiry(inv.expiresAt)}</StyledExpiry>
-                                    <CopyButton text={inv.code} />
+                                    <CopyButton text={inv.code} label="코드" />
+                                    <CopyButton text={buildInviteLink(inv.code)} label="링크" />
                                     <StyledDeleteButton type="button" onClick={() => setDeleteTarget(inv.id)}>
                                         취소
                                     </StyledDeleteButton>

--- a/client/lib/ads.ts
+++ b/client/lib/ads.ts
@@ -1,0 +1,4 @@
+// AdSense 퍼블리셔 ID 단일 소스.
+// NEXT_PUBLIC_* 는 빌드타임 인라인이라 배포 env 미설정 시 광고가 안 뜨므로 기본값을 둔다.
+// 퍼블리셔 ID는 페이지 소스에 노출되는 공개값이라 하드코딩 무방(env로 오버라이드 가능).
+export const ADSENSE_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT ?? 'ca-pub-5655041057903258';

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.1.11",
+    "version": "0.2.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -3,6 +3,7 @@ import Document, {Html, Head, Main, NextScript, DocumentContext} from 'next/docu
 import {ServerStyleSheet} from 'styled-components';
 
 import {SITE_DESCRIPTION, SITE_KEYWORDS, SITE_OG_DESCRIPTION, SITE_OG_IMAGE, SITE_TITLE, SITE_TWITTER_DESCRIPTION, SITE_URL} from '../lib/seo';
+import {ADSENSE_CLIENT} from '../lib/ads';
 
 class ReservationDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
@@ -64,9 +65,9 @@ class ReservationDocument extends Document {
                           href="/favicon/apple-icon-180x180.png" />
                     <link rel="manifest"
                           href="/favicon/manifest.json" />
-                    {process.env.NEXT_PUBLIC_ADSENSE_CLIENT && (
+                    {ADSENSE_CLIENT && (
                         <script async
-                                src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${process.env.NEXT_PUBLIC_ADSENSE_CLIENT}`}
+                                src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
                                 crossOrigin="anonymous" />
                     )}
                 </Head>

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 
+import Link from 'next/link';
 import {useRouter} from 'next/router';
 
 import {signIn, signOut, useSession} from 'next-auth/react';
@@ -120,7 +121,9 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
             )}
             <StyledCard>
                 <StyledTitle>
-                    <StyledBrandLogo src="/logo/logo-black.svg" alt="TAS" />
+                    <StyledBrandLink href="/" aria-label="홈으로 이동">
+                        <StyledBrandLogo src="/logo/logo-black.svg" alt="TAS" />
+                    </StyledBrandLink>
                 </StyledTitle>
                 <StyledSubtitle>SNS 계정으로 로그인</StyledSubtitle>
                 {displayError && ERROR_MESSAGES[displayError] && (
@@ -289,6 +292,11 @@ const StyledCard = styled.div`
 
 const StyledTitle = styled.h1`
     margin: 0 0 8px;
+`;
+
+const StyledBrandLink = styled(Link)`
+    display: inline-block;
+    line-height: 0;
 `;
 
 const StyledBrandLogo = styled.img`

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -51,12 +51,17 @@ const ERROR_MESSAGES: Record<string, string> = {
     'sync-error': '계정 동기화 중 오류가 발생했습니다. 다시 시도해 주세요.',
 };
 
+// http(로컬) 환경에서는 secure 쿠키가 저장되지 않으므로 https일 때만 secure 부여
+function secureFlag(): string {
+    return typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; secure' : '';
+}
+
 function setInviteCookie(code: string) {
-    document.cookie = `tas-invite-code=${encodeURIComponent(code)}; path=/; max-age=600; samesite=lax; secure`;
+    document.cookie = `tas-invite-code=${encodeURIComponent(code)}; path=/; max-age=600; samesite=lax${secureFlag()}`;
 }
 
 function clearInviteCookie() {
-    document.cookie = 'tas-invite-code=; path=/; max-age=0; samesite=lax; secure';
+    document.cookie = `tas-invite-code=; path=/; max-age=0; samesite=lax${secureFlag()}`;
 }
 
 export default function LoginPage({providerIds, isDatabaseConfigured, loginError}: LoginPageProps) {
@@ -70,6 +75,17 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
     const [showGuestLoad, setShowGuestLoad] = useState(false);
 
     const authError = typeof router.query.error === 'string' ? router.query.error : null;
+
+    // 초대 링크(/login?invite=CODE)로 진입 시 코드 자동 입력 + 쿠키 세팅
+    // → 로그인 직후 OAuth 콜백에서 초대가 적용되어 새 매장이 아닌 초대 매장으로 가입됨
+    useEffect(() => {
+        const q = router.query.invite;
+        const code = typeof q === 'string' ? q.trim().toUpperCase().slice(0, 6) : '';
+        if (code) {
+            setInviteCode(code);
+            setInviteCookie(code);
+        }
+    }, [router.query.invite]);
 
     useEffect(() => {
         if (!authError && hasAccess) {

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -64,6 +64,36 @@ function clearInviteCookie() {
     document.cookie = `tas-invite-code=; path=/; max-age=0; samesite=lax${secureFlag()}`;
 }
 
+// 카카오톡·인스타·네이버앱 등 인앱(WebView) 브라우저 감지.
+// Google OAuth는 인앱 브라우저에서 'disallowed_useragent'로 차단되므로 안내가 필요.
+function isInAppBrowser(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    return /KAKAOTALK|Instagram|NAVER\(|; ?wv\)|Line\/|FBAN|FBAV|FB_IAB|Daum|everytimeApp|Threads|Snapchat/i.test(ua);
+}
+
+// 현재 페이지를 외부 브라우저(가능하면 크롬)에서 열도록 유도.
+function openInExternalBrowser() {
+    if (typeof window === 'undefined') return;
+    const url = window.location.href;
+    const ua = navigator.userAgent || '';
+
+    // 카카오톡 인앱: 전용 스킴으로 외부 브라우저 열기
+    if (/KAKAOTALK/i.test(ua)) {
+        window.location.href = `kakaotalk://web/openExternal?url=${encodeURIComponent(url)}`;
+        return;
+    }
+    // 안드로이드: 크롬으로 강제 오픈(intent)
+    if (/Android/i.test(ua)) {
+        const noScheme = url.replace(/^https?:\/\//, '');
+        window.location.href = `intent://${noScheme}#Intent;scheme=https;package=com.android.chrome;end`;
+        return;
+    }
+    // iOS 등: 강제 불가 → 주소 복사 후 안내
+    navigator.clipboard?.writeText(url).catch(() => {});
+    alert('주소가 복사되었습니다.\nSafari 등 브라우저에 붙여넣어 접속해 주세요.');
+}
+
 export default function LoginPage({providerIds, isDatabaseConfigured, loginError}: LoginPageProps) {
     const {data: session, status} = useSession();
     const router = useRouter();
@@ -73,6 +103,12 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
     const monthEntryPath = getMonthEntryPath();
     const [inviteCode, setInviteCode] = useState('');
     const [showGuestLoad, setShowGuestLoad] = useState(false);
+    const [inApp, setInApp] = useState(false);
+
+    // 인앱 브라우저 감지(마운트 후 1회) — SSR 하이드레이션 불일치 방지를 위해 effect에서 처리
+    useEffect(() => {
+        setInApp(isInAppBrowser());
+    }, []);
 
     const authError = typeof router.query.error === 'string' ? router.query.error : null;
 
@@ -101,7 +137,11 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
         return null;
     }
 
-    const providers = ALL_PROVIDERS.filter((p) => providerIds.includes(p.id));
+    const filteredProviders = ALL_PROVIDERS.filter((p) => providerIds.includes(p.id));
+    // 인앱 브라우저에선 카카오 로그인이 가장 안정적이므로 맨 위로 노출
+    const providers = inApp
+        ? [...filteredProviders].sort((a, b) => Number(b.id === 'kakao') - Number(a.id === 'kakao'))
+        : filteredProviders;
     const canStartLogin = providers.length > 0;
     const displayError = authError ?? loginError ?? (hasLoginError ? 'no-account' : null);
 
@@ -142,6 +182,18 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
                     </StyledBrandLink>
                 </StyledTitle>
                 <StyledSubtitle>SNS 계정으로 로그인</StyledSubtitle>
+                {inApp && (
+                    <StyledInAppNotice>
+                        <StyledInAppTitle>📱 인앱 브라우저로 접속 중이에요</StyledInAppTitle>
+                        <StyledInAppText>
+                            구글 로그인은 보안 정책상 인앱 브라우저에서 차단됩니다.{' '}
+                            <b>카카오 로그인</b>을 이용하시거나, 아래 버튼으로 외부 브라우저에서 열어 주세요.
+                        </StyledInAppText>
+                        <StyledInAppButton type="button" onClick={openInExternalBrowser}>
+                            외부 브라우저로 열기
+                        </StyledInAppButton>
+                    </StyledInAppNotice>
+                )}
                 {displayError && ERROR_MESSAGES[displayError] && (
                     <StyledLoginError>
                         <StyledLoginErrorText>{ERROR_MESSAGES[displayError]}</StyledLoginErrorText>
@@ -362,6 +414,53 @@ const StyledInviteInput = styled.input`
         letter-spacing: normal;
         font-weight: 400;
         font-size: 14px;
+    }
+`;
+
+const StyledInAppNotice = styled.div`
+    width: 100%;
+    margin: 0 0 16px;
+    padding: 12px 14px;
+    box-sizing: border-box;
+    border: 1px solid #fde68a;
+    border-radius: 10px;
+    background: #fffbeb;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`;
+
+const StyledInAppTitle = styled.strong`
+    font-size: 13px;
+    font-weight: 700;
+    color: #92400e;
+`;
+
+const StyledInAppText = styled.p`
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.6;
+    color: #92400e;
+
+    b {
+        font-weight: 700;
+    }
+`;
+
+const StyledInAppButton = styled.button`
+    align-self: flex-start;
+    margin-top: 2px;
+    padding: 8px 14px;
+    border: 1px solid #f59e0b;
+    border-radius: 8px;
+    background: #f59e0b;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+
+    @media (hover: hover) and (pointer: fine) {
+        &:hover { opacity: 0.9; }
     }
 `;
 

--- a/client/pages/onboarding/index.tsx
+++ b/client/pages/onboarding/index.tsx
@@ -51,8 +51,7 @@ const OnboardingPage: NextPage = () => {
     const [step, setStep] = useState<OnboardingStep>(0);
 
     useEffect(() => {
-        // 게스트·SNS 모두 인트로(step 0, "30초 설정 안내")부터 시작
-        setStep(0);
+        setStep(guest ? 0 : 1);
     }, [guest]);
 
     const [shopName, setShopName] = useState('');
@@ -119,11 +118,11 @@ const OnboardingPage: NextPage = () => {
         }
     };
 
-    const handleSkipOnboarding = async () => {
+    const handleSkipOnboarding = () => {
+        const snapshot = loadLocalDbSnapshot();
+        snapshot.onboarded = true;
+        saveLocalDbSnapshot(snapshot);
         if (guest) {
-            const snapshot = loadLocalDbSnapshot();
-            snapshot.onboarded = true;
-            saveLocalDbSnapshot(snapshot);
             // 서비스 개시 시점에 약관 동의 영구 기록 (consent 단계의 세션 ack 정리)
             setGuestTermsAgreed(CURRENT_TERMS_VERSION);
             clearGuestConsentAck();
@@ -131,34 +130,12 @@ const OnboardingPage: NextPage = () => {
             window.location.href = '/';
             return;
         }
-
-        // 비게스트(SNS): 기본 설정(원장 1명)으로 온보딩 완료 처리.
-        // 단순 router.replace('/')만 하면 onboarded=false라 미들웨어가 다시 /onboarding으로 보내 무한 루프.
-        setLoading(true);
-        setFinalError('');
-        try {
-            const res = await fetch('/api/onboarding', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({}),
-            });
-            if (!res.ok && res.status !== 409) {
-                const data = await res.json().catch(() => ({}));
-                setFinalError(data.error ?? '오류가 발생했습니다.');
-                return;
-            }
-            await update();
-            router.replace('/');
-        } catch {
-            setFinalError('네트워크 오류가 발생했습니다.');
-        } finally {
-            setLoading(false);
-        }
+        router.replace('/');
     };
 
     const handleConfirmSkip = () => {
         setShowSkipConfirm(false);
-        void handleSkipOnboarding();
+        handleSkipOnboarding();
     };
 
     const handleComplete = async () => {
@@ -253,7 +230,7 @@ const OnboardingPage: NextPage = () => {
                             <StyledHighlight>⚡ 30초 설정으로 바로 시작</StyledHighlight>
                             <span>업종별 서비스와 가격을 자동 추천해드립니다.</span>
                         </StyledStep0Desc>
-                        {guest && <GuestNotice />}
+                        <GuestNotice />
                         <StyledNavRow>
                             <StyledSkipBtn type="button" onClick={() => setShowSkipConfirm(true)}>건너뛰기</StyledSkipBtn>
                             <StyledNextBtn type="button" onClick={() => setStep(1)}>설정 시작</StyledNextBtn>

--- a/client/pages/onboarding/index.tsx
+++ b/client/pages/onboarding/index.tsx
@@ -51,7 +51,8 @@ const OnboardingPage: NextPage = () => {
     const [step, setStep] = useState<OnboardingStep>(0);
 
     useEffect(() => {
-        setStep(guest ? 0 : 1);
+        // 게스트·SNS 모두 인트로(step 0, "30초 설정 안내")부터 시작
+        setStep(0);
     }, [guest]);
 
     const [shopName, setShopName] = useState('');
@@ -118,11 +119,11 @@ const OnboardingPage: NextPage = () => {
         }
     };
 
-    const handleSkipOnboarding = () => {
-        const snapshot = loadLocalDbSnapshot();
-        snapshot.onboarded = true;
-        saveLocalDbSnapshot(snapshot);
+    const handleSkipOnboarding = async () => {
         if (guest) {
+            const snapshot = loadLocalDbSnapshot();
+            snapshot.onboarded = true;
+            saveLocalDbSnapshot(snapshot);
             // 서비스 개시 시점에 약관 동의 영구 기록 (consent 단계의 세션 ack 정리)
             setGuestTermsAgreed(CURRENT_TERMS_VERSION);
             clearGuestConsentAck();
@@ -130,12 +131,34 @@ const OnboardingPage: NextPage = () => {
             window.location.href = '/';
             return;
         }
-        router.replace('/');
+
+        // 비게스트(SNS): 기본 설정(원장 1명)으로 온보딩 완료 처리.
+        // 단순 router.replace('/')만 하면 onboarded=false라 미들웨어가 다시 /onboarding으로 보내 무한 루프.
+        setLoading(true);
+        setFinalError('');
+        try {
+            const res = await fetch('/api/onboarding', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({}),
+            });
+            if (!res.ok && res.status !== 409) {
+                const data = await res.json().catch(() => ({}));
+                setFinalError(data.error ?? '오류가 발생했습니다.');
+                return;
+            }
+            await update();
+            router.replace('/');
+        } catch {
+            setFinalError('네트워크 오류가 발생했습니다.');
+        } finally {
+            setLoading(false);
+        }
     };
 
     const handleConfirmSkip = () => {
         setShowSkipConfirm(false);
-        handleSkipOnboarding();
+        void handleSkipOnboarding();
     };
 
     const handleComplete = async () => {
@@ -230,7 +253,7 @@ const OnboardingPage: NextPage = () => {
                             <StyledHighlight>⚡ 30초 설정으로 바로 시작</StyledHighlight>
                             <span>업종별 서비스와 가격을 자동 추천해드립니다.</span>
                         </StyledStep0Desc>
-                        <GuestNotice />
+                        {guest && <GuestNotice />}
                         <StyledNavRow>
                             <StyledSkipBtn type="button" onClick={() => setShowSkipConfirm(true)}>건너뛰기</StyledSkipBtn>
                             <StyledNextBtn type="button" onClick={() => setStep(1)}>설정 시작</StyledNextBtn>

--- a/client/public/ads.txt
+++ b/client/public/ads.txt
@@ -1,4 +1,1 @@
-# ads.txt — Google AdSense 게시자 인증 (https://adstxt.guru/)
-# AdSense 사이트 승인 후, 발급받은 게시자 ID(pub-XXXXXXXXXXXXXXXX)로
-# 아래 줄을 교체하고 주석(#)을 제거하세요. 잘못된 ID 노출 방지를 위해 기본은 주석 처리.
-# google.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0
+google.com, pub-5655041057903258, DIRECT, f08c47fec0942fa0

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ hair_reservations/
 ├── server/          # 백엔드 (API 핸들러 + DB + Auth + Prisma 자산)
 ├── docs/            # 문서
 ├── plan.md          # 게스트 데이터 마이그레이션(병합 플로우) 계획
-├── CLAUDE.md        # 커밋 컨벤션 (한글, feat:/fix:/refactor: 등, 커밋 시 푸시 포함)
+├── CLAUDE.md        # Claude 작업 지시사항 (세션 시작 규칙·워크플로·프론트 표준·커밋 컨벤션)
 └── index.md         # 이 파일
 ```
 
@@ -28,7 +28,7 @@ hair_reservations/
 | 경로 | 파일 | 설명 |
 |------|------|------|
 | `/` | `index.tsx` | 메인 캘린더 (SSR, `getServerSideProps`로 예약·고객·이력 초기 로드) |
-| `/login` | `login.tsx` | 로그인 (Google, Kakao, Naver OAuth) + 게스트 진입 버튼 |
+| `/login` | `login.tsx` | 로그인 (Google, Kakao, Naver OAuth) + 게스트 진입. 초대 링크(`?invite=CODE`) 코드 자동입력, 인앱 브라우저(WebView) 감지 시 안내 배너 + 카카오 우선 노출, 로고→루트 링크 |
 | `/logout` | `logout.tsx` | 로그아웃 후 `/login`으로 리다이렉트 |
 | `/mypage` | `mypage.tsx` | 계정 관리 (프로필, 연결된 SNS, 로그아웃, 회원탈퇴) |
 | `/settings/[tab]` | `settings/[tab].tsx` → `settings.tsx` | 설정 (탭: revenue/point/store/service/designer/member/sns/naver) |
@@ -150,7 +150,7 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 - Google: 기본 스코프(openid email profile)만 사용 — **로그인 전용**. Gmail 권한은 별도 연동 플로우(`/api/gmail/connect`)에서 요청
 - JWT 세션 전략
 - 로그인 시 `syncAuthUser()`로 DB 사용자 동기화 + 초대 코드 처리
-- 초대코드 없이 신규가입 시 새 매장(owner) 자동 생성 (`onboarded: true`)
+- 초대코드 없이 신규가입 시 새 매장(owner) 자동 생성 (`onboarded: false` — 이후 온보딩 진행)
 - **계정 연동/병합**: 기존 로그인 상태에서 타 프로바이더 연결(`/api/account/link`). 해당 계정이 다른 유저 소유면 `pendingMerge`를 세션에 실어 병합 플로우(merge-preview → merge) 유도
 - **멀티매장**: `preferredStoreId`(세션 update로 갱신) 기반으로 `resolveUserMembership()`이 활성 매장 결정. jwt 콜백이 매 요청 `role`/`storeId`/`onboarded`를 DB에서 재조회
 - `authorized` 콜백: `loginError='no-account'` 시 `/login`으로 리다이렉트

--- a/plan.md
+++ b/plan.md
@@ -309,4 +309,34 @@ Phase 1(API 이전) 먼저 — 위험이 낮고 즉시 경계가 깔끔해짐. P
 - **버그2(온보딩 중 로그인으로 튕김)**: 초대 흐름 수정으로 해소 가능성 → 운영 재테스트 대기. 재현 시 튕기는 시점 + 콘솔 에러 필요.
 - **OAuth 콘솔 작업(코드 외)**: Google/Kakao 콘솔 redirect URI 등록, Cloudflare SSL=Full(strict), Google 동의화면 프로덕션 게시.
 - **Gmail 제한범위(`gmail.readonly`) 인증**: 데모영상 + CASA 보안평가 필요(별도).
+
+---
+
+# AdSense 광고 붙이기 (퍼블리셔 ID 주입)
+
+> **진행 현황 (2026-06-20, 완료)**: 퍼블리셔 ID `ca-pub-5655041057903258` 코드 기본값 주입 + ads.txt 갱신. 운영 모드 검증 — `/login` HTML에 로더 스크립트 삽입, `/ads.txt` 정상 응답, `next build` 그린. 후속: AdSense 콘솔 사이트 승인 + 자동광고 ON, 개별 유닛용 슬롯 ID 발급.
+
+## 배경
+- 광고 인프라는 이미 구축됨: `_document.tsx`가 `NEXT_PUBLIC_ADSENSE_CLIENT` 존재 시 AdSense 로더 스크립트 자동 삽입, `AdBanner` 컴포넌트(`<ins class="adsbygoogle">`)와 배치(푸터·로그인·온보딩·동의)도 존재.
+- 미설정이던 퍼블리셔 ID만 주입하면 페이지 레벨 스크립트(자동 광고) 활성화.
+
+## 요구사항 / 접근
+- 퍼블리셔 ID: `ca-pub-5655041057903258` (ads.txt용 publisher id: `pub-5655041057903258`).
+- `NEXT_PUBLIC_*`는 빌드타임 인라인이라 배포 env 미설정 시 광고가 안 뜸 → **코드에 기본값**을 두어 env 없이도 동작하게 함(env로 오버라이드 가능). 퍼블리셔 ID는 페이지 소스에 노출되는 공개값이라 하드코딩 무방.
+
+## 영향 파일
+- `client/lib/ads.ts` (신규) — `ADSENSE_CLIENT` 단일 소스(env ?? 기본값).
+- `client/components/ad/AdBanner.tsx` — 로컬 상수 → `lib/ads` 사용.
+- `client/pages/_document.tsx` — 로더 스크립트도 `lib/ads` 사용.
+- `client/public/ads.txt` — 실제 게시자 라인 활성화.
+- `client/.env.example` — 기본값 안내.
+
+## 기대 결과 / 검증
+- 운영 빌드에서 `<head>`에 `adsbygoogle.js?client=ca-pub-5655041057903258` 로더 삽입.
+- `/ads.txt` → `google.com, pub-5655041057903258, DIRECT, f08c47fec0942fa0` 응답.
+- `next build` 그린.
+
+## 주의 / 후속
+- 개별 광고 유닛(`AdBanner`)은 **슬롯 ID**(`NEXT_PUBLIC_ADSENSE_FOOTER_SLOT`/`AUTH_SLOT`)가 있어야 `<ins>`가 렌더됨 — 슬롯은 AdSense 콘솔에서 발급 후 env 설정 필요. 그 전까지는 페이지 레벨(자동 광고)만 동작.
+- AdSense 사이트 승인 + 콘솔에서 자동광고 ON 필요.
  

--- a/plan.md
+++ b/plan.md
@@ -280,4 +280,33 @@ Phase 1(API 이전) 먼저 — 위험이 낮고 즉시 경계가 깔끔해짐. P
 - `adFree`는 매 요청 jwt 갱신이라 키 사용 직후 `update()` 호출로 즉시 반영.
 
 ## 진행 순서 권장
-1. 스키마 + 마이그레이션 → 2. 서버 로직 + 세션 전파 → 3. 클라 게이트(AdBanner) → 4. redeem API + 설정 UI → 5. 발급 스크립트 → 6. 전체 흐름 검증(키 발급 → 입력 → 광고 사라짐 확인) 
+1. 스키마 + 마이그레이션 → 2. 서버 로직 + 세션 전파 → 3. 클라 게이트(AdBanner) → 4. redeem API + 설정 UI → 5. 발급 스크립트 → 6. 전체 흐름 검증(키 발급 → 입력 → 광고 사라짐 확인)
+
+---
+
+# 로그인/인증 안정화 — OAuth 진단 + 초대 링크 + 인앱 브라우저 대응
+
+> **진행 현황 (2026-06-20, 완료)**: 아래 항목 구현·검증·푸시 완료(`claude/angdae-issue-gym218`). 커밋 `54cf696`(로고 링크), `dd816c5`(초대 링크), `43ea35c`(온보딩 step0 되돌림), `c73a2c6`(인앱 브라우저).
+
+## 배경 / 문제 (QA·운영 제보)
+- Google/Kakao 로그인 실패 → 원인은 **콘솔 설정**(인앱브라우저 `disallowed_useragent`, 카카오 redirect URI 미등록)으로 규명. **코드 수정 불필요**(콘솔에 `https://takeaseat.co.kr/api/auth/callback/{google,kakao}` 등록 필요).
+- 초대코드로 로그인했는데 새 매장이 생성됨 → 초대가 **수동 코드 입력**으로만 적용되고 "링크"가 없어서, 코드 미입력 시 `syncAuthUser`가 새 매장(owner) 경로로 빠짐.
+- 카카오톡 등 인앱 브라우저에서 구글 로그인 차단 → 사용자가 막힘.
+
+## 구현 항목 (완료)
+1. **로그인 로고 → 루트(/) 링크** (`pages/login.tsx`) — `next/link`로 감싸 홈 이동.
+2. **초대 링크 지원** (`pages/login.tsx`) — `/login?invite=CODE` 진입 시 코드 자동입력 + `tas-invite-code` 쿠키 세팅(대문자화·6자 슬라이스). 콜백에서 초대 매장 합류. 쿠키 `secure`는 https에서만 부여(로컬 http 누락 방지).
+3. **초대 링크 복사** (`components/settings/MemberSection.tsx`) — 코드/링크 복사 버튼 + 안내 문구.
+4. **인앱 브라우저 대응** (`pages/login.tsx`) — WebView(KakaoTalk·Instagram·Naver·Line·FB·Threads 등) 감지 → 안내 배너 + "외부 브라우저로 열기"(카카오 스킴/안드로이드 chrome intent/iOS 복사 폴백) + 카카오 로그인 우선 정렬.
+5. **온보딩 step0 노출 변경 → 되돌림** — SNS 사용자에게 step0(30초 인트로) 노출은 불필요하여 원복.
+
+## 검증 (실제 브라우저 구동, Playwright)
+- 초대: `/login?invite=abc123` → 입력칸 `ABC123` + 쿠키 세팅, 8자 입력 시 6자 슬라이스, 미지정 시 빈값. ✅
+- 인앱: KakaoTalk UA → 배너 노출 + 카카오 우선 정렬 / 일반 UA → 배너 없음 + 기본 순서. ✅
+- 타입체크 + `next build` 그린.
+
+## 후속 / 미해결
+- **버그2(온보딩 중 로그인으로 튕김)**: 초대 흐름 수정으로 해소 가능성 → 운영 재테스트 대기. 재현 시 튕기는 시점 + 콘솔 에러 필요.
+- **OAuth 콘솔 작업(코드 외)**: Google/Kakao 콘솔 redirect URI 등록, Cloudflare SSL=Full(strict), Google 동의화면 프로덕션 게시.
+- **Gmail 제한범위(`gmail.readonly`) 인증**: 데모영상 + CASA 보안평가 필요(별도).
+ 


### PR DESCRIPTION
## 개요
로그인/인증 흐름 개선과 AdSense 광고 게재를 위한 변경 묶음. client 버전 `0.1.11 → 0.2.0` (기능 추가, minor bump).

## 변경 사항

### 로그인/인증
- **로고 → 루트(/) 링크** (`login.tsx`): 로그인 전 브랜드 로고 클릭 시 홈 이동
- **초대 링크 지원** (`login.tsx`, `MemberSection.tsx`): `/login?invite=CODE` 진입 시 코드 자동입력 + 쿠키 세팅 → 새 매장 생성 대신 초대 매장 합류. 멤버관리에 "링크 복사" 추가. 초대 쿠키 `secure`는 https에서만 부여(로컬 http 누락 방지)
- **인앱 브라우저 대응** (`login.tsx`): 카카오톡·인스타·네이버앱 등 WebView 감지 → 안내 배너 + "외부 브라우저로 열기"(카카오 스킴/안드로이드 chrome intent/iOS 복사) + 카카오 로그인 우선 노출. (Google OAuth가 인앱에서 `disallowed_useragent`로 차단되는 문제 안내)

### 광고 (AdSense)
- **퍼블리셔 ID 적용** (`lib/ads.ts`, `_document.tsx`, `AdBanner.tsx`): `ca-pub-5655041057903258`를 코드 기본값으로 단일화 → 모든 페이지 `<head>`에 로더 스크립트 자동 주입(env 오버라이드 가능)
- **ads.txt** 게시자 인증 라인 활성화

### 문서/규칙
- **CLAUDE.md 신설**: 세션 시작 규칙·개발 워크플로·프론트 표준·커밋 컨벤션 명문화
- **index.md/plan.md** 동기화 (로그인·광고 작업 반영, `onboarded` 값 코드와 일치하도록 수정)

## 검증
실제 브라우저(Playwright)·운영 모드(`next start`) 구동으로 확인:
- 초대 자동입력(대문자·6자 슬라이스·쿠키), 인앱 배너+카카오 우선 정렬, 일반 UA 미노출
- AdSense 로더가 전 페이지(`/`, `/login`, `/about`, `/terms`, `/privacy`, `/inquiry`) `<head>`에 삽입, `/ads.txt` 정상 응답
- `next build` 그린

## 후속 (코드 외)
- OAuth 콘솔: Google/Kakao redirect URI 등록, Cloudflare SSL=Full(strict), 동의화면 프로덕션 게시
- AdSense: 사이트 승인 + 자동광고 ON, 개별 유닛용 슬롯 ID 발급 후 env 설정
- QA 버그2(온보딩→로그인 튕김) 운영 재테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_