### PR TITLE
feat: 매출 차트 채널에 온라인예약 추가

### DIFF
--- a/client/components/settings/revenue/revenueChartUtils.ts
+++ b/client/components/settings/revenue/revenueChartUtils.ts
@@ -1,9 +1,9 @@
 import type {PaymentMethod} from '../../../utils/reservations';
 import {toDateKey} from '../../../utils/reservations';
 
-export const CHANNEL_ORDER = ['전화예약', '현장방문', '네이버예약'] as const;
+export const CHANNEL_ORDER = ['전화예약', '현장방문', '네이버예약', '온라인예약'] as const;
 
-export const CHANNEL_COLORS: Record<string, string> = {'전화예약': '#FB8C00', '현장방문': '#4285F4', '네이버예약': '#2DB400'};
+export const CHANNEL_COLORS: Record<string, string> = {'전화예약': '#FB8C00', '현장방문': '#4285F4', '네이버예약': '#2DB400', '온라인예약': '#7C3AED'};
 
 export const PAYMENT_METHOD_COLORS = ['#2D7FF9', '#00A896', '#FB8C00', '#E85D75', '#7E57C2', '#4C6EF5', '#8E8E93', '#34A853'] as const;
 


### PR DESCRIPTION
## 개요
공개 예약(channel=`online`) 매출이 매출 차트에 색·순서로 반영되도록 채널 목록에 `온라인예약`을 추가합니다. (동시에 자동 코드리뷰 Action의 Claude Max 토큰 동작 검증용 테스트 PR)

## 변경 내용
- `revenueChartUtils.ts`: `CHANNEL_ORDER`·`CHANNEL_COLORS`에 `온라인예약`(보라 `#7C3AED`) 추가.

## 검증
- `next build` + 타입체크 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UgaEDxCc6J5j3P3yj6wFG)_