### PR TITLE
fix: 중복예약 충돌 모달이 안 뜨는 회귀 수정 (v0.2.2)

### DIFF
--- a/client/hooks/useNaverBookingSync.ts
+++ b/client/hooks/useNaverBookingSync.ts
@@ -91,21 +91,27 @@ function restoreConflictsFromPairs(): ConflictInfo[] {
     if (pairs.length === 0) return [];
 
     const reservationMap = useCalendarStore.getState().reservationMap;
-    const activeReservations = Object.values(reservationMap).flat()
-        .filter((r) => r.status !== 'cancelled' && r.status !== 'noshow');
+    // 현재 로드된 범위에서 '취소/노쇼로 해소된 것이 확인된' 예약 id만 모은다.
+    // 로드되지 않은(=확인 불가) 예약은 스냅샷을 그대로 유지해야, 다른 날짜를 보고 있어도
+    // 알림에서 해당 충돌 모달을 열 수 있다. (예전엔 미로드 예약을 '없는 것'으로 보고 버려서
+    // 다른 날짜로 이동하면 충돌이 영구히 안 열리던 회귀의 원인)
+    const resolvedIds = new Set(
+        Object.values(reservationMap).flat()
+            .filter((r) => r.status === 'cancelled' || r.status === 'noshow')
+            .map((r) => r.id),
+    );
     const conflicts: ConflictInfo[] = [];
 
     for (const stored of pairs) {
-        // 취소·노쇼가 아닌 예약이 여전히 존재하는지 확인
-        const newExists = activeReservations.some((r) => r.id === stored.newReservation.id);
-        const existingExists = activeReservations.some((r) => r.id === stored.existingReservation.id);
-        if (newExists && existingExists) {
-            // 원본 스냅샷을 유지 (변경 비교용)
-            conflicts.push({
-                newReservation: stored.newReservation,
-                existingReservation: stored.existingReservation,
-            });
+        // 둘 중 하나라도 취소/노쇼로 확인되면 해소된 것으로 보고 제외
+        if (resolvedIds.has(stored.newReservation.id) || resolvedIds.has(stored.existingReservation.id)) {
+            continue;
         }
+        // 원본 스냅샷을 유지 (변경 비교용 + 미로드 날짜에서도 모달 오픈 가능)
+        conflicts.push({
+            newReservation: stored.newReservation,
+            existingReservation: stored.existingReservation,
+        });
     }
 
     return conflicts;
@@ -500,16 +506,28 @@ export function useNaverBookingSync() {
 
         let existing = queue.find((conflict) => conflictKey(conflict) === key);
 
-        // queue에도 없으면 notification + reservationMap에서 직접 복원
+        // queue에도 없으면: ① 저장된 충돌 스냅샷 → ② 현재 로드된 reservationMap 순으로 복원.
+        // ①을 먼저 보는 이유: 스냅샷엔 예약 두 건의 전체 정보가 들어 있어, 지금 보고 있지 않은
+        // 날짜의 충돌도 모달을 열 수 있다(예전엔 reservationMap에 없으면 조용히 return 해서 안 떴음).
         if (!existing) {
-            const [newIdStr, existingIdStr] = key.split('-');
-            const newId = Number(newIdStr);
-            const existingId = Number(existingIdStr);
-            const allReservations = Object.values(reservationMap).flat();
-            const newRes = allReservations.find((r) => r.id === newId);
-            const existingRes = allReservations.find((r) => r.id === existingId);
-            if (!newRes || !existingRes) return;
-            existing = {newReservation: newRes, existingReservation: existingRes};
+            const savedPair = loadActiveConflictPairs().find(
+                (p) => `${p.newReservation.id}-${p.existingReservation.id}` === key,
+            );
+            if (savedPair) {
+                existing = {
+                    newReservation: savedPair.newReservation,
+                    existingReservation: savedPair.existingReservation,
+                };
+            } else {
+                const [newIdStr, existingIdStr] = key.split('-');
+                const newId = Number(newIdStr);
+                const existingId = Number(existingIdStr);
+                const allReservations = Object.values(reservationMap).flat();
+                const newRes = allReservations.find((r) => r.id === newId);
+                const existingRes = allReservations.find((r) => r.id === existingId);
+                if (!newRes || !existingRes) return;
+                existing = {newReservation: newRes, existingReservation: existingRes};
+            }
             queue = [...queue, existing];
             setConflictQueue(queue);
             saveActiveConflictPairs(queue);

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/plan.md
+++ b/plan.md
@@ -358,4 +358,23 @@ Phase 1(API 이전) 먼저 — 위험이 낮고 즉시 경계가 깔끔해짐. P
 
 ## 후속 (코드 외)
 - 네이버 스마트플레이스/예약에 등록된 사이트 URL을 `https://takeaseat.co.kr`로 교체(근본).
+
+---
+
+# 중복예약(충돌) 모달 안 뜨는 회귀 수정
+
+> **진행 현황 (2026-06-20, 완료)**: `useNaverBookingSync.ts` 2곳 수정. 빌드/타입체크 그린. 런타임(클릭 동작)은 Gmail 충돌 데이터+로그인 필요라 배포 후 모바일 확인 요망.
+
+## 근본 원인
+충돌 모달을 여는 경로가 **현재 캘린더에 로드된 예약(reservationMap)에 그 두 예약이 있어야만** 동작. 다른 날짜를 보면:
+1. `restoreConflictsFromPairs`가 미로드 예약 충돌을 버림 → `saveActiveConflictPairs(merged)`가 저장본을 덮어써 영구 삭제
+2. `openConflictByKey`가 reservationMap에서 못 찾으면 조용히 `return` → 모달 안 뜸
+→ "처음엔 떴다가 다른 날짜 보면 영구히 안 뜨는" 회귀.
+
+## 수정 (2곳, `useNaverBookingSync.ts`)
+1. `restoreConflictsFromPairs`: 미로드 예약을 버리지 않음. 현재 로드된 범위에서 **취소/노쇼로 확인된 경우만** 제외 → 저장본이 보존됨(덮어쓰기 시에도 유지).
+2. `openConflictByKey`: 폴백을 `loadActiveConflictPairs()` 스냅샷 우선으로 → 어떤 날짜든 모달 오픈, 조용한 return 제거.
+
+## 알려진 한계 / 후속
+- 감지 effect의 자동확정(line~162)은 여전히 로드된 감지(detectedKeys)만 기준이라, 미로드 충돌이 'confirmed' 상태로 표시될 수 있음(모달은 열림). 카운트 정확도까지 원하면 별도 보강.
  


### PR DESCRIPTION
## 개요
전체알림에서 중복예약(충돌)을 눌러도 충돌 모달이 안 뜨는 **회귀 수정**. (v0.2.2)

## 근본 원인
충돌 모달 오픈이 **현재 캘린더에 로드된 예약(reservationMap)** 에 의존:
1. `restoreConflictsFromPairs`가 미로드 예약의 충돌을 버림 → `saveActiveConflictPairs(merged)`가 저장본을 덮어써 **영구 삭제**
2. `openConflictByKey`가 reservationMap에서 못 찾으면 **조용히 `return`** → 모달 안 뜸

→ "처음엔 떴다가, 다른 날짜를 보면 그 충돌이 영구히 안 열리는" 회귀.

## 수정 (`useNaverBookingSync.ts` 2곳)
1. **`restoreConflictsFromPairs`**: 미로드 예약을 버리지 않음. 현재 로드된 범위에서 **취소/노쇼로 확인된 경우만** 제외 → 저장 스냅샷 보존(덮어쓰기에도 유지)
2. **`openConflictByKey`**: 폴백을 `loadActiveConflictPairs()` 스냅샷 우선으로 → 로드 여부와 무관하게 모달 오픈, 조용한 return 제거

## 검증
- 타입체크 + `next build` 그린
- ⚠️ 런타임(실제 클릭)은 Gmail 충돌 데이터 + 로그인이 필요해 이 환경에서 재현 불가 → **배포 후 모바일에서 확인 필요**

## 알려진 한계 (후속)
- 감지 effect의 자동확정 로직은 여전히 로드된 감지만 기준이라 미로드 충돌이 'confirmed'로 표시될 수 있음(모달은 열림). 카운트 정확도까지 원하면 별도 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_