### PR TITLE
fix: 로그인 사용자 온보딩 건너뛰기 무한 루프 수정 (v0.2.5)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pages/onboarding/index.tsx
+++ b/client/pages/onboarding/index.tsx
@@ -119,11 +119,11 @@ const OnboardingPage: NextPage = () => {
         }
     };
 
-    const handleSkipOnboarding = () => {
-        const snapshot = loadLocalDbSnapshot();
-        snapshot.onboarded = true;
-        saveLocalDbSnapshot(snapshot);
+    const handleSkipOnboarding = async () => {
         if (guest) {
+            const snapshot = loadLocalDbSnapshot();
+            snapshot.onboarded = true;
+            saveLocalDbSnapshot(snapshot);
             // 서비스 개시 시점에 약관 동의 영구 기록 (consent 단계의 세션 ack 정리)
             setGuestTermsAgreed(CURRENT_TERMS_VERSION);
             clearGuestConsentAck();
@@ -131,12 +131,35 @@ const OnboardingPage: NextPage = () => {
             window.location.href = '/';
             return;
         }
-        router.replace('/');
+
+        // 비게스트(로그인): 기본 설정(원장 1명)으로 온보딩 완료 처리 후 진입.
+        // 단순 이동만 하면 onboarded=false라 미들웨어가 다시 /onboarding으로 보내 무한 루프.
+        setLoading(true);
+        setFinalError('');
+        try {
+            const res = await fetch('/api/onboarding', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({}),
+            });
+            if (!res.ok && res.status !== 409) {
+                const data = await res.json().catch(() => ({}));
+                setFinalError(data.error ?? '오류가 발생했습니다.');
+                return;
+            }
+            // 완료와 동일하게 세션 갱신 후 하드 리로드 (갱신된 쿠키로 미들웨어가 판정)
+            await update();
+            window.location.href = '/';
+        } catch {
+            setFinalError('네트워크 오류가 발생했습니다.');
+        } finally {
+            setLoading(false);
+        }
     };
 
     const handleConfirmSkip = () => {
         setShowSkipConfirm(false);
-        handleSkipOnboarding();
+        void handleSkipOnboarding();
     };
 
     const handleComplete = async () => {


### PR DESCRIPTION
## 개요
로그인 사용자가 온보딩에서 **건너뛰기**를 누르면 무한 루프(다시 온보딩)에 빠지던 버그 수정. (v0.2.5)

## 원인
비게스트 `handleSkipOnboarding`이 `router.replace('/')`만 하고 **onboarded를 저장하지 않음** → 미들웨어가 `onboarded=false` 보고 다시 `/onboarding`으로 → 무한 루프.

## 수정
완료 경로와 동일하게:
- 빈 body로 `/api/onboarding` 호출 → 기본 원장 생성 + `onboarded=true`
- `await update()` → `window.location.href='/'`(하드 리로드)로 진입
- (게스트 분기는 기존대로 로컬 스냅샷 처리 유지)

## 검증
- 타입체크 + `next build` 그린
- ⚠️ 인증 플로우라 실제 로그인 클릭 재현은 이 환경에서 불가 → 배포 후 확인 필요. 완료 경로(v0.2.4)와 동일 패턴이라 위험 낮음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREcAi14vbp8XAPuurMwG3)_