### PR TITLE
refactor: h3 태그를 strong으로 교체 및 모달 헤더 정렬 조정

### DIFF
--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -193,7 +193,8 @@ export const StyledHeader = styled.div`
     }
 `;
 
-export const StyledHeaderTitle = styled.h3`
+export const StyledHeaderTitle = styled.strong`
+    display: block;
     margin: 0;
     font-size: var(--modal-title-font);
     font-weight: 700;

--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -164,7 +164,7 @@ export const StyledDetail = styled.div<{ $width?: number | string }>`
 
 export const StyledHeader = styled.div`
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     flex-shrink: 0;
     gap: var(--modal-header-gap);

--- a/client/components/calendar/overlays/ReservationDetailHeader.tsx
+++ b/client/components/calendar/overlays/ReservationDetailHeader.tsx
@@ -42,6 +42,7 @@ const StyledReservationTitleGroup = styled.div`
 const StyledReservationTitle = styled.strong`
     display: block;
     margin: 0;
+    font-size: 18px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/client/components/calendar/overlays/ReservationDetailHeader.tsx
+++ b/client/components/calendar/overlays/ReservationDetailHeader.tsx
@@ -39,7 +39,8 @@ const StyledReservationTitleGroup = styled.div`
     overflow: hidden;
 `;
 
-const StyledReservationTitle = styled.h3`
+const StyledReservationTitle = styled.strong`
+    display: block;
     margin: 0;
     white-space: nowrap;
     overflow: hidden;

