### PR TITLE
style: 모달 헤더 제목(strong)에 align-self: center 추가

### DIFF
--- a/client/components/calendar/overlays/ModalStyles.ts
+++ b/client/components/calendar/overlays/ModalStyles.ts
@@ -195,6 +195,7 @@ export const StyledHeader = styled.div`
 
 export const StyledHeaderTitle = styled.strong`
     display: block;
+    align-self: center;
     margin: 0;
     font-size: var(--modal-title-font);
     font-weight: 700;
@@ -207,6 +208,12 @@ export const StyledHeaderTitleGroup = styled.div`
     flex-direction: column;
     gap: 4px;
     min-width: 0;
+
+    /* 그룹(제목+부제목) 안에서는 제목의 align-self:center(헤더 직접 자식용)를 무효화해
+       가로 중앙 정렬로 튀는 것을 막고 원래 좌측 정렬을 유지한다. */
+    ${StyledHeaderTitle} {
+        align-self: stretch;
+    }
 `;
 
 export const StyledHeaderTitleGroupText = styled.p`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.18.1",
+    "version": "0.18.2",
     "private": true,
     "scripts": {
         "dev": "next dev",


### PR DESCRIPTION
## 개요
`StyledHeader`가 `align-items: flex-start`라 헤더의 직접 자식인 제목(`strong`)이 상단에 붙던 것을, 세로 중앙 정렬로 바로잡습니다.

## 변경 내용 (`client/components/calendar/overlays/ModalStyles.ts`)
- `StyledHeaderTitle`(styled.strong)에 `align-self: center` 추가 → 헤더 직접 자식일 때 닫기 버튼(44px) 기준 세로 중앙 정렬.
- `StyledHeaderTitleGroup`에 컴포넌트 선택자 가드 추가: `${StyledHeaderTitle} { align-self: stretch; }` → 제목+부제목 그룹(예약목록/이력/매출상세/매출지표/알림/ConfirmDialog 등 6곳)에서 제목이 가로 중앙으로 튀지 않고 좌측 정렬 유지.
- 버전: `0.18.1` → `0.18.2` (patch).

## 검증
- 로컬 `next build` → `✓ Compiled successfully`.
- Playwright(Chromium) 실측: 직접 자식 제목은 버튼과 center-y 차이 0.00px(세로 중앙), 그룹 제목은 그룹/부제목과 left 일치(좌측 유지). 가드 없을 시 가로 중앙으로 깨짐도 대조군으로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UgaEDxCc6J5j3P3yj6wFG)_