### PR TITLE
feat: 예약 설정 UI 개선 (가로 풀폭·영문 매장명 필수·중복 확인)

### DIFF
--- a/client/components/settings/BookingManageSection.tsx
+++ b/client/components/settings/BookingManageSection.tsx
@@ -17,6 +17,8 @@ export function BookingManageSection() {
     const [saving, setSaving] = useState(false);
     const [slug, setSlug] = useState('');
     const [settings, setSettings] = useState<BookingSettings>(DEFAULT_BOOKING_SETTINGS);
+    // 중복 확인 버튼 상태
+    const [checkState, setCheckState] = useState<'idle' | 'checking' | 'available' | 'taken' | 'invalid'>('idle');
 
     useEffect(() => {
         let alive = true;
@@ -33,13 +35,41 @@ export function BookingManageSection() {
     }, []);
 
     const trimmedSlug = slug.trim().toLowerCase();
-    const slugValid = trimmedSlug === '' || isValidBookingSlug(trimmedSlug);
-    const publicUrl = `https://${BOOKING_HOST}/${trimmedSlug || '(슬러그 미설정)'}`;
+    const slugEmpty = trimmedSlug === '';
+    const slugFormatInvalid = !slugEmpty && !isValidBookingSlug(trimmedSlug);
+    // 이 화면은 온라인 예약 ON일 때만 노출되므로 영문 매장명은 필수.
+    const slugValid = !slugEmpty && !slugFormatInvalid;
+    const publicUrl = `https://${BOOKING_HOST}/${trimmedSlug || '(영문 매장명 미설정)'}`;
+
+    const onSlugChange = (value: string) => {
+        setSlug(value);
+        setCheckState('idle');
+    };
+
+    const handleCheckSlug = async () => {
+        if (!slugValid) {
+            setCheckState('invalid');
+            return;
+        }
+        setCheckState('checking');
+        try {
+            const res = await fetch(`/api/store?checkSlug=${encodeURIComponent(trimmedSlug)}`);
+            const data = await res.json();
+            setCheckState(data.available ? 'available' : (data.reason === 'format' ? 'invalid' : 'taken'));
+        } catch {
+            setCheckState('idle');
+            toast('중복 확인 중 오류가 발생했습니다.');
+        }
+    };
 
     const handleSave = async () => {
         if (saving) return;
+        if (slugEmpty) {
+            toast('영문 매장명은 필수입니다.');
+            return;
+        }
         if (!slugValid) {
-            toast('슬러그 형식이 올바르지 않습니다.');
+            toast('영문 매장명 형식이 올바르지 않습니다.');
             return;
         }
         setSaving(true);
@@ -48,7 +78,7 @@ export function BookingManageSection() {
                 method: 'PATCH',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
-                    bookingSlug: trimmedSlug === '' ? null : trimmedSlug,
+                    bookingSlug: trimmedSlug,
                     bookingSettings: settings,
                 }),
             });
