### PR TITLE
feat: 서비스 변경 시 예정 예약에 일괄 반영 (v0.4.0)

### DIFF
--- a/client/components/settings/ServiceManageSection.tsx
+++ b/client/components/settings/ServiceManageSection.tsx
@@ -358,9 +358,11 @@ export const ServiceManageSection = () => {
     const [manageError, setManageError] = useState('');
 
     const handleSaveEdit = (original: ServiceItem, updated: ServiceItem) => {
-        updateService(original.name, updated);
+        const appliedCount = updateService(original.name, updated);
         setEditingItem(null);
-        toast('서비스가 저장되었습니다.');
+        toast(appliedCount > 0
+            ? `서비스가 저장되었습니다. 예정된 예약 ${appliedCount}건에 반영했습니다.`
+            : '서비스가 저장되었습니다.');
     };
 
     const handleDelete = (name: string) => {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/store/calendarStore.ts
+++ b/client/store/calendarStore.ts
@@ -40,6 +40,7 @@ import {
     buildMovedCategoryState,
     buildMovedServiceInCategoryState,
     buildRenamedCategoryState,
+    buildServiceCatalogReservationUpdates,
     buildUpdatedServiceState,
 } from './calendarStoreServiceHelpers';
 import {
@@ -185,7 +186,7 @@ export interface CalendarState {
     deleteDesigner: (designerId: number) => void;
     updateCategoryBaseColor: (category: string, color: string) => void;
     addService: (item: ServiceItem) => void;
-    updateService: (name: string, updated: ServiceItem) => void;
+    updateService: (name: string, updated: ServiceItem) => number;
     deleteService: (name: string) => void;
     renameCategory: (prevCategory: string, nextCategory: string) => void;
     moveCategory: (dragCategory: string, targetCategory: string) => void;
@@ -500,11 +501,36 @@ export const useCalendarStore = create<CalendarState>((set) => ({
             return withSyncedCatalog(state, nextCatalog);
         }),
 
-    updateService: (name, updated) =>
+    updateService: (name, updated) => {
+        const {serviceCatalog: prevCatalog, reservationMap, reservationHistory} = useCalendarStore.getState();
+        const nextCatalog = buildUpdatedServiceState(prevCatalog, name, updated);
+        const {nextReservationMap, updates} = buildServiceCatalogReservationUpdates(
+            reservationMap, name, updated.name, prevCatalog, nextCatalog,
+        );
+
         set((state) => {
-            const nextCatalog = buildUpdatedServiceState(state.serviceCatalog, name, updated);
-            return withSyncedCatalog(state, nextCatalog);
-        }),
+            const synced = withSyncedCatalog(state, nextCatalog);
+            return updates.length > 0
+                ? {...synced, reservationMap: nextReservationMap}
+                : synced;
+        });
+
+        // 변경된 예약 영속화: 로컬 모드는 스냅샷, 원격은 변경 건마다 PUT (전체 예약이 메모리에 있음)
+        if (updates.length > 0) {
+            syncReservationState(nextReservationMap, reservationHistory);
+            if (!shouldUseLocalDb()) {
+                for (const change of updates) {
+                    fetch('/api/reservations', {
+                        method: 'PUT',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify(change),
+                    }).catch(() => {});
+                }
+            }
+        }
+
+        return updates.length;
+    },
 
     deleteService: (name) =>
         set((state) => {

--- a/client/store/calendarStoreServiceHelpers.ts
+++ b/client/store/calendarStoreServiceHelpers.ts
@@ -1,4 +1,14 @@
 import type {ServiceItem} from '../utils/services';
+import {
+    buildCatalogMap,
+    calcEndTime,
+    joinServiceNames,
+    parseServiceString,
+    sumDurationMinutes,
+    sumPrice,
+} from '../utils/services';
+import {hasCompletedPayment} from '../features/reservations/model';
+import type {Reservation, ReservationMap} from '../utils/reservations';
 import {groupCatalogByCategory, reorder} from './calendarStoreHelpers';
 
 export function buildAddedServiceState(serviceCatalog: ServiceItem[], item: ServiceItem) {
@@ -76,4 +86,98 @@ export function buildMovedServiceInCategoryState(
     const insertIndex = dragIndex < targetIndex ? targetIndex - 1 : targetIndex;
     nextCatalog.splice(insertIndex, 0, movedWithCategory);
     return nextCatalog;
+}
+
+/* ------------------------------------------------------------------ */
+/*  서비스 변경 → 기존 예약 일괄 반영                                   */
+/* ------------------------------------------------------------------ */
+
+export interface ReservationServiceUpdate {
+    prev: Reservation;
+    updated: Reservation;
+}
+
+function localTodayKey(): string {
+    const now = new Date();
+    const m = String(now.getMonth() + 1).padStart(2, '0');
+    const d = String(now.getDate()).padStart(2, '0');
+    return `${now.getFullYear()}-${m}-${d}`;
+}
+
+function minutesBetween(startTime: string, endTime: string): number {
+    const [sh, sm] = startTime.split(':').map(Number);
+    const [eh, em] = endTime.split(':').map(Number);
+    return (eh * 60 + em) - (sh * 60 + sm);
+}
+
+// '앞으로의 미결제 예약'만 대상: 오늘 이후 + active + 결제·완료 전
+function isApplicableReservation(reservation: Reservation, todayKey: string): boolean {
+    const status = reservation.status ?? 'active';
+    if (status !== 'active') return false;
+    if (reservation.date < todayKey) return false;
+    if (hasCompletedPayment(reservation)) return false;
+    return true;
+}
+
+/**
+ * 서비스 카탈로그의 소요시간/가격(또는 이름) 변경을 기존 예약에 일괄 반영한다.
+ * - 대상: 오늘 이후의 active·미결제 예약 중 해당 서비스를 포함한 건.
+ * - 수동조정 보존: 저장된 가격이 '구 카탈로그 합계'와 다르면 가격 유지,
+ *   저장된 소요시간이 '구 카탈로그 합계'와 다르면 종료시간 유지.
+ */
+export function buildServiceCatalogReservationUpdates(
+    reservationMap: ReservationMap,
+    originalName: string,
+    updatedName: string,
+    prevCatalog: ServiceItem[],
+    nextCatalog: ServiceItem[],
+): {nextReservationMap: ReservationMap; updates: ReservationServiceUpdate[]} {
+    const oldCatalogMap = buildCatalogMap(prevCatalog);
+    const newCatalogMap = buildCatalogMap(nextCatalog);
+    const oldKnownNames = new Set(prevCatalog.map((s) => s.name));
+    const todayKey = localTodayKey();
+
+    const updates: ReservationServiceUpdate[] = [];
+    const nextReservationMap: ReservationMap = {};
+
+    for (const [dateKey, reservations] of Object.entries(reservationMap)) {
+        let dateChanged = false;
+        const nextList = reservations.map((reservation) => {
+            if (!isApplicableReservation(reservation, todayKey)) return reservation;
+
+            const names = parseServiceString(reservation.service, oldKnownNames);
+            if (!names.includes(originalName)) return reservation;
+
+            const oldTotalPrice = sumPrice(names, oldCatalogMap);
+            const oldTotalDuration = sumDurationMinutes(names, oldCatalogMap);
+            const priceIsManual = (reservation.price ?? 0) !== oldTotalPrice;
+            const durationIsManual = minutesBetween(reservation.startTime, reservation.endTime) !== oldTotalDuration;
+
+            const newNames = names.map((name) => (name === originalName ? updatedName : name));
+            const nextService = joinServiceNames(newNames);
+            const nextPrice = priceIsManual ? (reservation.price ?? 0) : sumPrice(newNames, newCatalogMap);
+            const nextEndTime = durationIsManual
+                ? reservation.endTime
+                : calcEndTime(reservation.startTime, sumDurationMinutes(newNames, newCatalogMap));
+
+            if (nextService === reservation.service
+                && nextPrice === (reservation.price ?? 0)
+                && nextEndTime === reservation.endTime) {
+                return reservation;
+            }
+
+            const updated: Reservation = {
+                ...reservation,
+                service: nextService,
+                price: nextPrice,
+                endTime: nextEndTime,
+            };
+            updates.push({prev: reservation, updated});
+            dateChanged = true;
+            return updated;
+        });
+        nextReservationMap[dateKey] = dateChanged ? nextList : reservations;
+    }
+
+    return {nextReservationMap, updates};
 }

--- a/index.md
+++ b/index.md
@@ -105,7 +105,7 @@ hair_reservations/
 | `calendarStoreDesignerHelpers.ts` | 디자이너 상태 빌더 (add, update, delete) |
 | `calendarStoreReservationHelpers.ts` | 예약 상태 빌더 (reservationMap 조작) |
 | `calendarStoreOverlayHelpers.ts` | 오버레이(모달) 상태 관리 |
-| `calendarStoreServiceHelpers.ts` | 서비스 카탈로그 상태 빌더 |
+| `calendarStoreServiceHelpers.ts` | 서비스 카탈로그 상태 빌더 + 서비스 변경(소요시간·가격·이름) 시 앞으로의 미결제 예약 일괄 반영(`buildServiceCatalogReservationUpdates`, 수동조정 건 보존) |
 | `calendarStoreStoreSettingsHelpers.ts` | 매장 설정 상태 빌더 |
 | `toastStore.ts` | 토스트 알림 |
 

--- a/plan.md
+++ b/plan.md
@@ -380,6 +380,34 @@ Phase 1(API 이전) 먼저 — 위험이 낮고 즉시 경계가 깔끔해짐. P
 
 ---
 
+# 서비스 변경 → 기존 예약 일괄 반영
+
+> **진행 현황 (2026-06-21, 진행 중)**: 서비스 관리에서 소요시간/가격 변경 시 앞으로의 미결제 예약에 일괄 반영.
+
+## 배경 / 문제
+- 예약은 서비스를 `service`(이름 문자열, `+`로 멀티 결합) + `price`/`endTime` **스냅샷**으로 저장(생성 시점 카탈로그 값 복사). 카탈로그를 바꿔도 기존 예약은 그대로.
+- `loadPageData`는 매장의 **전체 예약**을 날짜 필터·limit 없이 로드 → 클라이언트 스토어 `reservationMap`에 전 예약이 있음 → **클라이언트 스토어에서 일괄 재계산**해도 누락 없음.
+
+## 결정 (사용자 확인)
+- **적용 범위**: 앞으로의 미결제 예약만 — `date >= 오늘` AND `status === 'active'` AND `!hasCompletedPayment`. 과거·완료·결제·취소·노쇼 보존.
+- **변경 대상**: 가격·소요시간(종료시간) 모두 재계산. 이름 변경 시 예약의 service 문자열도 갱신(라벨 일관성).
+- **수동 수정건 보존**: 저장된 `price`가 (구 카탈로그 기준 합계)와 다르면 수동조정으로 보고 가격 유지. `endTime-startTime`이 구 카탈로그 합계 소요시간과 다르면 시간 유지.
+
+## 구현
+- `store/calendarStoreServiceHelpers.ts`: 순수 헬퍼 `buildServiceCatalogReservationUpdates(reservationMap, originalName, updatedName, prevCatalog, nextCatalog)` → `{nextReservationMap, updates: {prev, updated}[]}`.
+- `store/calendarStore.ts` `updateService`: 카탈로그 갱신과 함께 예약 재계산 적용 + 영속화(로컬=스냅샷, 원격=변경 예약마다 `PUT /api/reservations`). 반영 건수 반환.
+- `components/settings/ServiceManageSection.tsx`: 저장 토스트에 반영 건수 표시.
+
+## 범위 밖 / 주의
+- 소요시간 변경으로 종료시간이 밀리면 다른 예약과 겹칠 수 있음(이 앱은 중복예약 허용 — 데이터 무결성 문제 없음). 별도 차단 안 함.
+- 서버 측 일괄 엔드포인트는 만들지 않음(전체 예약이 클라이언트에 로드되므로 기존 PUT 경로 재사용).
+
+## 검증
+- 타입체크 + 빌드 그린.
+- 가격만/시간만/둘다 변경, 멀티서비스 예약, 수동조정 예약 보존, 과거·완료·결제 예약 불변, 게스트(로컬) 모드 동작.
+
+---
+
 # 멤버(staff)에게 네이버예약 연동 차단
 
 > **진행 현황 (2026-06-21, 진행 중)**: 네이버 동기화 기능 잔여 노출(알림 벨·충돌 자동감지·충돌 모달)을 오너 전용으로 정리.


### PR DESCRIPTION
## 배경
예약은 서비스를 `service`(이름 문자열) + `price`/`endTime` **스냅샷**으로 저장하므로, 서비스 관리에서 소요시간/가격을 바꿔도 기존 예약은 반영되지 않았습니다. 이를 **앞으로의 미결제 예약에 일괄 반영**합니다.

## 동작 (결정 사항)
- **적용 범위**: `오늘 이후` + `status=active` + `결제·완료 전` 예약만. 과거·완료·결제·취소·노쇼는 불변(매출 기록 보존).
- **재계산 대상**: 가격·종료시간(소요시간) 모두. 멀티서비스(`컷+펌`)는 변경 서비스만 반영해 합산. 이름 변경 시 예약 `service` 문자열도 갱신.
- **수동 수정건 보존**: 저장된 가격이 구 카탈로그 합계와 다르면 가격 유지, 소요시간도 동일 기준으로 유지.

## 변경
- `store/calendarStoreServiceHelpers.ts` — 순수 헬퍼 `buildServiceCatalogReservationUpdates` 추가
- `store/calendarStore.ts` — `updateService`가 카탈로그 갱신 + 예약 재계산 + 영속화(로컬=스냅샷 / 원격=변경 건마다 `PUT /api/reservations`), 반영 건수 반환
- `components/settings/ServiceManageSection.tsx` — 저장 토스트에 반영 건수 표시
- `package.json` 0.3.1 → 0.4.0 (minor)

## 설계 근거
`loadPageData`가 매장 전체 예약을 날짜 필터 없이 로드 → 클라이언트 스토어에 전 예약이 있으므로, 별도 서버 일괄 엔드포인트 없이 스토어 재계산 + 기존 PUT 경로로 누락 없이 완전.

## 범위 밖
- 소요시간 증가로 종료시간이 밀려 다른 예약과 겹칠 수 있으나, 이 앱은 중복예약을 허용(클러스터 표시)하므로 무결성 문제 없음 → 별도 차단 안 함.

## 검증
- `npx tsc --noEmit` 통과, `next build` 그린
- 기본/수동보존/완료·과거 제외/멀티서비스/이름변경 케이스 로직 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjLqsd3ocxzFmiX2xeUUKX)_