### PR TITLE
fix: run.app 리다이렉트 제거 — 운영 무한 리다이렉트 핫픽스 (v0.2.3)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -5,18 +5,6 @@ export default auth((req) => {
     const {pathname} = req.nextUrl;
     const user = req.auth?.user;
 
-    // run.app(Cloud Run 기본 URL)로 들어온 트래픽은 정식 도메인으로 정규화(308).
-    // OAuth 콜백·세션 쿠키·AdSense가 모두 takeaseat.co.kr 기준이라, run.app 접속은
-    // 로그인이 깨지고 광고 도메인도 어긋난다. host만 바꿔 같은 경로로 영구 리다이렉트.
-    const host = req.headers.get('host') ?? '';
-    if (host.endsWith('.run.app')) {
-        const url = req.nextUrl.clone();
-        url.protocol = 'https:';
-        url.host = 'takeaseat.co.kr';
-        url.port = '';
-        return Response.redirect(url, 308);
-    }
-
     // 약관 동의·온보딩 가드에서 항상 허용하는 경로 (인프라 + 동의/약관 관련 페이지)
     const isExempt =
         pathname.startsWith('/api/') ||
@@ -56,8 +44,6 @@ export default auth((req) => {
     // (미들웨어는 고정 URL로만 보낼 수 있어 '이전 페이지' 처리를 클라이언트 가드에 위임)
 });
 
-// /login도 미들웨어가 타게 둠 — run.app→도메인 정규화가 로그인 페이지에도 적용되도록.
-// (login은 아래 동의/온보딩 게이트에서는 isExempt로 그대로 통과)
 export const config = {
-    matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico).*)'],
+    matcher: ['/((?!api/auth|_next/static|_next/image|favicon.ico|login).*)'],
 };


### PR DESCRIPTION
## 🚨 핫픽스 — 운영 무한 리다이렉트로 서비스 중단

PR #54에서 넣은 `proxy.ts`의 **run.app→takeaseat.co.kr 308 리다이렉트**가 운영에서 무한 루프를 유발.

**원인**: Cloudflare가 origin(Cloud Run)에 `Host: *.run.app`으로 전달하는 구성이면, `takeaseat.co.kr` 접속도 컨테이너에선 Host=run.app으로 보여 → 308로 takeaseat.co.kr 리다이렉트 → Cloudflare가 다시 Host=run.app 전달 → **무한 308 루프**.

## 수정
- `proxy.ts`를 PR #54 이전 상태로 되돌림 (run.app 리다이렉트 블록 + matcher 변경 제거)
- diff 확인: `proxy.ts`는 #54 직전과 **완전히 동일**
- client `0.2.3`

## 후속
- run.app 정규화가 필요하면, **운영 Host 헤더를 먼저 검증**한 뒤 루프 안전한 방식(예: Cloudflare 미경유 `cf-ray` 부재 시에만 리다이렉트)으로 재도입.
- 또는 인프라 레벨(Cloud Run 도메인 매핑/Cloudflare Host 설정)로 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_