### PR TITLE
fix: 온보딩 완료 후 한 번 더 뜨는 문제 수정 (v0.2.4)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pages/onboarding/index.tsx
+++ b/client/pages/onboarding/index.tsx
@@ -191,14 +191,16 @@ const OnboardingPage: NextPage = () => {
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
                 // 이미 설정된 매장(JWT만 stale onboarded=false) → 세션 갱신 후 홈으로 (레이어 막다른 길 방지)
-                if (res.status === 409) { await update(); router.replace('/'); return; }
+                if (res.status === 409) { await update(); window.location.href = '/'; return; }
                 setFinalError(data.error ?? '오류가 발생했습니다.');
                 return;
             }
 
-            // 세션(JWT) 갱신 → onboarded 반영 후 진입 (없으면 미들웨어가 계속 /onboarding으로 보냄)
+            // 세션(JWT) 갱신 → onboarded 반영 후 진입.
+            // 하드 리로드로 이동해야 갱신된 쿠키를 미들웨어가 보고 /onboarding으로 되돌리지 않음
+            // (router.replace 같은 소프트 이동은 갱신 전 쿠키로 미들웨어가 판정해 온보딩이 한 번 더 뜸)
             await update();
-            router.replace('/');
+            window.location.href = '/';
         } catch {
             setFinalError('네트워크 오류가 발생했습니다.');
         } finally {


### PR DESCRIPTION
## 개요
온보딩 **완료(시작하기)를 눌러도 온보딩이 한 번 더 떠서, 두 번 완료해야 진입되던** 버그 수정. (v0.2.4)

## 근본 원인
비게스트 완료 경로가 `await update()` 후 **`router.replace('/')`(소프트 이동)** 사용:
1. `/api/onboarding`이 DB `onboarded=true` 저장
2. `update()`로 세션 쿠키 갱신을 시도하지만, **소프트 이동이 갱신된 쿠키를 미들웨어가 보기 전에 `/`로 이동** → 미들웨어가 아직 `onboarded=false` 쿠키로 판정 → `/onboarding`으로 되돌림 (**한 번 더 뜸**)
3. 두 번째 진입의 마운트 `update()` + 재완료로 쿠키가 갱신돼 **2번째에 진입**

게스트 완료 경로는 이미 **하드 리로드(`window.location.href`)** 를 써서 1번에 됨 — 비게스트만 소프트 이동이라 불일치.

## 수정
`handleComplete` 비게스트 성공/409 분기를 게스트와 동일하게 **`await update()` → `window.location.href = '/'`**(하드 리로드)로 변경 → 갱신된 쿠키로 미들웨어가 판정해 한 번에 진입.

## 검증
- 타입체크 + `next build` 그린
- ⚠️ 인증 필요 플로우라 이 환경에선 실제 로그인 완료 클릭 재현 불가 → **배포 후 직접 확인 필요**. 다만 동일 파일의 게스트 경로가 이미 같은 방식으로 정상 동작 중이라 회귀 위험은 낮음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_