@@ -81,17 +111,25 @@ export function BookingManageSection() {
                 <StyledSettingsCardTitle>공개 예약 페이지 주소</StyledSettingsCardTitle>
                 <StyledSettingsHint>영문 매장명이 예약 페이지 주소가 됩니다. 영문 소문자·숫자·하이픈, 3~32자.</StyledSettingsHint>
                 <StyledField>
-                    <StyledLabel htmlFor="booking-slug">영문 매장명</StyledLabel>
-                    <StyledInput
-                        id="booking-slug"
-                        type="text"
-                        value={slug}
-                        placeholder="예) mystore"
-                        onChange={(e) => setSlug(e.target.value)}
-                        disabled={loading}
-                        $invalid={!slugValid}
-                    />
-                    {!slugValid && <StyledError>영문 소문자·숫자·하이픈 3~32자, 하이픈으로 시작·끝 불가.</StyledError>}
+                    <StyledLabel htmlFor="booking-slug">영문 매장명 <StyledReq>필수</StyledReq></StyledLabel>
+                    <StyledSlugRow>
+                        <StyledInput
+                            id="booking-slug"
+                            type="text"
+                            value={slug}
+                            placeholder="예) mystore"
+                            onChange={(e) => onSlugChange(e.target.value)}
+                            disabled={loading}
+                            $invalid={slugFormatInvalid || checkState === 'taken'}
+                        />
+                        <StyledCheckBtn type="button" onClick={handleCheckSlug} disabled={loading || !slugValid || checkState === 'checking'}>
+                            {checkState === 'checking' ? '확인 중…' : '중복 확인'}
+                        </StyledCheckBtn>
+                    </StyledSlugRow>
+                    {slugFormatInvalid && <StyledError>영문 소문자·숫자·하이픈 3~32자, 하이픈으로 시작·끝 불가.</StyledError>}
+                    {!slugFormatInvalid && checkState === 'available' && <StyledOk>사용 가능한 주소입니다. ✓</StyledOk>}
+                    {!slugFormatInvalid && checkState === 'taken' && <StyledError>이미 사용 중인 주소입니다. 다른 값을 입력해 주세요. ✗</StyledError>}
+                    {!slugFormatInvalid && checkState === 'invalid' && <StyledError>형식을 확인해 주세요.</StyledError>}
                 </StyledField>
                 <StyledUrlPreview>공개 주소: <strong>{publicUrl}</strong></StyledUrlPreview>
             </StyledSettingsCard>
@@ -205,6 +243,41 @@ const StyledInput = styled.input<{$invalid?: boolean}>`
     box-sizing: border-box;
 
     &:focus { outline: none; border-color: var(--blue-color); }
+`;
+
+const StyledReq = styled.span`
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--brand-color);
+`;
+
+const StyledSlugRow = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    ${StyledInput} { flex: 1; min-width: 0; }
+`;
+
+const StyledCheckBtn = styled.button`
+    flex-shrink: 0;
+    height: 42px;
+    padding: 0 14px;
+    border: 1px solid var(--blue-color);
+    border-radius: 8px;
+    background: var(--white-color);
+    color: var(--blue-color);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+`;
+
+const StyledOk = styled.span`
+    font-size: 12px;
+    color: var(--green-color, #16a34a);
 `;
 
 const StyledFullSelect = styled.select`

--- a/client/components/settings/BookingManageSection.tsx
+++ b/client/components/settings/BookingManageSection.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import {useToastStore} from '../../store/toastStore';
 import {DEFAULT_BOOKING_SETTINGS, isValidBookingSlug} from '../../features/store-settings/model';
 import type {BookingSettings} from '../../features/store-settings/model';
-import {StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint, StyledSaveBtn, StyledSelect} from './settings-styles';
+import {StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint, StyledSaveBtn} from './settings-styles';
 
 const BOOKING_HOST = process.env.NEXT_PUBLIC_BOOKING_HOST ?? 'book.takeaseat.co.kr';
 const SLOT_OPTIONS = [10, 15, 20, 30, 60];
@@ -79,9 +79,9 @@ export function BookingManageSection() {
 
             <StyledSettingsCard>
                 <StyledSettingsCardTitle>공개 예약 페이지 주소</StyledSettingsCardTitle>
-                <StyledSettingsHint>영문 소문자·숫자·하이픈, 3~32자. 예약 페이지 URL에 사용됩니다.</StyledSettingsHint>
+                <StyledSettingsHint>영문 매장명이 예약 페이지 주소가 됩니다. 영문 소문자·숫자·하이픈, 3~32자.</StyledSettingsHint>
                 <StyledField>
-                    <StyledLabel htmlFor="booking-slug">슬러그</StyledLabel>
+                    <StyledLabel htmlFor="booking-slug">영문 매장명</StyledLabel>
                     <StyledInput
                         id="booking-slug"
                         type="text"
@@ -100,14 +100,14 @@ export function BookingManageSection() {
                 <StyledSettingsCardTitle>예약 규칙</StyledSettingsCardTitle>
                 <StyledField>
                     <StyledLabel htmlFor="booking-slot">예약 시간 간격</StyledLabel>
-                    <StyledSelect
+                    <StyledFullSelect
                         id="booking-slot"
                         value={settings.slotIntervalMin}
                         onChange={(e) => setNum('slotIntervalMin', Number(e.target.value))}
                         disabled={loading}
                     >
                         {SLOT_OPTIONS.map((m) => <option key={m} value={m}>{m}분</option>)}
-                    </StyledSelect>
+                    </StyledFullSelect>
                 </StyledField>
                 <StyledField>
                     <StyledLabel htmlFor="booking-lead">최소 사전 예약 시간(분)</StyledLabel>
@@ -203,6 +203,21 @@ const StyledInput = styled.input<{$invalid?: boolean}>`
     color: var(--black-color);
     background: var(--white-color);
     box-sizing: border-box;
+
+    &:focus { outline: none; border-color: var(--blue-color); }
+`;
+
+const StyledFullSelect = styled.select`
+    width: 100%;
+    height: 42px;
+    padding: 0 12px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 8px;
+    font-size: 14px;
+    color: var(--black-color);
+    background: var(--white-color);
+    box-sizing: border-box;
+    cursor: pointer;
 
     &:focus { outline: none; border-color: var(--blue-color); }
 `;

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.19.0",
+    "version": "0.19.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/server/api/store.ts
+++ b/server/api/store.ts
@@ -17,6 +17,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (req.method === 'GET') {
         if (!requireRole(session, 'staff', res)) return;
 
+        // 영문 매장명(슬러그) 중복 확인 — 설정 화면의 "중복 확인" 버튼용
+        const checkSlug = typeof req.query.checkSlug === 'string' ? req.query.checkSlug : null;
+        if (checkSlug !== null) {
+            const normalized = checkSlug.trim().toLowerCase();
+            if (!isValidBookingSlug(normalized)) {
+                return res.status(200).json({available: false, reason: 'format'});
+            }
+            try {
+                const existing = await prisma.store.findUnique({where: {bookingSlug: normalized}, select: {id: true}});
+                const available = !existing || existing.id === session.storeId;
+                return res.status(200).json({available});
+            } catch {
+                // 마이그레이션 미적용 등 — 확인 불가
+                return res.status(200).json({available: true, reason: 'unverified'});
+            }
+        }
+
         const [store, businessHours, closedDates, pointSettings] = await Promise.all([
             prisma.store.findUnique({where: {id: session.storeId}, select: {name: true, shopType: true, usePointSystem: true, useMembershipSystem: true, useCouponSystem: true}}),
             prisma.storeBusinessHour.findMany({where: {storeId: session.storeId}, orderBy: {dayIndex: 'asc'}}),


### PR DESCRIPTION
## 개요
고객 예약 설정(매장 관리 내) UI를 개선합니다.

## 변경 내용
- **가로 풀폭**: 슬롯 간격 셀렉트를 입력칸과 동일한 100% 폭으로 정렬.
- **"슬러그" → "영문 매장명"**: 용어를 사용자 친화적으로 변경(안내문 포함).
- **영문 매장명 필수화**: 이 설정 화면은 온라인 예약 토글 ON일 때만 노출되므로, 영문 매장명을 필수로 검증(빈 값이면 저장 차단 + 안내).
- **중복 확인 버튼**: 입력칸 옆 "중복 확인" 버튼 → `GET /api/store?checkSlug=` 로 "사용 가능 ✓ / 이미 사용 중 ✗" 표시. 저장 시에도 서버 unique(409)로 이중 방어.
- 서버 GET에 `checkSlug` 분기 추가(형식·중복 판정, 컬럼 미존재 시 방어적 폴백).
- 버전: `0.19.0` → `0.19.1` (patch).

## 참고
- "노출할 서비스 선택" 기능은 스키마 추가가 필요해 Phase 1 마이그레이션에 함께 넣을 예정(운영 마이그레이션 횟수 최소화).

## 검증
- `next build` + 타입체크 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UgaEDxCc6J5j3P3yj6wFG)_