### PR TITLE
fix: 알림 레이어 고객명·담당자명을 변경된 이름으로 동기화

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.15.3",
+    "version": "0.15.4",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/store/calendarStore.ts
+++ b/client/store/calendarStore.ts
@@ -887,20 +887,12 @@ export const useCalendarStore = create<CalendarState>((set) => ({
         set({syncNotifications: loadSyncNotifications()});
     },
 
+    // 알림에 박제된 고객명·담당자명을 현재 데이터와 동기화한다.
+    // 빈 값 보정뿐 아니라 '이름 변경'도 반영(현재 이름과 다르면 갱신).
     patchNotificationNames: () =>
         set((state) => {
             const assigneeById = new Map(state.assignees.map((d) => [d.id, d.name]));
             const allReservations = Object.values(state.reservationMap).flat();
-
-            const needsPatch = state.syncNotifications.some((n) => {
-                if (!n.customerName || !n.appointmentDate || !n.appointmentTime) return true;
-                if (!n.assigneeName || n.assigneeName === '미지정') {
-                    const reservation = allReservations.find((r) => r.id === n.reservationId);
-                    if (reservation?.assigneeId && assigneeById.has(reservation.assigneeId)) return true;
-                }
-                return false;
-            });
-            if (!needsPatch) return {};
 
             let changed = false;
             const next = state.syncNotifications.map((n) => {
@@ -908,12 +900,18 @@ export const useCalendarStore = create<CalendarState>((set) => ({
                 if (!reservation) return n;
                 const customer = state.customerMap[reservation.customerId];
                 const patch: Partial<typeof n> = {};
-                if (!n.customerName && customer?.name) patch.customerName = customer.name;
+                // 고객명: 현재 고객명과 다르면 갱신(빈 값·플레이스홀더 보정 + 이름 변경 반영).
+                // 고객을 못 찾으면 기존 스냅샷 유지(빈 값으로 덮지 않음).
+                if (customer?.name && n.customerName !== customer.name) patch.customerName = customer.name;
                 if (!n.appointmentDate && reservation.date) patch.appointmentDate = reservation.date;
                 if (!n.appointmentTime && reservation.startTime) patch.appointmentTime = reservation.startTime;
-                if ((!n.assigneeName || n.assigneeName === '미지정') && reservation.assigneeId) {
+                // 담당자명: 배정 담당자의 현재 이름과 다르면 갱신, 미배정이면 '미지정'.
+                // 담당자 목록이 아직 안 들어왔으면(name 미해석) 기존 값 유지.
+                if (reservation.assigneeId) {
                     const name = assigneeById.get(reservation.assigneeId);
-                    if (name) patch.assigneeName = name;
+                    if (name && n.assigneeName !== name) patch.assigneeName = name;
+                } else if (n.assigneeName !== '미지정') {
+                    patch.assigneeName = '미지정';
                 }
                 if (Object.keys(patch).length === 0) return n;
                 changed = true;

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ hair_reservations/
 | `/login` | `login.tsx` | 로그인 (Google, Kakao, Naver OAuth) + 게스트 진입. 초대 링크(`?invite=CODE`) 코드 자동입력, 인앱 브라우저(WebView) 감지 시 안내 배너 + 카카오 우선 노출, 로고→루트 링크 |
 | `/logout` | `logout.tsx` | 로그아웃 후 `/login`으로 리다이렉트 |
 | `/mypage` | `mypage.tsx` | 계정 관리 (프로필, 연결된 SNS, 로그아웃, 회원탈퇴) |
-| `/settings/[tab]` | `settings/[tab].tsx` → `settings.tsx` | 설정 (탭: revenue/point/store/service/assignee/member/sns/naver) |
+| `/settings/[tab]` | `settings/[tab].tsx` → `settings.tsx` | 설정 (탭: revenue/point/membership/service/assignee/store/member/sns/naver) |
 | `/address` | `address.tsx` | 고객 명단 |
 | `/onboarding` | `onboarding/index.tsx` | 신규 매장 초기 설정 (로그인 사용자). 온보딩 완료자는 이전 페이지로 리다이렉트 |
 | `/onboarding/guest` | `onboarding/guest.tsx` | 게스트 온보딩 (index 컴포넌트 재사용, 경로로 분기) |
@@ -64,7 +64,7 @@ hair_reservations/
 | `modals/` | 전역 오버레이 (layout과 분리) | `NaverSyncConflictModal.tsx`[^2](+`.styles.ts`), `CustomerMergeSuggestionModal.tsx`[^3], `GuestMigrationLayer.tsx`(게스트→계정 병합 레이어), `ConsentDpaLayer.tsx`(처리위탁 DPA 동의 레이어 — "보기"는 `PolicyViewLayer`) |
 | `policy/` | 정책 문서 표시 | `PolicyPage.tsx`(앱 인라인 페이지 레이아웃, mypage `StyledContainer` 사용), `PolicyViewLayer.tsx`(약관 "보기" — 공통 `ModalStyles` 레이어), `policyCss.ts`(인라인·풀페이지 공유 CSS + 독립 HTML 생성 `renderPolicyHtml`)[^20] |
 | `onboarding/` | 온보딩 스텝 분리 | `OnboardingStep1~5.tsx`, `onboarding-types.ts`, `onboarding-step-styles.tsx` |
-| `settings/` | 설정 화면 섹션 | `StoreManageSection.tsx`, `ServiceManageSection.tsx`, `AssigneeManageSection.tsx`, `PointManageSection.tsx`(+`PointSettingsTab`/`PointAdjustTab`/`PointHistoryTab`), `MemberSection.tsx`, `SNSLinkingSection.tsx`[^14], `NaverBookingSection.tsx`[^15], `settings-styles.ts`[^16]. 큰 섹션은 본체와 `*.styles.ts` 분리 |
+| `settings/` | 설정 화면 섹션 | `StoreManageSection.tsx`(매장정보+업종+적립금/회원권 시스템 토글), `ServiceManageSection.tsx`, `AssigneeManageSection.tsx`, `PointManageSection.tsx`(+`PointSettingsTab`/`PointAdjustTab`/`PointHistoryTab`), `MembershipManageSection.tsx`(회원권 상품 CRUD + 고객 발급·잔여 조회)[^21], `MemberSection.tsx`, `SNSLinkingSection.tsx`[^14], `NaverBookingSection.tsx`[^15], `settings-styles.ts`[^16]. 큰 섹션은 본체와 `*.styles.ts` 분리 |
 | `settings/revenue/` | 매출 관리 | `RevenueSection.tsx`(+`.styles.ts`, 순수 차트 로직은 `revenueChartUtils.ts`), `RevenueChartGrid.tsx`, `RevenueKpiGrid.tsx`, `RevenueFilters.tsx`, `RevenueMetricModal.tsx`, `RevenueReservationList.tsx`, `RevenueDailyList.tsx`, `RevenueDailyDetailModal.tsx`, `revenue-styles.ts`/`revenue-chart-styles.ts` |
 | `address/` | 고객 명단 | `AddressContent.tsx`, `AddressCustomerRow.tsx`, `AddressCustomerSummary.tsx`, `AddressCustomerRecharge.tsx` |
 | `ui/` | 공통 UI | `Buttons.tsx`, `Icons.tsx`, `PageHero.tsx`, `SeoHead.tsx`, `ServiceChip.tsx`, `AssigneeLabel.tsx`/`ColorTag.tsx`(담당자 색상 배지), `LabelBadge.tsx`(tone×shape 배지), `ReservationStatusBadge.ts`(예약 상태 배지), `ReservationInfoCard.tsx`, `CsFooter.tsx`(고객센터 푸터 공통), `GuestNotice.tsx`, `FieldError.tsx`, `FormControls.ts` |
@@ -81,13 +81,15 @@ hair_reservations/
 [^18]: app 라우터에 `app/` 디렉터리(NextAuth route handler)가 있으면 잘못된 경로의 404를 app 라우터가 처리하므로, `app/not-found.tsx`(+최소 `app/layout.tsx`)에 디자인 가이드 동일 스타일 + 자동 리다이렉트를 구현. `pages/404.tsx`는 pages 라우터 폴백용으로 동일 UI 유지
 [^19]: 약관 버전은 `utils/terms.ts`의 `CURRENT_TERMS_VERSION`(날짜 기반 `YYYY-MM-DD`)으로 관리. 동의 여부 판정 — 게스트: `getGuestTermsVersion()===CURRENT_TERMS_VERSION`(localStorage), 로그인: 세션 `termsVersion===CURRENT_TERMS_VERSION`. 미동의 시 게이트 노출, 동의 시 게스트는 localStorage(`setGuestTermsAgreed`)·로그인은 `POST /api/consent`(→ `User.agreedTermsVersion`/`agreedTermsAt` 갱신) 후 세션 갱신. `/consent/<경로>` 형태로 복귀 경로를 슬래시로 전달(`next.config.mjs` rewrite). Aside 하단에 이용약관/개인정보처리방침 링크 제공, 게스트 로그아웃 시 동의 플래그도 초기화. **동의 항목 구성** — 게스트: 이용약관 + 개인정보 수집·이용(서버 위탁 없음). 로그인(SNS 연동, 서버 보관): 위 2개 + **개인정보 처리위탁(DPA)** 별도 항목. 게스트가 SNS 연동한 경우는 이미 받은 동의는 건너뛰고 DPA만 `_app.tsx`의 앱 레벨 `ConsentDpaLayer`로 추가 수령. 각 항목 "보기"는 `PolicyViewLayer`로 표시
 [^20]: **정책 문서 단일 소스 구조** — 법률 본문은 문서당 파일 하나(`content/policies/{terms,privacy,dpa}.ts`)에만 두고, 제목 메타는 `content/policies/index.ts` 레지스트리(`navTitle`/`docTitle`/`body`)로 관리. 이 본문을 **인라인 페이지**(`/terms`·`/privacy`·`/dpa` → `PolicyPage`)·**보기 레이어**(`PolicyViewLayer`)·**풀페이지**(`/policies/:slug` → `api/policies/[slug].ts`가 `renderPolicyHtml`로 독립 HTML 응답)가 모두 공유 → 한 곳만 고치면 전체 반영. 공통 CSS도 `components/policy/policyCss.ts`(`POLICY_VARS_*`·`POLICY_ELEMENT_CSS`)에서 styled-components(인라인)·`<style>`(풀페이지) 양쪽이 같은 문자열 사용. DPA는 서버 보관(수탁) 개시 시점에 필요하므로 SNS 연동(인증) 이후에만 노출
+[^21]: 회원권 관리는 `Store.useMembershipSystem` 토글 ON일 때만 aside 메뉴·`/settings/membership` 탭 노출. 상품(횟수/기간권) CRUD + 고객 발급·수동 차감까지 구현(Phase 1·2). **결제 연동(예약 결제수단으로 자동 차감, `PaymentMethod.membership`)은 미구현(Phase 3 예정)**
 
 ### 도메인 모델 (`client/features/`)
 
 | 파일 | 모델 | 핵심 필드 |
 |------|------|----------|
 | `reservations/model.ts` | `Reservation` | id, date, startTime/endTime, customerId, assigneeId?, service, status[^4], price, naverBookingId?, channel[^5] |
-| `customers/model.ts` | `Customer` | id, name, tel, points, memoTags, pointHistories, allergyNote, claimNote, preferenceNote |
+| `customers/model.ts` | `Customer` | id, name, tel, points, memoTags, pointHistories, allergyNote, claimNote, preferenceNote. 헬퍼: `formatTel`(표시 000-0000-0000)·`normalizeTel`(저장용 숫자만, 단일 출처) |
+| `memberships/model.ts` | `MembershipProduct`/`CustomerMembership` | 회원권(횟수·기간권, 적립금과 별개). product: totalCount?/validDays?/price/status, 발급분: remainingCount/expiresAt?/status |
 | `assignees/model.ts` | `Assignee` | id, name, schedule(7일), status[^6], color, phone |
 | `services/model.ts` | `ServiceItem` | name, durationMinutes, category, price |
 | `services/default-services.ts` | - | 업종(ShopType) union + 업종별 기본 서비스·카테고리 색상(Partial, 온보딩용) |
@@ -184,7 +186,10 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `assignees.ts` | `/api/assignees` | GET(staff) / PUT(owner) / DELETE(owner) | - | 담당자 CRUD + 일정(AssigneeSchedule) upsert. DELETE는 영구 삭제(분리): 예약은 assigneeId=null로 보존, 스케줄은 cascade 삭제 |
 | `assignees-merge.ts` | `/api/assignees/merge` | POST | owner | 담당자 병합 (source→target 예약 재배정 후 source 삭제) |
 | `services.ts` | `/api/services` | GET(staff) / PUT(owner) | - | 서비스 카탈로그 관리 |
-| `store.ts` | `/api/store` | GET(staff) / PUT(owner) | - | 매장 설정 (영업시간, 휴무일, 포인트 설정) |
+| `store.ts` | `/api/store` | GET(staff) / PUT(owner) | - | 매장 설정 (영업시간, 휴무일, 포인트 설정, 업종, **적립금/회원권 시스템 토글** `usePointSystem`/`useMembershipSystem`) |
+| `memberships.ts` | `/api/memberships` | GET(staff) / POST·PUT·DELETE(owner) | - | 회원권 상품(횟수/기간권) CRUD + 보유 목록 조회 |
+| `membership-issue.ts` | `/api/membership-issue` | POST(staff) | - | 고객에게 회원권 발급/취소 (상품 스냅샷 → CustomerMembership) |
+| `membership-use.ts` | `/api/membership-use` | POST(staff) | - | 회원권 횟수 수동 차감/복원 (결제 흐름과 독립, MembershipUsage 기록) |
 | `onboarding.ts` | `/api/onboarding` | POST | owner | 매장 초기 설정 (legacyId 부여). **이미 담당자/서비스가 있으면 409 `ALREADY_SETUP` 거부** |
 | `migrate-local.ts` | `/api/migrate-local` | POST | owner | 게스트 로컬 데이터 전체 이전 (services/assignees/customers/reservations). 기존 데이터 있으면 409 + `confirm` 플래그로 병합 진행 |
 | `naver-booking-sync.ts` | `/api/naver-booking-sync` | POST | owner | 네이버 예약 동기화[^9] |
@@ -271,6 +276,9 @@ Store ─┬── Customer ──── Reservation ──── ReservationPay
        │       └──────── Reservation (optional)
        │
        ├── Service
+       ├── MembershipProduct ─┬─ MembershipProductService (N:N Service)
+       │       └── CustomerMembership ── MembershipUsage
+       ├── CouponProduct ──── CustomerCoupon
        ├── Membership ── User ──┬─ AuthAccount (1유저 N프로바이더)
        │                          └─ GmailConnection (1유저 1연동, 로그인 계정과 분리)
        ├── StoreBusinessHour (7일)
@@ -278,6 +286,9 @@ Store ─┬── Customer ──── Reservation ──── ReservationPay
        ├── StorePointSettings
        └── Invite
 ```
+
+> **Store 기능 토글**: `usePointSystem`/`useMembershipSystem`/`useCouponSystem`(모두 `@default(false)`). 적립금·회원권은 토글 → aside 메뉴/페이지까지 연동 완료. **쿠폰은 DB 모델(`CouponProduct`/`CustomerCoupon`, 마이그레이션 `0007`)과 토글 컬럼만 존재 — API·UI·토글 배선·`PaymentMethod.coupon`은 미구현(예정).**
+> **결제 연동 현황**: `PaymentMethod` enum엔 아직 `membership`·`coupon` 없음 → 회원권·쿠폰 모두 **예약 결제수단 차감(각 Phase 3) 미구현**. 회원권 차감은 현재 `membership-use`(수동)만.
 
 ### 주요 Enum
 

--- a/index.md
+++ b/index.md
@@ -70,7 +70,7 @@ hair_reservations/
 | `ui/` | 공통 UI | `Buttons.tsx`, `Icons.tsx`, `PageHero.tsx`, `SeoHead.tsx`, `ServiceChip.tsx`, `AssigneeLabel.tsx`/`ColorTag.tsx`(담당자 색상 배지), `LabelBadge.tsx`(tone×shape 배지), `ReservationStatusBadge.ts`(예약 상태 배지), `ReservationInfoCard.tsx`, `CsFooter.tsx`(고객센터 푸터 공통), `GuestNotice.tsx`, `FieldError.tsx`, `FormControls.ts` |
 | `account/` | 계정 관련 모달 | `AccountDeleteModal.tsx` |
 
-[^1]: 네이버 동기화 알림 벨 아이콘 + 알림 목록 패널. 미읽음 카운트는 `!read || (conflict && !confirmed)` 조건으로 계산
+[^1]: 네이버 동기화 알림 벨 아이콘 + 알림 목록 패널. 미읽음 카운트는 `!read || (conflict && !confirmed)` 조건으로 계산. 알림에 박제된 고객명·담당자명은 `patchNotificationNames`(calendarStore)가 데이터 로드/변경 시 현재 이름과 다르면 자동 동기화(이름 변경 반영, 미배정은 '미지정')
 [^2]: 네이버 예약 시간 중복(conflict) 해결 모달. pending → deferred/confirmed 상태 전이
 [^3]: 동명이인·유사 고객 병합 제안 모달 (게스트 모드에서는 비활성)
 [^3a]: 고객 상세의 하위 UI 분리 — 적립금 이력 아이템(`PointHistoryItem` 공용), 메모 태그 섹션, 이력 더보기 모달, 병합 분리 확인 모달

--- a/plan.md
+++ b/plan.md
@@ -9,177 +9,70 @@
 > 결정(사용자): 할인 방식 **정액+정률 둘 다**, 발급 **직접발급+코드형 둘 다**, 결제는 **결제수단에 `coupon` 추가해 차감**.
 > 위치: 적립금(금액)·회원권(횟수/기간)에 이어 **할인**을 담당. 회원권 시스템 패턴을 그대로 따른다.
 
+### 진행 현황 (2026-06-29 갱신)
+- ✅ **DB 모델 선반영**: `CouponProduct`/`CustomerCoupon` + `Store.useCouponSystem` 토글 컬럼 (마이그레이션 `0007_coupon_models`).
+- ❌ 나머지 미착수: 토글 배선(`/api/store`·StoreManageSection·calendarStore — 현재 store API는 적립금/회원권 토글만 처리), CRUD API, aside '쿠폰 관리' 메뉴/아이콘, `/settings/coupon` 탭, 발급/코드 클레임, **`PaymentMethod.coupon` enum 추가**, 결제 연동.
+
 ### 현황 조사 결과
 - 결제 = `ReservationPaymentEntry`(method `PaymentMethod` + amount Int, 예약당 다건=분할결제). 결제 UI는 `ReservationDetailPaymentLayer`(method 셀렉트 + 금액 + 추가/삭제).
 - `PaymentMethod` enum에 이미 `discount`(할인·수동), `points`(적립금) 존재. 프런트 union(`reservations/model.ts`)엔 '할인'·'적립금' 라벨.
 - 토글 패턴(`usePointSystem`/`useMembershipSystem`) + aside 게이팅 + `/settings/[tab]` 디스패치 + `CustomerAutocomplete`(발급 고객검색) 재사용 가능.
 
 ### 설계 (회원권 미러링)
-- **Store.useCouponSystem Boolean @default(false)** — 매장관리 토글.
-- **CouponProduct**(쿠폰 정의): id, legacyId, storeId, name, `discountType`(amount|rate), `discountValue Int`(원 또는 %), `maxDiscount Int?`(정률 상한), `minOrderAmount Int?`(최소 결제금액), `validDays Int?`(만료), `code String?`(있으면 코드형 — @@unique[storeId,code]), status(active|archived). @@unique[storeId,legacyId].
-- **CustomerCoupon**(고객 보유): id, legacyId, storeId, customerId, productId?, name 스냅샷, discountType/discountValue/maxDiscount/minOrderAmount 스냅샷, issuedAt, expiresAt?, usedAt?, reservationId?(사용처), status(active|used|expired|cancelled).
-- **PaymentMethod**에 `coupon` 추가(할인과 구분 — 추적되는 쿠폰 차감).
+- **Store.useCouponSystem Boolean @default(false)** — 매장관리 토글. (컬럼 생성 완료)
+- **CouponProduct**(쿠폰 정의): id, legacyId, storeId, name, `discountType`(amount|rate), `discountValue Int`(원 또는 %), `maxDiscount Int?`(정률 상한), `minOrderAmount Int?`(최소 결제금액), `validDays Int?`(만료), `code String?`(있으면 코드형 — @@unique[storeId,code]), status(active|archived). @@unique[storeId,legacyId]. (모델 생성 완료)
+- **CustomerCoupon**(고객 보유): id, legacyId, storeId, customerId, productId?, name 스냅샷, discountType/discountValue/maxDiscount/minOrderAmount 스냅샷, issuedAt, expiresAt?, usedAt?, reservationId?(사용처), status(active|used|expired|cancelled). (모델 생성 완료)
+- **PaymentMethod**에 `coupon` 추가(할인과 구분 — 추적되는 쿠폰 차감). (미반영)
 
 ### 구현 단계
-1. **Phase 1 — 토글 + 모델 + 상품 관리**: Store 토글 + CouponProduct/CustomerCoupon 마이그레이션, CRUD API, 매장관리 체크박스, aside '쿠폰 관리' 메뉴/아이콘, `/settings/coupon` 상품 탭(정액/정률·코드·만료·최소금액).
+1. **Phase 1 — 토글 + 모델 + 상품 관리**: ~~CouponProduct/CustomerCoupon 마이그레이션~~(완료) + Store 토글 배선, CRUD API, 매장관리 체크박스, aside '쿠폰 관리' 메뉴/아이콘, `/settings/coupon` 상품 탭(정액/정률·코드·만료·최소금액).
 2. **Phase 2 — 발급**: 직접 발급(`CustomerAutocomplete`로 고객 검색) + 코드형 클레임(코드 입력→해당 고객에 CustomerCoupon 발급), 보유 목록, 고객 상세에 보유 쿠폰 표시.
 3. **Phase 3 — 결제 연동(머니플로우, 신중)**: 결제 레이어 method에 '쿠폰' 추가 → 보유 쿠폰 선택 → 할인액 자동계산(정액=value, 정률=round(total×%) capped maxDiscount, minOrderAmount 검증) → `ReservationPaymentEntry(coupon)` 기록 + CustomerCoupon used 처리(트랜잭션). 매출 집계(RevenueFilters/charts)에 쿠폰 할인 반영.
-   - ⚠️ 회원권 Phase 3b(결제 자동차감)와 같은 핵심 머니플로우 영역 → 함께/테스트 동반 권장.
+   - ⚠️ 회원권 Phase 3(결제 자동차감)와 같은 핵심 머니플로우 영역 → 함께/테스트 동반 권장.
 
 ### 리스크/주의
 - 정률 반올림·상한·최소금액 경계, 분할결제와의 합계 정합성.
 - 결제 차감은 트랜잭션(예약 결제 ↔ 쿠폰 used). 만료/중복사용/타고객 쿠폰 방어.
-- 새 테이블 마이그레이션 → 운영 반영은 0006(회원권)처럼 `migrate deploy` 필요.
-
----
-
-## 진행 중 — 고객 연락처 저장 포맷 통일 (DB=숫자만, 표시=000-0000-0000)
-
-> 결정(사용자): **연락처는 DB에 숫자만 저장, 화면엔 패턴(000-0000-0000)으로 노출.**
-
-### 현황 조사 결과
-- `Customer.tel String` 단일 컬럼. 쓰기 경로마다 정규화가 달라 **DB에 포맷이 섞여 저장됨**(운영 DB에서 하이픈 포함 행 실재 확인).
-  - 주소록 추가(`CustomerAddModal`): `tel.trim().replace(/\D/g,'')` → 숫자만 ✅
-  - 예약 등록 신규 고객(`useReservationCreateForm` 208행): `newCustomerTel.trim()` → 입력 원형 ⚠️
-  - 고객 상세 수정(`CustomerDetail` 254행): `editForm.tel.trim()` → 입력 원형 ⚠️
-  - 서버 `customers.ts`(POST 44·PUT 119/130): `customer.tel` 그대로 저장(정규화 없음) ⚠️
-  - 시드 데이터: 전부 숫자만 ✅
-- 표시: `formatTel`(`features/customers/model.ts`)이 이미 숫자 추출 후 10/11자리 패턴 변환 → **표시 쪽은 이미 정상**(추가 작업 거의 없음).
-- 부작용: 검색(`tel.includes`)·중복 병합 추천이 포맷 불일치로 누락.
-
-### 구현 항목
-1. **공용 헬퍼** `normalizeTel(tel) = tel.replace(/\D/g,'')`를 `features/customers/model.ts`에 추가(`formatTel` 옆, 단일 출처).
-2. **클라 쓰기 통일**(로컬DB 모드 대응): `CustomerAddModal`·`useReservationCreateForm`·`CustomerDetail` 저장 직전 `normalizeTel` 사용.
-3. **서버 쓰기 통일**(원격 모드 길목 방어): `server/api/customers.ts` POST·PUT에서 `tel` 저장 시 `normalizeTel` 적용.
-4. **기존 데이터 1회성 정규화**(운영 DB): `UPDATE "Customer" SET tel = regexp_replace(tel, '\D', '', 'g') WHERE tel ~ '[^0-9]';` — 사용자가 Supabase에서 실행.
-
-### 리스크
-- 표시는 `formatTel`이 비표준 길이(10/11 아님)면 원본 반환 → 잘못된 번호는 그대로 보임(의도된 폴백).
-- 서버/클라 양쪽 정규화 → 동작 변화는 "저장 포맷 통일"뿐, 검증/필수 로직은 유지.
-
----
-
-## 진행 중 — 업종별 라벨 시스템 (매장관리 직종 표시·수정 + 담당자/서비스 문구 전환)
-
-> 매장 관리에 직종(shopType) 표시·수정 추가, 직종에 맞게 "담당자"·"서비스" 문구가 화면에 반영되게.
-> 배경: 업종 중립화(rename) 후속. 음식점 등 타 업종에서도 자연스럽게 쓰도록.
-
-### 현황 조사 결과
-- `shopType String?` (nullable, 필수 아님). 온보딩에서만 **다중 선택**(콤마 저장), 이후 수정 UI 없음. null-wipe 버그는 수정 완료(`4aa5df8`).
-- 현재 업종 목록 = 뷰티 5종뿐: `hair/nail/waxing/lash/skin`(+`etc`). 서버 `VALID_SHOP_TYPES`(onboarding.ts·migrate-local.ts)도 동일. 음식점·병원 없음.
-- 라벨 문구 분포: "담당자" ~33파일, "서비스" ~30+파일. **단 "서비스"의 상당수(terms.ts 26·privacy.ts 14·dpa.ts 5·about·maintenance)는 "(우리) 앱 서비스" 의미 → 라벨 아님, 치환 금지.** 진짜 라벨은 Assignee/ServiceManageSection·예약 폼·캘린더·매출 등.
-
-### 설계 결정
-1. **업종 확장**(사용자 확정): 음식점(food)·병원/의원(medical)·기타 등 타 업종 추가. 각 업종을 **category**로 묶고 category별 라벨셋 정의.
-
-   | category | 업종 | assignee 라벨 | service 라벨 |
-   |----------|------|--------------|-------------|
-   | beauty | 헤어/네일/왁싱/속눈썹/피부 | 담당자 | 시술 |
-   | food | 음식점 | 테이블 | 메뉴 |
-   | medical | 병원/의원 | 담당의 | 진료 |
-   | etc | 기타 | 담당자 | 서비스 |
-   (구체 라벨값은 구현 전 1차 확정)
-
-2. **다중/단일(사용자: "업종 성격 따라 다중 가능/불가")**: 라벨은 **category 기준**. 같은 category 내 세부업종 다중 허용(예: 헤어+네일), **cross-category 비허용**. → 매장관리에선 category 1개 선택(라벨 확정) + 같은 category 세부 다중. 온보딩 기존 다중 선택은 유지(같은 category 가정), 라벨은 primary(첫 업종)의 category로.
-
-3. **라벨 주입 메커니즘**: `features/store-settings/labels.ts`에 `getStoreLabels(shopType) → {assignee, service}` + category 매핑. `useStoreLabels()` 훅(calendarStore의 shopType 구독). 컴포넌트의 하드코딩 "담당자"/"서비스" → `labels.assignee`/`labels.service`. 합성문구는 템플릿(`${labels.assignee} 관리`).
-
-4. **적용 범위(단계)**:
-   - **Phase A(핵심)**: aside 메뉴, AssigneeManageSection·ServiceManageSection(제목·필드·placeholder), 예약 생성/상세 폼, 캘린더 헤더/범례.
-   - **Phase B(확장)**: 매출·모달·온보딩 등 나머지 라벨.
-   - **제외(영구)**: 약관/개인정보/DPA/about/maintenance의 "서비스"(앱 명칭). PageHero 영문 eyebrow(ASSIGNEE/SERVICE)는 유지.
-
-### 영향 파일 (예상)
-- 신규: `features/store-settings/labels.ts`, `useStoreLabels` 훅.
-- 수정: `onboarding-types.ts`(SHOP_TYPES 확장), 서버 `VALID_SHOP_TYPES`(onboarding.ts·migrate-local.ts), `StoreManageSection`(업종 표시·수정 UI), 라벨 치환 다수 컴포넌트.
-- DB: shopType 컬럼 그대로(문자열). 마이그레이션 불필요(값 종류만 확장).
-
-### 리스크
-- 약관 등 "서비스" 오치환 → 라벨 대상만 선별 치환(전수 find-replace 금지).
-- 다중 업종 시 라벨 결정 규칙 명확화(primary/category).
-- 음식점은 라벨만으론 부족(인원수·테이블 자원·회전시간은 별도 트랙) — 이번 범위는 **라벨/직종 표시까지만**.
 
 ---
 
 ## 진행 중 — 매장관리: 적립금/회원권 시스템 토글 + 회원권 풀 기능
 
 > 매장 관리에서 "적립금 시스템 사용"·"회원권 시스템 사용"을 켜면 aside 설정에 메뉴가 뜨고 페이지가 열린다.
-> 아이콘 교체(담당자=이름표/뱃지, 사용안내=전구)는 선행 완료(`be7fe49`).
+
+### 진행 현황 (2026-06-29 갱신)
+- ✅ **Phase 1(토글 + 메뉴/페이지)**: Store 토글 2개(`usePointSystem`/`useMembershipSystem`, 마이그레이션 `0005_store_feature_toggles`), `/api/store` GET/PUT·매퍼·calendarStore 연동, StoreManageSection 체크박스, Aside 메뉴 게이팅 + 회원권 메뉴/아이콘, `/settings/membership` 탭.
+- ✅ **Phase 2(모델 + 관리 UI)**: 4개 모델(`MembershipProduct`/`MembershipProductService`/`CustomerMembership`/`MembershipUsage`, 마이그레이션 `0006_membership_models`), API(`memberships.ts` 상품 CRUD·`membership-issue.ts` 발급/취소·`membership-use.ts` 수동 차감/복원), `MembershipManageSection` UI.
+- ❌ **Phase 3(결제 연동) 남음**: `PaymentMethod.membership` enum 추가, 예약 결제 시 회원권 선택→자동 차감(MembershipUsage 기록), 잔여/만료 검증, 고객 상세에 보유 회원권·이력 표시.
 
 ### 확정된 설계 결정 (사용자 확인)
-- **적립금 = 금액 / 회원권 = 비금액(횟수·기간)**. 금액권은 기존 적립금 충전(recharge)에 이미 있으므로 **별도로 안 만든다**(중복 방지). 적립금 화면 "충전/선불금" 라벨 정비는 회원권과 같이 진행.
+- **적립금 = 금액 / 회원권 = 비금액(횟수·기간)**. 금액권은 기존 적립금 충전(recharge)에 이미 있으므로 **별도로 안 만든다**(중복 방지).
 - **회원권**: 한 모델에 `횟수(옵션) + 만료(옵션)` 둘 다 담아 횟수권/기간권/복합 모두 표현. 서비스 **지정·전체 둘 다** 지원. 결제 시 **결제수단으로 차감 연동**. **선택적 만료**.
 - 적립금 토글 **기존 매장 기본값 = 꺼짐**(`default(false)`).
 - aside: 적립금 관리(기존 `point`)는 적립금 토글 ON일 때만, 회원권 관리(신규)는 회원권 토글 ON일 때만 노출.
 
-### 데이터 모델 (Prisma)
-- **Store**: `usePointSystem Boolean @default(false)`, `useMembershipSystem Boolean @default(false)`.
-- **MembershipProduct**(회원권 상품): id, storeId, legacyId(@@unique[storeId,legacyId]), name, `totalCount Int?`(횟수, null=무제한), `validDays Int?`(발급일+유효일수, null=무기한), `price Int`, `appliesToAllServices Boolean @default(true)`, status, services(MembershipProductService[]).
-- **MembershipProductService**: 회원권↔Service N:N(특정 서비스 지정 시).
-- **CustomerMembership**(고객 보유분): id, storeId, legacyId, customerId, productId?, name(스냅샷), `totalCount Int?`, `remainingCount Int?`, issuedAt, `expiresAt DateTime?`, status(active/expired/used_up/cancelled), usages.
-- **MembershipUsage**(차감/조정 이력): id, customerMembershipId, reservationId?, `delta Int`(음수=차감/양수=환불·발급), type(issue/use/adjust/refund), createdAt, memo.
-- **PaymentMethod** enum에 `membership` 추가.
-
-### 구현 단계
-1. **Phase 1 — 토글 + 메뉴/페이지 골격**(스키마: Store 토글 2개만): Store boolean 2개 + 마이그레이션, `/api/store` GET/PATCH·매퍼·클라 스토어 연동, StoreManageSection에 native 체크박스 2개, Aside 메뉴 게이팅 + 회원권 메뉴/아이콘 신설, `/settings/membership` 페이지 골격(탭 디스패치 등록), 적립금 라벨 정비. 로컬 PG 검증 → 커밋.
-2. **Phase 2 — 회원권 모델 + 관리 UI**: 위 4개 모델 + 마이그레이션, CRUD API(상품 발행/조회/수정/보관), `/settings/membership` 관리 화면(상품 목록·생성, 고객별 발급·잔여 조회).
-3. **Phase 3 — 결제 연동**: PaymentMethod.membership, 예약 결제 시 회원권 선택→차감(MembershipUsage 기록), 잔여/만료 검증, 고객 상세에 보유 회원권·이력 표시.
-
-### 리스크/주의
-- 새 테이블은 마이그레이션 → **운영 반영은 DB 접근 가능 시**(rename 배포 배치와 함께). 로컬 검증은 지금 가능.
+### 리스크/주의 (Phase 3)
 - 결제 차감은 트랜잭션으로(예약 결제 ↔ 회원권 차감 정합성). 만료/잔여 0 방어.
 
 ---
 
-## 완료 — seed ID 재매핑 버그 수정 + ESLint 툴체인 복구
+## 진행 중 — 업종별 라벨 시스템 (매장관리 직종 표시·수정 + 담당자/서비스 문구 전환)
 
-> 담당자 rename 소스 검증 중 발견. 커밋 `dee8700`(seed)·`4cc4ce8`(deps). 둘 다 rename 과 독립.
+> 매장 관리에 직종(shopType) 표시·수정 추가, 직종에 맞게 "담당자"·"서비스" 문구가 화면에 반영되게.
 
-### 1) seed 담당자 ID 재매핑 버그 (correctness) — 수정됨
-- **증상**: `prisma:seed` 시 `reservations.json`의 모든 예약이 `assigneeId=null`(미배정)로 들어가 담당자별 예약·매출이 통째로 빔.
-- **근본 원인(2중)**: ① `normalizeAssignees`·`normalizeReservationPayload`·`seedTestConflicts`가 같은 담당자 ID를 각자 독립 맵으로 재매핑 → 불일치(담당자 legacyId 1·2·3·4 vs 예약 130·140·145). ② `buildLegacyIdMap`이 `MAX_INT_32` 초과 ID 중복을 안 걸러 nextId 낭비·덮어씀.
-- **수정**: `buildLegacyIdMap` dedup + `loadAssigneeIdMap`(assignees.json 단일 출처·메모이즈)을 세 정규화 함수가 공유.
-- **검증**: 로컬 PG 시드 → 예약 54건 전부 유효 담당자 연결, dangling 0 (수정 전 0건 연결 → 후 54건).
+### 진행 현황 (2026-06-29 갱신)
+- ✅ **Phase A(핵심)**: `features/store-settings/labels.ts`(category 매핑·`getStoreLabels`·`sanitizeShopType`) + `hooks/useStoreLabels.ts` 구현. aside 메뉴·담당자/서비스 관리·예약 폼·캘린더 적용. 업종 확장(beauty/food/medical/fitness/class/pet/repair/space/counsel/etc) 반영 — 라벨 표는 index.md 참조.
+- 🔶 **Phase B(확장)**: 매출·모달·온보딩 등 나머지 라벨 — '단계적 확대' 진행 중.
+- 미결(이월): "시술"→"서비스" 명칭 통일 여부 — 현재 라벨 시스템이 beauty service 라벨을 '서비스'로 노출하므로 사실상 흡수. 별도 전수 치환은 불필요로 판단(필요 시 재검토).
 
-### 2) ESLint 툴체인 복구 (infra) — 수정됨
-- **증상**: `pnpm lint` 실행 자체 불가. eslint 10 에선 react 룰 `getFilename` 비호환, eslint 9 로 내리면 brace-expansion override(5.0.6 일괄)가 minimatch@3.x(1.x API) 를 깨뜨림(`expand is not a function`).
-- **수정**: eslint 10.4.1→9.39.4(next/plugin-react peer 정렬) + brace-expansion override 를 `brace-expansion@1: 1.1.12`(1.x 만 패치)로 정정. minimatch@10.x 는 5.0.6 자연 해석, ReDoS 패치 유지.
-- **검증**: `pnpm lint` 정상 실행. tsc·next build 통과.
-- **후속(미정)**: lint 가 드러낸 기존 코드 이슈 **22 errors·51 warnings**(주로 `react-hooks/set-state-in-effect`, `no-unused-vars`)는 별도 정리 필요.
-
----
-
-## 완료(최근) — 캘린더 타임라인: 영업시간 연동 + 표시 개선
-
-> 배포 완료. 상세는 git 히스토리(`d5a2333`·`4fdbba4`·`456750a` 외 `9ae39ab`·`ab7fe43`).
-
-- **A 영업시간 → 축 연동**: `getTimelineRange(viewType, businessHours)`(`utils/timelineRange.ts`) 신설. `Timeline`/`TimelineTitle`이 `storeSettings.businessHours` 구독. 모든 뷰 영업시간 그대로(패딩 0). 죽은 `store.time` 슬라이스 제거.
-- **B 표시/동작**: 1시간=100px(30분=50px) 단일화, 현재시간 바 드리프트 수정, 빈 곳 클릭 예약추가 좌표 수정(이전 구버전은 클릭 단위 불일치로 하단 클릭이 ~3h 어긋남 → 수정됨).
-- **실측(Playwright)**: 영업시간 변경 시 일/3일/주 축 반영, 빈 곳 클릭·드래그 이동 시작시각 모두 정확 확인.
-
----
-
-## 완료 — 디자이너 영구 삭제 (분리 삭제 방식)
-
-> 구현·빌드 검증 완료. 상세는 git 히스토리.
-> 결정: **디자이너만 분리 삭제** — 디자이너+스케줄은 제거하되 과거 예약은 `designerId` 미지정으로 보존. 절대 차단되지 않음(예약 cascade 삭제 X).
-> UI: "퇴직자" 섹션 카드에만 "영구 삭제" 버튼 노출(2단계 안전장치). 확인 모달에 영향받는 예약 건수 표기.
-
-### 배경/현황 (조사 결과)
-- 서버 `designers.ts`는 PUT-by-omission으로 하드 삭제하되 **예약 연결 시 400 차단**. 영속화 `syncToServer`는 **에러를 삼키고 로컬 낙관적 제거** → 기존 `deleteDesigner`를 그대로 버튼에 붙이면 "화면선 사라지나 서버 거부 → 새로고침 시 부활" 버그. 그래서 전용 DELETE 엔드포인트로 간다.
-- DB: `DesignerSchedule`은 onDelete Cascade(자동), `Reservation.designerId`는 optional FK → 트랜잭션에서 명시적 `updateMany(null)` 후 designer.delete.
-- 프런트 `Reservation.designerId: number | null`, UI는 이미 `null`을 "미지정" 표시 → 분리 삭제와 정합.
-
-### 구현 항목
-1. **`server/api/designers.ts`** — `DELETE` 추가. `requireRole('owner')`, body `{ id }`(legacyId) → `storeId_legacyId`로 해석. 트랜잭션: `reservation.updateMany({designerId:해당 → null})` → `designer.delete()`(스케줄 Cascade). `Allow`에 DELETE 추가. 미존재 시 404.
-2. **`store/calendarStoreHelpers.ts`** — `deleteDesignerOnServer(id)` 추가(`deleteCustomerOnServer` 패턴). 원격 DELETE, 로컬 모드는 스냅샷에서 디자이너 제거 + 해당 예약 designerId=null.
-3. **`store/calendarStore.ts`** — `deleteDesigner` 액션 수정: PUT-by-omission 제거 → 디자이너 상태 제거 + `reservationMap` 내 해당 예약 designerId=null + `deleteDesignerOnServer(id)`.
-4. **`components/settings/DesignerManageSection.tsx`** — "영구 삭제" UI 추가. **퇴직자 섹션에만** 노출(2단계 안전장치: 재직→삭제(퇴직)→영구 삭제). 확인 모달에 "예약 N건은 '미지정'으로 남고 디자이너는 영구 삭제됩니다" 안내 후 `deleteDesigner(id)`.
-5. **문서**: 완료 후 `index.md`·`plan.md` 갱신.
+### 설계 결정 (요약)
+- 라벨은 **category 기준**. 같은 category 내 세부업종 다중 허용, **cross-category 비허용**. 다중 업종(콤마) 시 첫 업종(primary)의 category로 라벨 결정.
+- 라벨 주입: `getStoreLabels(shopType) → {assignee, service}` + `useStoreLabels()` 훅(calendarStore의 shopType 구독). 합성문구는 템플릿(`${labels.assignee} 관리`).
+- **제외(영구)**: 약관/개인정보/DPA/about/maintenance의 "서비스"(앱 명칭). PageHero 영문 eyebrow(ASSIGNEE/SERVICE)는 유지.
 
 ### 리스크
-- 분리 삭제라 예약 데이터 손실 없음. 단 매출/통계에서 해당 예약은 "미지정"으로 집계됨(의도된 동작).
-- 로컬 모드 스냅샷과 원격 동작 일치 확인 필요.
+- 약관 등 "서비스" 오치환 → 라벨 대상만 선별 치환(전수 find-replace 금지).
+- 음식점은 라벨만으론 부족(인원수·테이블 자원·회전시간은 별도 트랙) — 이번 범위는 **라벨/직종 표시까지만**.
 
 ---
 
@@ -193,7 +86,7 @@
 - → 무기한 보류 아님. **몇 달 내** 현실화.
 
 ### 순서
-1. ~~**B-1 공통 로직 추출**~~ — **완료**. `calendarStoreServiceHelpers.ts`에 인라인이던 `minutesBetween`·수동판정(`isPriceManual`/`isDurationManual`)을 `features/services/model.ts`로 이동(무동작 변경, `export *`로 자동 재export, 서버 import 가능). `parseServiceString`/`sumPrice`/`sumDurationMinutes`/`calcEndTime`/`LEGACY_NAME_MAP`은 이미 model에 있었음.
+1. ~~**B-1 공통 로직 추출**~~ — **완료**. `calendarStoreServiceHelpers.ts`에 인라인이던 `minutesBetween`·수동판정(`isPriceManual`/`isDurationManual`)을 `features/services/model.ts`로 이동(무동작 변경, `export *`로 자동 재export, 서버 import 가능).
 2. **네이버 연동 마일스톤에 결합**:
    - `naver-booking-sync.ts:88` 매 폴링 전체예약 풀스캔 **bound**(연동 시 그 파일 만지므로 같이) — 인덱스+범위/증분.
    - **A(매출 집계 서버화)** 를 이 마일스톤으로 끌어와 착수(연동으로 데이터 곧 늘어 명분 생김). A 스텝은 docs "A" 섹션 참조.
@@ -203,115 +96,3 @@
 - 원격 전용 + local(`shouldUseLocalDb`)은 클라 계산 유지(모드 분기). 서버는 revenue.ts **순수함수 재사용**(query→`dbReservationToFrontend`→`groupByDate`→동일 함수 호출, 재구현 X).
 - 예외: `getRevenueInsights` 신규/재방문은 범위 밖 이력 필요 → stored `Customer.firstVisitDate` 사용.
 - 회귀=매출 오표시 → 클라==서버 합계 일치 검증.
-
----
-
-## 업종 중립화 — 미용실 한정 용어 제거 (계획, 미착수)
-
-> 목표: "미용실·뷰티샵" 한정 색을 빼고 범용 "예약·고객 관리 서비스"로.
-> 참고: 이전 세션에서 카피 변경·plan을 작성했으나 워킹트리 정리(2026-06-24)로 전부 되돌아감. 아래는 재정리한 계획.
-
-### 0. 선작업 — 점검중(maintenance) 페이지 + 게이트 (rename 배포 안전장치) — ✅ 구현·검증 완료, main 배포·드라이런 대기
-
-> rename은 "깨지는 창"이 불가피(아래 §2 참고) → 그 동안 사용자에게 **500 대신 "점검 중"**을 보여줄 장치를 먼저 만든다. rename 외 향후 마이그레이션·장애 대응에도 재사용.
-
-- **점검 페이지**: `client/pages/maintenance.tsx` — **DB/Prisma 비의존 페이지**(getServerSideProps·getInitialProps 없음). 빌드상 ƒ(서버 렌더)지만 — `_document.getInitialProps`(styled-components SSR)로 앱 전체가 ƒ — DB를 안 건드리므로 마이그레이션 중에도 안전. 로고 + "점검 중" 문구. **상태: 구현·검증 완료**(런타임 200 + noindex 확인). _app·LayoutComponent에서 bare 페이지 처리도 완료.
-- **게이트**: `client/proxy.ts`(Next 16은 `proxy.ts`가 미들웨어 파일 — 내부상수 `PROXY_FILENAME='proxy'`). `MAINTENANCE_MODE==='true'`면 모든 요청을 `/maintenance`로 `NextResponse.rewrite`. `/maintenance`·`/_next` 바이패스. **상태: 구현·검증 완료**(커밋 `c8a4706`).
-  - ⚠️ **설계 교훈 — 게이트는 `auth()` 밖 최상단에 둘 것**: 처음엔 `auth()` 콜백 안에 넣었더니 NextAuth가 요청 URL을 `AUTH_URL` origin으로 치환 → `rewrite`가 외부 프록시로 새서 **500**(`Failed to proxy ... ECONNREFUSED`). `auth()` 밖에서 *치환 전 진짜 요청 origin*을 쓰게 해 해결(origin 불일치에서도 정상). 부수효과로 auth가 깨져도 점검 페이지가 뜸(인증 독립).
-  - env(`process.env`)만 사용 — 미들웨어 Edge 런타임이라 무거운 import(Prisma 등) 금지.
-- **토글 — ✅ 런타임 반영 검증 완료**: 로컬 프로덕션 빌드(`MAINTENANCE_MODE` 없이 빌드) 후 `next start`에서 env만 바꿔 ON→점검·OFF→정상 확인 → **빌드타임 인라인 아님**(런타임 읽기). 단 Cloud Run `--update-env-vars`는 **새 리비전 롤아웃**(이미지 재빌드 X, 인스턴스 내 즉시 전환은 아님)이라 배포 후 실제 토글 1회 드라이런 권장.
-- **헬스체크**: Cloud Run에 **HTTP 헬스 프로브가 설정돼 있지 않으면 포트 응답만 보므로 `/api/health` 불필요**할 수 있음 → 현재 서비스 프로브 설정 먼저 확인 후 항목 유지/제거 결정.
-- **rename 배포 시퀀스**: ① 점검 ON → ② 마이그레이션(RENAME) → ③ 새 코드 배포 → ④ 검증 → ⑤ 점검 OFF. 사용자는 내내 "점검 중"만 봄(500 노출 0).
-- **열린 질문**: (a) 게이트는 proxy.ts에 통합(별도 미들웨어 X). (b) 로그인/인증 포함 전체 차단이 단순·안전. (c) Cloud Run 프로브 방식 확인 후 헬스체크 경로 필요 여부 결정.
-
-### 0-1. 점검 게이트 `/login` 누수 수정 (rename 선행) — ✅ 완료
-
-> **문제**: `proxy.ts`의 `config.matcher`가 `login`을 제외(`(?!...|login)`)해 미들웨어가 `/login`에서 아예 실행 안 됨 → `MAINTENANCE_MODE='true'`여도 `/login`은 점검 페이지로 안 가고 정상 렌더. rename 마이그레이션 중 `/login` 진입 시 데이터 로드로 500 노출 위험. 열린 질문 (b)("로그인 포함 전체 차단이 단순·안전")를 코드에 반영.
-
-- **요구사항**: 점검 모드일 때 `/login`도 `/maintenance`로 덮는다. 정상 모드에서는 `/login` 동작 무변(현행 유지).
-- **접근**: `matcher`에서 `login` 토큰만 제거 → 미들웨어가 `/login`에서도 실행됨. 점검 게이트가 auth() 밖 최상단이라 ON이면 rewrite로 먼저 가로챔. OFF면 `authMiddleware`로 진입하지만 `/login`은 이미 `isExempt`(14~22줄)라 약관·온보딩 리다이렉트 없이 통과 → 정상 모드 동작 동일. `api/auth`·`_next/*`·`favicon.ico` 제외는 유지(인프라/인증 엔드포인트는 계속 살려둠).
-- **영향 파일**: `client/proxy.ts`(matcher 1줄).
-- **예상 결과**: ON → `/login`이 점검 페이지. OFF → `/login` 기존대로. 타입/빌드 무변.
-- **검증**: 타입체크/린트. 정상모드 `/login` 통과·점검모드 `/login` 차단 로직 추적.
-
-### 0-2. §0 main 배포 + 토글 드라이런 (rename 선행) — 진행 중
-
-> **목표**: 점검 페이지·게이트(현재 develop만)를 운영(main→Cloud Run)에 **`MAINTENANCE_MODE=false`로** 먼저 심고, 토글이 운영에서 실제 동작하는지 1회 리허설. 사용자 영향 0. rename 때 비로소 ON.
-
-- **버전**: `client/package.json` 0.8.0 → **0.9.0**(minor — develop에 `feat` 점검 페이지·게이트 포함, breaking 없음).
-- **머지**: develop→main **fast-forward 가능**(develop..main=0). main 푸시 자동배포 워크플로 없음(배포는 수동 gcloud) → main 푸시 자체는 사용자 영향 없음.
-- **배포(사용자 실행)**: `gcloud run deploy`로 새 코드 운영 반영. `MAINTENANCE_MODE` 미설정=OFF라 배포만으론 점검 안 켜짐.
-- **드라이런(사용자 실행)**: 운영에서 `MAINTENANCE_MODE` ON → `/maintenance` 확인 → OFF. Cloud Run env 변경은 새 리비전 롤아웃이므로 실제 1회 확인 필요.
-- **제약**: 샌드박스에 gcloud·GCP 인증 없음 → 배포·토글은 복붙 명령 제공, 실행은 사용자.
-- **드라이런 결과(2026-06-25)**: 0.9.0 운영 배포 후 토글 ON 확인. 홈(`/`)·`/maintenance`·`/login` 모두 게이트 정상 — 단 `/login`은 **Cloudflare가 캐시**해서 맨 URL은 옛 로그인 화면이 떴고, 캐시 무력화 쿼리(`?cb=`)로는 점검 페이지 확인됨. → **앱 게이트(`/login` 누수 수정)는 정상 작동**. CDN 캐시가 변수.
-- ⚠️ **rename 실배포 추가 스텝 — Cloudflare 캐시 퍼지**: 점검 ON 직후 **Cloudflare 캐시를 purge**(최소 `/login`, 안전하게 전체)해야 캐시된 페이지가 점검 화면을 새지 않음. 시퀀스: ① 점검 ON → **①' Cloudflare purge** → ② 마이그레이션 → … . 캐시 TTL 만료를 기다리지 말 것.
-
-### 1. 카피·문서 — ✅ 완료 (커밋 `ff8f8a8`)
-- 브랜딩 카피: `about.tsx`(태그라인/meta "미용실·뷰티샵을 위한"→ 제거), `README.md`("Salon"→"Reservation & customer management"), `design-guide.html`(placeholder "헤어샵"→"매장")
-- 내부 문서: `prisma-seed-runbook.md`·`service-launch-plan.md` 영문 "salon"→"reservation"
-
-### 2. "디자이너" → "담당자" 전면 rename (이름 확정)
-
-> **방식 결정(2026-06-24): 물리 rename(DB 테이블/컬럼까지).** `@@map` 절충안 대신 DB까지 일관. 데이터가 적은 지금 실행(단, `ALTER ... RENAME`은 즉시 메타데이터 연산이라 위험·소요는 데이터 양과 무관 — "지금"의 이점은 다운타임 중 영향 사용자가 거의 0이라는 점뿐).
-
-**확정안:**
-- 화면 한글: **디자이너 → 담당자**
-- DB/코드 식별자: `Designer → Assignee`, `designerId → assigneeId`, `DesignerSchedule → AssigneeSchedule`, `DesignerStatus → AssigneeStatus`, `Store.designers → Store.assignees`
-- URL: `/settings/designer → /settings/assignee`
-- 방식: **물리 테이블/컬럼까지 진짜 rename**(`ALTER TABLE ... RENAME`, 데이터 제자리 보존). `@@map` 절충안은 폐기(반쪽 상태가 찝찝 → DB 콘솔까지 일관).
-
-**이름 충돌 검증 완료**: `Member`/`Manager`/`Staff`는 `enum MembershipRole {owner, manager, staff}`(권한 시스템)에서 이미 점유 중 → 사용 불가. `Assignee`는 어디와도 안 겹침(안전).
-
-**⚠️ Prisma 함정**: 모델명만 바꾸고 `prisma migrate`하면 `DROP TABLE Designer` + `CREATE TABLE Assignee`로 생성돼 **데이터 전부 소실**. 반드시 생성된 SQL을 손으로 `ALTER TABLE ... RENAME`으로 교체. FK는 이름이 아닌 정체성 기반이라 RENAME 시 자동 유지됨.
-
-**마이그레이션 SQL (손으로 작성):**
-> ⚠️ 테이블/컬럼/enum뿐 아니라 **Postgres 자동생성 제약·인덱스·FK·PK 이름**까지 모두 RENAME해야 함. 안 하면 다음 `prisma migrate`가 drift로 감지 → drop/recreate 시도. 실제 이름은 운영 DB에서 `\d "Designer"`·`\d "DesignerSchedule"`로 **먼저 확인**(아래는 Prisma 기본 네이밍 가정).
-```sql
--- 테이블/컬럼/enum
-ALTER TABLE "Designer" RENAME TO "Assignee";
-ALTER TABLE "DesignerSchedule" RENAME TO "AssigneeSchedule";
-ALTER TABLE "AssigneeSchedule" RENAME COLUMN "designerId" TO "assigneeId";
-ALTER TABLE "Reservation" RENAME COLUMN "designerId" TO "assigneeId";
-ALTER TYPE "DesignerStatus" RENAME TO "AssigneeStatus";
--- PK / unique 인덱스
-ALTER INDEX "Designer_pkey" RENAME TO "Assignee_pkey";
-ALTER INDEX "Designer_storeId_legacyId_key" RENAME TO "Assignee_storeId_legacyId_key";
-ALTER INDEX "DesignerSchedule_pkey" RENAME TO "AssigneeSchedule_pkey";
-ALTER INDEX "DesignerSchedule_designerId_dayIndex_key" RENAME TO "AssigneeSchedule_assigneeId_dayIndex_key";
--- FK 제약 (운영 DB 실측으로 확정 — 2026-06-24)
-ALTER TABLE "Assignee" RENAME CONSTRAINT "Designer_storeId_fkey" TO "Assignee_storeId_fkey";
-ALTER TABLE "AssigneeSchedule" RENAME CONSTRAINT "DesignerSchedule_designerId_fkey" TO "AssigneeSchedule_assigneeId_fkey";
-ALTER TABLE "Reservation" RENAME CONSTRAINT "Reservation_designerId_fkey" TO "Reservation_assigneeId_fkey";
--- (확인) Reservation.designerId 단독 인덱스 없음 → RENAME 대상 아님. Reservation 인덱스는 storeId 조합뿐.
-```
-**위 이름은 운영 DB 실측 결과(`pg_constraint`·`pg_indexes`)와 대조해 확정됨.** 단, 마이그레이션 시점에 스키마가 또 바뀌었을 수 있으니 실행 직전 재확인 권장.
-**검증**: 마이그레이션 후 `prisma migrate diff`(또는 `migrate dev`)가 **빈 diff**여야 함(drift 0). diff가 남으면 빠진 제약/인덱스 이름이 있다는 신호.
-
-**진행 상태(2026-06-25)** — 브랜치 `refactor/designer-to-assignee`(커밋 `fdbee67`):
-- ✅ `schema.prisma` rename 완료(model/enum/필드/관계, 잔여 Designer 0).
-- ✅ 마이그레이션 `0004_rename_designer_to_assignee/migration.sql` 작성(ALTER RENAME, 데이터 보존). enum 값 불변.
-- ✅ **정적 검증**: 0001~0003의 Designer DDL 12객체(테이블2·enum1·컬럼2·PK2·unique2·FK3) 전부 0004 RENAME으로 커버. Reservation designerId 단독 인덱스 없음 확인.
-- ⏳ **라이브 검증 대기**: 샌드박스에 Postgres 설치 불가(no sudo) → 사용자 로컬에서 `cd client && pnpm prisma:migrate:local` 후 `pnpm prisma:validate` + migrate status로 빈 diff 확인 필요.
-- ✅ **코드 rename 완료**(커밋 `bd0f12a`): client 71 + server 11 파일 식별자 치환, 파일/디렉터리 15개 rename(features/assignees·pages/api/assignees·컴포넌트·스토어·유틸·서버API·seed), API URL `/api/designers`→`/api/assignees`, 라우트 `/settings/designer`→`/settings/assignee`, 한글 '디자이너'→'담당자' 전수. **tsc --noEmit 소스 에러 0**. 잔존 designer/디자이너 0.
-- ✅ `index.md` 갱신(동일 매핑).
-- ✅ **호스트 검증 완료**: `prisma generate` + `pnpm build` + `prisma:migrate:local`(0004 replay) 전부 통과.
-- ✅ **운영 전환 완료(2026-06-25)**: §0 시퀀스대로 점검 ON → Cloudflare purge → 운영 DB 0004 적용(세션 풀러 5432) → main 머지·배포(`tas-00071`) → 점검 OFF(`tas-00072`) → 스모크 검증. 버전 0.10.0.
-  - ⚠️ **운영 마이그레이션 연결 교훈**: Supabase `db.xxx.supabase.co:5432`(direct)는 **IPv6 전용**이라 Prisma가 P1001. 트랜잭션 풀러 6543은 advisory lock 불가. → **세션 풀러(`...pooler.supabase.com:5432`, 유저명 `postgres.<ref>`)** 로 마이그레이션해야 함.
-  - 🐛 **후속 핫픽스(0.10.1, `c7324aa`)**: 담당자 추가 시 `buildAddedAssigneeState`가 신규 legacyId를 `Date.now()`(13자리)로 만들어 Int 컬럼 초과(P2020). 기존 버그(rename 무관, 게스트는 localStorage라 안 터짐)였고 서버 첫 추가에서 발현 → `max(id)+1`로 수정.
-- **남은 정리**: 머지된 브랜치 `refactor/designer-to-assignee` 삭제 가능, .git 잠금 잔재(`*.stale`·`*.x*`) 호스트에서 정리 가능.
-
-**작업 범위 (영향 파일):**
-- `server/prisma/schema.prisma` — `model Designer`·`model DesignerSchedule`·`enum DesignerStatus`·`designerId` FK(Reservation/DesignerSchedule)·`Store.designers` 관계. ⚠️ **enum 값은 영문**(`active`/`on_leave`/`resigned`) — 타입 이름만 rename(`AssigneeStatus`), **값은 건드리지 말 것**(한글 아님). 한글 `재직/휴직/퇴직`은 프런트 표시값.
-- 서버: `/api/designers`→`/api/assignees`(라우트 파일·핸들러), `designers-merge`·`naver-booking-fix-designer`, `server/db/mappers.ts`(`dbReservationToFrontend`의 `designerId` 분기 + **영문↔한글 상태 매퍼 `active:'재직'` 양방향 맵의 `DesignerStatus` 타입 참조**), `resolveDesignerCuid`.
-- 클라: store(`calendarStore`·`calendarStoreHelpers`·`calendarStoreDesignerHelpers`), 타입(⚠️ `Designer`/`DesignerStatus`/`DesignerStatusMeta`는 **`features/designers/model.ts`** 정의 + **`utils/designers.ts`가 `export *` 재export**(임포트 다수가 이 배럴 경유) / `designerId?` 필드는 `features/reservations/model.ts`), 온보딩(`onboarding-types` STEP 라벨·`LocalDesigner`), 캘린더 필터(`Header.tsx`), 매출(`revenue*`), 설정(`DesignerManageSection`→`AssigneeManageSection`), URL 라우트(`Aside.tsx:54`, `pages/settings/[tab].tsx`), 모달(`GuestMigrationLayer`·`NaverSyncConflictModal` 등 "디자이너" 문구 다수), PageHero `eyebrow="DESIGNER"`→`"ASSIGNEE"`.
-- 표시 문구: 한글 "디자이너"→"담당자" 전수.
-
-**⚠️ 사이트 접속 우려 — rename은 "치환"이라 안전한 배포 순서가 없음**:
-- 마이그레이션 먼저 → 옛 코드가 `Designer`/`designerId` 조회 → 500. 배포 먼저 → 새 코드가 `assigneeId` 조회하는데 DB는 아직 `designerId` → 500.
-- Cloud Run은 새 리비전 health 통과까지 옛 리비전이 트래픽 받음 → 오버랩 깨짐 불가피.
-- 깨지는 화면: 캘린더 로드, 예약 생성/수정, 매출, 담당자 관리, 네이버 동기화 등.
-- **대응 = §0 점검중 페이지**로 창 전체를 "점검 중"으로 덮어 500 노출 0. 트래픽 최저 시간대 실행.
-
-**배포 순서 (dev-workflow 메모리)**: 마이그레이션 포함 → main 머지(=배포)와 묶어 §0 시퀀스대로 저트래픽 시간대 실행. 로컬은 `pnpm prisma:migrate:local`.
-
-**미결**: "시술"→"서비스" 동반 변경 여부(별도 판단). 이번 rename 범위엔 미포함.


### PR DESCRIPTION
## 배경
헤더 종모양(알림 레이어)에 표시되는 고객명·담당자명이 알림 생성 시점에 박제(snapshot)되어, 이후 고객/담당자 이름을 변경해도 알림 목록에는 옛 이름이 그대로 남는 문제.

## 변경
`calendarStore.ts`의 `patchNotificationNames`를 수정:
- **고객명**: 비어 있을 때만 채우던 것을 → 현재 고객명과 다르면 갱신 (이름 변경·고객 병합 반영)
- **담당자명**: 비었거나 '미지정'일 때만 채우던 것을 → 현재 담당자명과 다르면 갱신, 미배정 예약은 '미지정'으로 표시
- **안전장치**: 고객/담당자를 못 찾거나(데이터 미로드) 담당자 목록 미로드 시 기존 값 유지 — 빈 값으로 덮어쓰지 않음

이 함수는 `customerMap`/`reservationMap` 변경 시 자동 실행(`useNaverBookingSync`의 effect)되므로, 고객/담당자 이름을 바꾸면 별도 조작 없이 알림 목록에 자동 반영됩니다.

## 검증
- 수정 파일 tsc 타입 에러 0 (남은 에러는 이 환경의 prisma 생성 클라이언트 누락에서 파생, 변경과 무관)
- reducer 로직 시나리오 9종 전부 통과: 고객명 변경 / 담당자명 변경 / 미지정→배정 / 배정→미배정 / 예약 미로드 시 보존 / no-op / 고객 미로드 시 보존 / 고객 병합 반영

## 문서
- `index.md`: 회원권 시스템·Store 기능 토글·쿠폰 모델·`normalizeTel` 등 누락분 반영, 알림 동기화 동작 주석 추가
- `plan.md`: 완료 항목 정리 + 회원권/쿠폰/라벨 진행 현황 갱신

## 버전
patch 범프: 0.15.3 → 0.15.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3dzNufQ4uiwzr4qsBAwE5)_