--- a/client/components/modals/CustomerMergeSuggestionModal.tsx
+++ b/client/components/modals/CustomerMergeSuggestionModal.tsx
@@ -144,7 +144,7 @@ export const CustomerMergeSuggestionModal = ({
             <StyledMergeModal ref={dialogRef} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
                 <StyledHeader>
                     <StyledHeaderTitleGroup>
-                        <strong>같은 고객인가요?</strong>
+                        <StyledMergeTitle>같은 고객인가요?</StyledMergeTitle>
                         <StyledHeaderTitleGroupText>
                             이름 패턴이 유사한 고객이 {allIds.length}명 발견되었습니다.
                             {isMulti && ' 병합할 고객을 선택하세요.'}
@@ -280,6 +280,10 @@ const StyledMergeOverlay = styled(StyledOverlay)`
 const StyledMergeModal = styled(StyledDetail)`
     width: min(400px, 90vw);
     max-width: min(400px, 90vw);
+`;
+
+const StyledMergeTitle = styled.strong`
+    font-size: 18px;
 `;
 
 const StyledScrollArea = styled.div`

--- a/client/components/modals/CustomerMergeSuggestionModal.tsx
+++ b/client/components/modals/CustomerMergeSuggestionModal.tsx
@@ -144,7 +144,7 @@ export const CustomerMergeSuggestionModal = ({
             <StyledMergeModal ref={dialogRef} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
                 <StyledHeader>
                     <StyledHeaderTitleGroup>
-                        <h3>같은 고객인가요?</h3>
+                        <strong>같은 고객인가요?</strong>
                         <StyledHeaderTitleGroupText>
                             이름 패턴이 유사한 고객이 {allIds.length}명 발견되었습니다.
                             {isMulti && ' 병합할 고객을 선택하세요.'}

--- a/client/components/modals/NaverSyncConflictModal.styles.ts
+++ b/client/components/modals/NaverSyncConflictModal.styles.ts
@@ -7,6 +7,10 @@ export const StyledConfirmOverlay = styled(StyledOverlay)`
     z-index: ${OVERLAY_Z_INDEX.supporting};
 `;
 
+export const StyledConflictTitle = styled.strong`
+    font-size: 18px;
+`;
+
 export const StyledCustomerValue = styled.span`
     font-weight: 600;
     color: #0f172a;

--- a/client/components/modals/NaverSyncConflictModal.tsx
+++ b/client/components/modals/NaverSyncConflictModal.tsx
@@ -26,6 +26,7 @@ import {CloseIconButton} from '../ui/CloseIconButton';
 import {ReservationInfoCard} from '../ui/ReservationInfoCard';
 import {NaverBookingInfo} from '../ui/NaverBookingInfo';
 import {
+    StyledConflictTitle,
     StyledConfirmOverlay,
     StyledConfirmModal,
     StyledScrollArea,
@@ -256,7 +257,7 @@ export const NaverSyncConflictModal = ({
                                 onClick={(e) => e.stopPropagation()}>
                 <StyledHeader>
                     <StyledHeaderTitleGroup>
-                        <strong>{isConfirmed ? '예약 시간 중복 처리 완료' : '예약 시간 중복 안내'}</strong>
+                        <StyledConflictTitle>{isConfirmed ? '예약 시간 중복 처리 완료' : '예약 시간 중복 안내'}</StyledConflictTitle>
                         <StyledHeaderTitleGroupText>{isConfirmed ? '처리 완료된 예약 중복 내역입니다.' : '네이버 예약 동기화 중 시간이 겹치는 예약이 발견되었습니다.'}</StyledHeaderTitleGroupText>
                     </StyledHeaderTitleGroup>
                     <CloseIconButton onClick={onDismiss} />

--- a/client/components/modals/NaverSyncConflictModal.tsx
+++ b/client/components/modals/NaverSyncConflictModal.tsx
@@ -256,7 +256,7 @@ export const NaverSyncConflictModal = ({
                                 onClick={(e) => e.stopPropagation()}>
                 <StyledHeader>
                     <StyledHeaderTitleGroup>
-                        <h3>{isConfirmed ? '예약 시간 중복 처리 완료' : '예약 시간 중복 안내'}</h3>
+                        <strong>{isConfirmed ? '예약 시간 중복 처리 완료' : '예약 시간 중복 안내'}</strong>
                         <StyledHeaderTitleGroupText>{isConfirmed ? '처리 완료된 예약 중복 내역입니다.' : '네이버 예약 동기화 중 시간이 겹치는 예약이 발견되었습니다.'}</StyledHeaderTitleGroupText>
                     </StyledHeaderTitleGroup>
                     <CloseIconButton onClick={onDismiss} />

--- a/client/components/policy/policyCss.ts
+++ b/client/components/policy/policyCss.ts
@@ -36,8 +36,10 @@ export const POLICY_ELEMENT_CSS = `
         margin: 2em 0 0.6em;
         color: var(--tas-accent);
     }
-    h3 {
+    .policy-subhead {
+        display: block;
         font-size: 1.05rem;
+        font-weight: 700;
         margin: 1.4em 0 0.4em;
     }
     p {

--- a/client/components/settings/MemberSection.styles.ts
+++ b/client/components/settings/MemberSection.styles.ts
@@ -226,7 +226,8 @@ export const StyledGuestCard = styled.div`
     box-shadow: var(--shadow-sm);
 `;
 
-export const StyledGuestTitle = styled.h3`
+export const StyledGuestTitle = styled.strong`
+    display: block;
     margin: 0 0 8px;
     font-size: 14px;
     font-weight: 600;

--- a/client/components/settings/settings-styles.ts
+++ b/client/components/settings/settings-styles.ts
@@ -88,7 +88,8 @@ export const StyledSettingsCard = styled.div`
     margin-bottom: 16px;
 `;
 
-export const StyledSettingsCardTitle = styled.h3`
+export const StyledSettingsCardTitle = styled.strong`
+    display: block;
     margin: 0 0 12px;
     font-size: 13px;
     font-weight: 600;

--- a/client/content/policies/privacy.ts
+++ b/client/content/policies/privacy.ts
@@ -17,24 +17,24 @@ export const PRIVACY_BODY = `
 </ol>
 <hr>
 <h2>제2조 (수집하는 개인정보의 항목 및 수집 방법)</h2>
-<h3>1. 회원 로그인 정보 (SNS 간편로그인)</h3>
+<strong class="policy-subhead">1. 회원 로그인 정보 (SNS 간편로그인)</strong>
 <p>회사는 카카오·네이버·구글 소셜 로그인을 통해 로그인 기능만을 이용하며, <strong>각 제공자가 부여하는 회원 식별용 고유 식별자(고유 ID/연동 토큰)만</strong>을 수집합니다.</p>
 <ul>
 <li><strong>수집 항목:</strong> SNS 제공자별 고유 식별자(고유 회원번호), 연동 토큰</li>
 <li><strong>미수집 항목:</strong> 이름, 닉네임, 이메일 주소, 프로필 사진, 성별, 연령대 등 프로필 정보는 수집하지 않습니다.</li>
 </ul>
-<h3>2. 메일 연동 정보 (Gmail 연동)</h3>
+<strong class="policy-subhead">2. 메일 연동 정보 (Gmail 연동)</strong>
 <p>회사는 이용자가 명시적으로 연동한 Google 계정의 메일(네이버예약 알림 메일)을 수신·열람하기 위해 Google OAuth를 통한 <strong>읽기 전용(read-only) 권한</strong>만을 요청합니다.</p>
 <ul>
 <li><strong>연동 방식:</strong> 로그인 계정과 <strong>분리하여</strong> 별도로 연동하며, 로그인에 사용한 계정 또는 별도의 다른 Gmail 계정을 선택하여 연결할 수 있습니다.</li>
 <li><strong>수집·처리 대상:</strong> 예약 관련 메일의 본문 및 메타데이터(발신자, 수신 시각, 제목 등)</li>
 <li>회사는 메일을 <strong>읽기 전용으로만</strong> 접근하며, 메일을 발송·수정·삭제하지 않습니다.</li>
 </ul>
-<h3>3. 자동으로 생성·수집되는 정보</h3>
+<strong class="policy-subhead">3. 자동으로 생성·수집되는 정보</strong>
 <ul>
 <li>서비스 이용 과정에서 접속 IP 주소, 쿠키, 접속 일시, 서비스 이용 기록, 기기·브라우저 정보가 자동으로 생성·수집될 수 있습니다.</li>
 </ul>
-<h3>4. 수집 방법</h3>
+<strong class="policy-subhead">4. 수집 방법</strong>
 <ul>
 <li>SNS 제공자 및 Google을 통한 인증·연동(API)</li>
 <li>서비스 이용 과정에서의 자동 생성·수집</li>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.18.0",
+    "version": "0.18.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 진행 중 — `h3` 태그를 `strong`으로 교체
+
+> 배경(사용자 요청): `h3`가 사용된 곳의 태그를 `strong`으로 바꾼다. 범위는 전부(일반 태그 + styled.h3 + CSS 선택자).
+
+### 구현 항목
+- 일반 `<h3>` → `<strong>`
+  - `client/components/modals/CustomerMergeSuggestionModal.tsx` (모달 제목)
+  - `client/components/modals/NaverSyncConflictModal.tsx` (모달 제목)
+- `styled.h3` → `styled.strong` (인라인→블록 방지 위해 `display: block;` 추가)
+  - `client/components/calendar/overlays/ModalStyles.ts` (`StyledHeaderTitle`)
+  - `client/components/calendar/overlays/ReservationDetailHeader.tsx` (`StyledReservationTitle`, ellipsis 유지 위해 block 필수)
+  - `client/components/settings/MemberSection.styles.ts` (`StyledGuestTitle`)
+  - `client/components/settings/settings-styles.ts` (`StyledSettingsCardTitle`)
+- 정책 문서(`client/content/policies/privacy.ts` 소제목 4곳): 본문이 `<strong>`을 인라인 강조로 광범위하게 사용 → 소제목엔 `.policy-subhead` 클래스를 붙이고 `policyCss.ts`의 `h3 {}` 선택자를 `.policy-subhead {}`로 교체(`display:block` 추가). 인라인 `<strong>` 오염 방지 + "태그 선택자 대신 클래스" 원칙 준수.
+
+### 리스크/주의
+- 접근성: 소제목/모달 제목이 heading 아웃라인에서 빠짐(사용자 명시 요청으로 수용). 모달은 `role="dialog"`+`aria-label`이 있어 이름 지정은 유지됨.
+
+---
+
 ## 진행 중 — 북마크(직접 URL 진입) 크래시 수정
 
 > 배경: 사용자가 `/month` 같은 캘린더 URL을 즐겨찾기했다가 다시 진입하면 화면이 에러남.


### PR DESCRIPTION
## 개요
`h3`가 사용된 모든 곳의 태그를 `strong`으로 교체하고, 관련 스타일과 모달 헤더 정렬을 조정합니다.

## 변경 내용
- **일반 `<h3>` → `<strong>`**
  - `CustomerMergeSuggestionModal.tsx`, `NaverSyncConflictModal.tsx` (모달 제목)
- **`styled.h3` → `styled.strong`** (인라인→블록 전환 방지 위해 `display: block` 추가)
  - `ModalStyles.ts`(`StyledHeaderTitle`), `ReservationDetailHeader.tsx`(`StyledReservationTitle`), `MemberSection.styles.ts`(`StyledGuestTitle`), `settings-styles.ts`(`StyledSettingsCardTitle`)
- **정책 문서**(`privacy.ts` + `policyCss.ts`): 본문이 `<strong>`을 인라인 강조로 광범위하게 사용하므로 소제목엔 `.policy-subhead` 클래스를 부여하고 CSS `h3 {}` 선택자를 `.policy-subhead {}`로 교체. 인라인 강조 오염 방지 + 태그 선택자 대신 클래스 사용.
- **font-size 없던 제목 3곳에 `18px` 지정**: `StyledReservationTitle`, 고객 병합 모달 제목(`StyledMergeTitle`), 네이버 중복 모달 제목(`StyledConflictTitle`).
- **모달 헤더 정렬**: `StyledHeader`의 `align-items: center` → `flex-start`.
- **버전**: `0.18.0` → `0.18.1` (patch).

## 참고
- 접근성: 소제목/모달 제목이 heading 아웃라인에서 빠집니다(요청에 따른 의도된 변경). 모달은 `role="dialog"` + `aria-label`로 이름은 유지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UgaEDxCc6J5j3P3yj6wFG)_