### PR TITLE
ci: 코드리뷰 인증에 Claude 구독 토큰(OAuth) 지원

### DIFF
--- a/.github/workflows/claude-review-reusable.yml
+++ b/.github/workflows/claude-review-reusable.yml
@@ -13,8 +13,13 @@ name: Claude Code Review (Reusable)
 on:
   workflow_call:
     secrets:
+      # 둘 중 하나만 등록하면 된다.
+      # - claude_code_oauth_token: Claude Pro/Max 구독 토큰(`claude setup-token`). API 종량 과금 없음(구독 한도 사용).
+      # - anthropic_api_key: Anthropic API 키(종량 과금).
+      claude_code_oauth_token:
+        required: false
       anthropic_api_key:
-        required: true
+        required: false
     inputs:
       prompt:
         description: "리뷰 프롬프트 (미지정 시 기본값 사용)"
@@ -50,6 +55,8 @@ jobs:
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
+          # OAuth 토큰(구독) 우선, 없으면 API 키 사용
+          claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,6 +16,8 @@ jobs:
     # 같은 저장소의 로컬 재사용 워크플로 호출
     uses: ./.github/workflows/claude-review-reusable.yml
     secrets:
+      # Claude Max 구독 토큰(있으면 이걸로 — 종량 과금 없음). API 키만 있으면 아래로.
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
       max_turns: 4


### PR DESCRIPTION
## 개요
자동 PR 리뷰 인증을 API 키(종량 과금) 외에 **Claude 구독 토큰(OAuth)** 으로도 할 수 있게 지원합니다. Claude Max로 CI 리뷰를 시도하기 위함(성공 시 종량 과금 없이 구독 한도 사용).

## 변경 내용
- `claude-review-reusable.yml`: 시크릿 `claude_code_oauth_token`(구독) + `anthropic_api_key`(API) 둘 다 optional로 받아 액션에 전달. OAuth 우선.
- `pr-review.yml`: caller에서 두 시크릿 모두 전달.

## 참고
- 둘 중 **하나만** 저장소/계정 시크릿에 등록하면 동작.
- 구독 토큰은 `claude setup-token`(Pro/Max)로 발급. 단 Anthropic의 2026-04 OAuth 제한으로 CI 동작이 보장되진 않아, 실제 PR로 검증 필요.
- 시크릿 등록 전에는 리뷰 Action이 실패(red)하며, 이는 세팅 단계에서 예상된 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UgaEDxCc6J5j3P3yj6wFG)_