### PR TITLE
feat: run.app→도메인 정규화 리다이렉트 + 온보딩 로고 링크

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pages/onboarding/index.tsx
+++ b/client/pages/onboarding/index.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 
 import type {NextPage} from 'next';
+import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {useSession} from 'next-auth/react';
 
@@ -213,7 +214,9 @@ const OnboardingPage: NextPage = () => {
             <SeoHead title="초기 설정" />
             <StyledCard>
                 <StyledCardHeader>
-                    <StyledBrandLogo src="/logo/logo-black.svg" alt="TAS" />
+                    <StyledBrandLink href="/" aria-label="홈으로 이동">
+                        <StyledBrandLogo src="/logo/logo-black.svg" alt="TAS" />
+                    </StyledBrandLink>
                     {step !== 0 && (
                         <StyledStepRow>
                             {visibleSteps.map((s, i) => (
@@ -400,6 +403,11 @@ const StyledCardHeader = styled.div`
     display: flex;
     flex-direction: column;
     gap: 10px;
+`;
+
+const StyledBrandLink = styled(Link)`
+    display: inline-block;
+    line-height: 0;
 `;
 
 const StyledBrandLogo = styled.img`

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -5,6 +5,18 @@ export default auth((req) => {
     const {pathname} = req.nextUrl;
     const user = req.auth?.user;
 
+    // run.app(Cloud Run 기본 URL)로 들어온 트래픽은 정식 도메인으로 정규화(308).
+    // OAuth 콜백·세션 쿠키·AdSense가 모두 takeaseat.co.kr 기준이라, run.app 접속은
+    // 로그인이 깨지고 광고 도메인도 어긋난다. host만 바꿔 같은 경로로 영구 리다이렉트.
+    const host = req.headers.get('host') ?? '';
+    if (host.endsWith('.run.app')) {
+        const url = req.nextUrl.clone();
+        url.protocol = 'https:';
+        url.host = 'takeaseat.co.kr';
+        url.port = '';
+        return Response.redirect(url, 308);
+    }
+
     // 약관 동의·온보딩 가드에서 항상 허용하는 경로 (인프라 + 동의/약관 관련 페이지)
     const isExempt =
         pathname.startsWith('/api/') ||
@@ -44,6 +56,8 @@ export default auth((req) => {
     // (미들웨어는 고정 URL로만 보낼 수 있어 '이전 페이지' 처리를 클라이언트 가드에 위임)
 });
 
+// /login도 미들웨어가 타게 둠 — run.app→도메인 정규화가 로그인 페이지에도 적용되도록.
+// (login은 아래 동의/온보딩 게이트에서는 isExempt로 그대로 통과)
 export const config = {
-    matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico|login).*)'],
+    matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico).*)'],
 };

--- a/plan.md
+++ b/plan.md
@@ -339,4 +339,23 @@ Phase 1(API 이전) 먼저 — 위험이 낮고 즉시 경계가 깔끔해짐. P
 ## 주의 / 후속
 - 개별 광고 유닛(`AdBanner`)은 **슬롯 ID**(`NEXT_PUBLIC_ADSENSE_FOOTER_SLOT`/`AUTH_SLOT`)가 있어야 `<ins>`가 렌더됨 — 슬롯은 AdSense 콘솔에서 발급 후 env 설정 필요. 그 전까지는 페이지 레벨(자동 광고)만 동작.
 - AdSense 사이트 승인 + 콘솔에서 자동광고 ON 필요.
+
+---
+
+# run.app 도메인 정규화 + 온보딩 로고 링크
+
+> **진행 현황 (2026-06-20, 완료)**: 구현·검증·푸시(`claude/angdae-issue-gym218`). 온보딩 로고 링크(`6ba521b`), run.app 정규화 리다이렉트.
+
+## 배경
+- 네이버앱이 Cloud Run 기본 URL(`tas-...run.app`)로 연결됨. 이 URL 접속은 OAuth 콜백/세션 쿠키/AdSense가 모두 `takeaseat.co.kr` 기준이라 **로그인이 깨짐**.
+
+## 구현 (완료)
+- `proxy.ts`: host가 `*.run.app`이면 같은 경로로 `https://takeaseat.co.kr`로 **308 영구 리다이렉트**. matcher에서 `login` 제외 해제(로그인 페이지도 정규화 적용).
+- `onboarding/index.tsx`: 헤더 로고 → 루트(/) 링크(로그인 화면과 동일).
+
+## 검증 (next start, Host 헤더 시뮬레이션)
+- `Host: tas-...run.app` → `/about`·`/login?invite=...` 모두 308 → `takeaseat.co.kr`(경로·쿼리 보존). 일반 Host는 200. `next build` 그린.
+
+## 후속 (코드 외)
+- 네이버 스마트플레이스/예약에 등록된 사이트 URL을 `https://takeaseat.co.kr`로 교체(근본).
  


### PR DESCRIPTION
## 개요
- Cloud Run 기본 URL(`*.run.app`)로 들어온 트래픽을 정식 도메인 `takeaseat.co.kr`로 정규화(B)
- 온보딩 헤더 로고 → 루트(/) 링크 (로그인 화면과 동일)

## 변경 사항

### `proxy.ts` — run.app 도메인 정규화 (핵심)
- host가 `*.run.app`이면 같은 경로/쿼리로 `https://takeaseat.co.kr`에 **308 영구 리다이렉트**
- matcher에서 `login` 제외 해제 → 로그인 페이지도 정규화 적용
- 이유: OAuth 콜백·세션 쿠키·AdSense가 모두 `takeaseat.co.kr` 기준이라, run.app 직접 접속은 `redirect_uri_mismatch`로 **로그인이 깨짐**. 네이버앱이 run.app으로 연결되는 케이스 방어.

### `onboarding/index.tsx`
- 헤더 로고를 `next/link`로 감싸 홈(`/`) 이동

## 검증 (next start, Host 헤더 시뮬레이션)
- `Host: tas-...run.app` → `/about`, `/login?invite=ABC123` 모두 **308 → takeaseat.co.kr** (경로·쿼리 보존)
- 일반 Host → 200 (리다이렉트 없음)
- 온보딩 로고 링크 타입체크 통과, `next build` 그린

## 후속 (코드 외)
- 네이버 스마트플레이스/예약에 등록된 사이트 URL을 `https://takeaseat.co.kr`로 교체(근본 대응)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_