### PR TITLE
feat: 고객 공개 온라인 예약 — 슬롯·예약생성·노출서비스 (Phase 1b·1c)

### DIFF
--- a/client/components/settings/BookingManageSection.tsx
+++ b/client/components/settings/BookingManageSection.tsx
@@ -3,6 +3,7 @@ import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 
 import {useToastStore} from '../../store/toastStore';
+import {useCalendarStore} from '../../store/calendarStore';
 import {DEFAULT_BOOKING_SETTINGS, isValidBookingSlug} from '../../features/store-settings/model';
 import type {BookingSettings} from '../../features/store-settings/model';
 import {StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint, StyledSaveBtn} from './settings-styles';
@@ -12,6 +13,7 @@ const SLOT_OPTIONS = [10, 15, 20, 30, 60];
 
 export function BookingManageSection() {
     const toast = useToastStore((s) => s.show);
+    const serviceCatalog = useCalendarStore((s) => s.serviceCatalog);
 
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -100,6 +102,18 @@ export function BookingManageSection() {
 
     const setNum = (key: 'slotIntervalMin' | 'minLeadMinutes' | 'maxAdvanceDays', value: number) => {
         setSettings((prev) => ({...prev, [key]: value}));
+    };
+
+    // 노출 서비스(1c): null=전체 노출. 체크 = 노출. 전체 선택이면 null로 저장(전체 노출).
+    const allServiceNames = serviceCatalog.map((s) => s.name);
+    const isServiceExposed = (name: string) => settings.bookableServiceNames === null || settings.bookableServiceNames.includes(name);
+    const toggleServiceExposure = (name: string) => {
+        setSettings((prev) => {
+            const current = new Set(prev.bookableServiceNames ?? allServiceNames);
+            if (current.has(name)) current.delete(name); else current.add(name);
+            const next = allServiceNames.filter((n) => current.has(n));
+            return {...prev, bookableServiceNames: next.length === allServiceNames.length ? null : next};
+        });
     };
 
     return (
@@ -193,6 +207,27 @@ export function BookingManageSection() {
                     />
                 </StyledField>
             </StyledSettingsCard>
+
+            {serviceCatalog.length > 0 && (
+                <StyledSettingsCard>
+                    <StyledSettingsCardTitle>노출 서비스</StyledSettingsCardTitle>
+                    <StyledSettingsHint>고객 예약 페이지에 보여줄 서비스를 선택합니다. 하나도 선택하지 않으면 전체가 노출됩니다.</StyledSettingsHint>
+                    <StyledServiceCheckList>
+                        {serviceCatalog.map((s, idx) => (
+                            <StyledServiceCheckRow key={s.name} htmlFor={`book-svc-${idx}`}>
+                                <input
+                                    id={`book-svc-${idx}`}
+                                    type="checkbox"
+                                    checked={isServiceExposed(s.name)}
+                                    onChange={() => toggleServiceExposure(s.name)}
+                                    disabled={loading}
+                                />
+                                <span>{s.name}</span>
+                            </StyledServiceCheckRow>
+                        ))}
+                    </StyledServiceCheckList>
+                </StyledSettingsCard>
+            )}
 
             <StyledFooter>
                 <StyledSaveBtn type="button" onClick={handleSave} disabled={saving || loading || !slugValid}>
@@ -314,6 +349,22 @@ const StyledCheckboxRow = styled.label`
     align-items: center;
     gap: 8px;
     margin-top: 16px;
+    font-size: 14px;
+    color: var(--dark-gray-color);
+    cursor: pointer;
+`;
+
+const StyledServiceCheckList = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 14px;
+`;
+
+const StyledServiceCheckRow = styled.label`
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 14px;
     color: var(--dark-gray-color);
     cursor: pointer;

--- a/client/features/booking/availability.ts
+++ b/client/features/booking/availability.ts
@@ -1,0 +1,137 @@
+// 공개(고객) 온라인 예약 슬롯 계산 — 순수 함수(서버 API에서 재사용).
+// 영업시간 − 기존 active 예약(네이버 포함) − 담당자 스케줄 − 서비스 총소요 − 최소 사전시간,
+// slotInterval 간격으로 예약 가능한 시작 시각("HH:MM")을 계산한다.
+
+export interface SlotBusinessHour {
+    openTime: string; // "HH:MM"
+    closeTime: string; // "HH:MM"
+    enabled: boolean;
+}
+
+export interface SlotAssigneeSchedule {
+    dayIndex: number;
+    enabled: boolean;
+    startTime: string;
+    endTime: string;
+}
+
+export interface SlotAssignee {
+    id: string;
+    schedules: SlotAssigneeSchedule[];
+}
+
+export interface SlotReservation {
+    assigneeId: string | null;
+    startTime: string;
+    endTime: string;
+}
+
+export interface AvailabilityInput {
+    dayIndex: number; // 0=일 … 6=토 (해당 날짜의 요일)
+    businessHour: SlotBusinessHour | null;
+    durationMin: number; // 선택 서비스 총 소요(분)
+    slotIntervalMin: number;
+    minStartMinute: number; // 이 분(자정 기준) 이전 슬롯 제외 — 최소 사전시간·오늘 현재시각 반영. 없으면 0.
+    reservations: SlotReservation[]; // 해당 날짜 active 예약
+    assigneeId: string | null; // 특정 담당자 선택, null=상관없음
+    assignees: SlotAssignee[]; // 활성 담당자(스케줄 포함)
+}
+
+export function timeToMinutes(hhmm: string): number {
+    const [h, m] = hhmm.split(':').map(Number);
+    return h * 60 + m;
+}
+
+export function minutesToTime(min: number): string {
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+function overlaps(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+    return aStart < bEnd && bStart < aEnd;
+}
+
+// 담당자가 [start,end)에 근무하는가. 해당 요일 스케줄 행이 없으면 영업시간대로 근무한다고 본다.
+function isAssigneeWorking(a: SlotAssignee, dayIndex: number, start: number, end: number): boolean {
+    const sch = a.schedules.find((s) => s.dayIndex === dayIndex);
+    if (!sch) return true; // 스케줄 미설정 = 영업시간 그대로 근무
+    if (!sch.enabled) return false;
+    return timeToMinutes(sch.startTime) <= start && end <= timeToMinutes(sch.endTime);
+}
+
+/**
+ * 예약 가능한 시작 시각 목록을 반환한다.
+ *
+ * 담당자 용량 모델: 한 슬롯에 겹치는 예약을 (배정 담당자별) + (미배정) 부하로 나눠,
+ * "근무 중이며 배정 예약이 없는 담당자 수 > 미배정 예약 수"일 때만 가용으로 본다.
+ * 미배정 예약(네이버 미매칭 등)은 어느 담당자인지 모르므로 여유 인원을 소모하는 것으로 계산.
+ * 담당자가 0명인 매장은 단일 자원(1)으로 취급 — 겹치는 예약이 하나도 없을 때만 가용.
+ */
+export function computeAvailableSlots(input: AvailabilityInput): string[] {
+    const {
+        dayIndex, businessHour, durationMin, slotIntervalMin,
+        minStartMinute, reservations, assigneeId, assignees,
+    } = input;
+
+    if (!businessHour || !businessHour.enabled) return [];
+    if (durationMin <= 0) return [];
+    const interval = slotIntervalMin > 0 ? slotIntervalMin : 30;
+
+    const open = timeToMinutes(businessHour.openTime);
+    const close = timeToMinutes(businessHour.closeTime);
+    if (close <= open) return [];
+
+    const slots: string[] = [];
+
+    for (let start = open; start + durationMin <= close; start += interval) {
+        if (start < minStartMinute) continue;
+        const end = start + durationMin;
+
+        const overlapping = reservations.filter((r) =>
+            overlaps(start, end, timeToMinutes(r.startTime), timeToMinutes(r.endTime)));
+
+        // 담당자가 없는 매장: 단일 자원으로 취급
+        if (assignees.length === 0) {
+            if (overlapping.length === 0) slots.push(minutesToTime(start));
+            continue;
+        }
+
+        const unassignedLoad = overlapping.filter((r) => !r.assigneeId).length;
+        const busyAssigneeIds = new Set(
+            overlapping.map((r) => r.assigneeId).filter((id): id is string => Boolean(id)),
+        );
+
+        const workingFree = assignees.filter((a) =>
+            isAssigneeWorking(a, dayIndex, start, end) && !busyAssigneeIds.has(a.id));
+
+        if (assigneeId) {
+            const chosenFree = workingFree.some((a) => a.id === assigneeId);
+            if (chosenFree && workingFree.length > unassignedLoad) slots.push(minutesToTime(start));
+        } else if (workingFree.length > unassignedLoad) {
+            slots.push(minutesToTime(start));
+        }
+    }
+
+    return slots;
+}
+
+// 상관없음(자동 배정) 시 슬롯을 실제로 맡길 담당자 하나를 고른다.
+// 근무 중이며 그 슬롯에 배정 예약이 없는 첫 담당자. 없으면 null(미배정).
+export function pickAssigneeForSlot(
+    input: Omit<AvailabilityInput, 'minStartMinute'> & {startMinute: number},
+): string | null {
+    const {dayIndex, durationMin, reservations, assignees, startMinute} = input;
+    if (assignees.length === 0) return null;
+    const end = startMinute + durationMin;
+
+    const overlapping = reservations.filter((r) =>
+        overlaps(startMinute, end, timeToMinutes(r.startTime), timeToMinutes(r.endTime)));
+    const busyAssigneeIds = new Set(
+        overlapping.map((r) => r.assigneeId).filter((id): id is string => Boolean(id)),
+    );
+
+    const free = assignees.find((a) =>
+        isAssigneeWorking(a, dayIndex, startMinute, end) && !busyAssigneeIds.has(a.id));
+    return free ? free.id : null;
+}

--- a/client/features/booking/availability.ts
+++ b/client/features/booking/availability.ts
@@ -118,9 +118,13 @@ export function computeAvailableSlots(input: AvailabilityInput): string[] {
 
 // 상관없음(자동 배정) 시 슬롯을 실제로 맡길 담당자 하나를 고른다.
 // 근무 중이며 그 슬롯에 배정 예약이 없는 첫 담당자. 없으면 null(미배정).
-export function pickAssigneeForSlot(
-    input: Omit<AvailabilityInput, 'minStartMinute'> & {startMinute: number},
-): string | null {
+export function pickAssigneeForSlot(input: {
+    dayIndex: number;
+    durationMin: number;
+    reservations: SlotReservation[];
+    assignees: SlotAssignee[];
+    startMinute: number;
+}): string | null {
     const {dayIndex, durationMin, reservations, assignees, startMinute} = input;
     if (assignees.length === 0) return null;
     const end = startMinute + durationMin;

--- a/client/features/booking/availability.ts
+++ b/client/features/booking/availability.ts
@@ -27,7 +27,7 @@ export interface SlotReservation {
 }
 
 export interface AvailabilityInput {
-    dayIndex: number; // 0=일 … 6=토 (해당 날짜의 요일)
+    dayIndex: number; // 스케줄 인덱스(0=월 … 6=일) — AssigneeSchedule.dayIndex와 같은 규칙
     businessHour: SlotBusinessHour | null;
     durationMin: number; // 선택 서비스 총 소요(분)
     slotIntervalMin: number;
@@ -117,7 +117,9 @@ export function computeAvailableSlots(input: AvailabilityInput): string[] {
 }
 
 // 상관없음(자동 배정) 시 슬롯을 실제로 맡길 담당자 하나를 고른다.
-// 근무 중이며 그 슬롯에 배정 예약이 없는 첫 담당자. 없으면 null(미배정).
+// computeAvailableSlots 용량 모델과 일치: 근무 중이며 배정 예약이 없는 담당자 중,
+// 앞쪽 unassignedLoad명은 미배정(네이버 등) 예약 몫으로 남기고 그 다음 담당자를 배정.
+// 여유가 없으면 null(미배정).
 export function pickAssigneeForSlot(input: {
     dayIndex: number;
     durationMin: number;
@@ -131,11 +133,12 @@ export function pickAssigneeForSlot(input: {
 
     const overlapping = reservations.filter((r) =>
         overlaps(startMinute, end, timeToMinutes(r.startTime), timeToMinutes(r.endTime)));
+    const unassignedLoad = overlapping.filter((r) => !r.assigneeId).length;
     const busyAssigneeIds = new Set(
         overlapping.map((r) => r.assigneeId).filter((id): id is string => Boolean(id)),
     );
 
-    const free = assignees.find((a) =>
+    const workingFree = assignees.filter((a) =>
         isAssigneeWorking(a, dayIndex, startMinute, end) && !busyAssigneeIds.has(a.id));
-    return free ? free.id : null;
+    return workingFree[unassignedLoad]?.id ?? null;
 }

--- a/client/features/store-settings/model.ts
+++ b/client/features/store-settings/model.ts
@@ -28,6 +28,9 @@ export interface BookingSettings {
     maxAdvanceDays: number;
     allowAssigneeChoice: boolean;
     noticeText: string | null;
+    // 공개 노출할 서비스명 화이트리스트. null 또는 []=전체 노출, 비어있지 않으면 그 서비스만 노출.
+    // (이 앱은 서비스를 name으로 식별 — DB 컬럼명은 bookableServiceIdsJson) 오너 설정에만 쓰이고 고객 응답엔 미노출.
+    bookableServiceNames: string[] | null;
 }
 
 export const DEFAULT_BOOKING_SETTINGS: BookingSettings = {
@@ -36,7 +39,21 @@ export const DEFAULT_BOOKING_SETTINGS: BookingSettings = {
     maxAdvanceDays: 30,
     allowAssigneeChoice: true,
     noticeText: null,
+    bookableServiceNames: null,
 };
+
+// bookableServiceIdsJson(Prisma Json) → 화이트리스트. 배열이면서 비어있지 않을 때만 유효, 그 외 null(전체 노출).
+export function parseBookableServiceNames(json: unknown): string[] | null {
+    if (!Array.isArray(json)) return null;
+    const names = json.filter((x): x is string => typeof x === 'string');
+    return names.length > 0 ? names : null;
+}
+
+// 요청 서비스가 모두 노출 허용 범위인지. 화이트리스트가 null이면 전체 허용.
+export function areServicesBookable(requested: string[], whitelist: string[] | null): boolean {
+    if (!whitelist) return true;
+    return requested.every((name) => whitelist.includes(name));
+}
 
 // 공개 URL 슬러그: 소문자 영숫자·하이픈, 3~32자, 하이픈으로 시작/끝 불가.
 export const BOOKING_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{1,30}[a-z0-9])$/;

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.21.0",
+    "version": "0.22.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pages/api/book/[slug]/availability.ts
+++ b/client/pages/api/book/[slug]/availability.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../../../server/api/book/[slug]/availability';

--- a/client/pages/api/book/[slug]/reserve.ts
+++ b/client/pages/api/book/[slug]/reserve.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../../../server/api/book/[slug]/reserve';

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -132,7 +132,20 @@ export default function BookingPage() {
             .then(async (res) => {
                 const data = await res.json().catch(() => ({}));
                 if (res.status === 201) { setResult(data as ReserveResult); return; }
-                if (res.status === 409) { setSubmitError('선택하신 시간이 방금 마감되었습니다. 다른 시간을 선택해 주세요.'); fetchSlots(); setSelectedSlot(''); return; }
+                if (res.status === 409) {
+                    const code = typeof data.error === 'string' ? data.error : '';
+                    if (code === 'duplicate') {
+                        setSubmitError('이미 같은 시간에 예약이 있습니다. 다른 시간을 선택해 주세요.');
+                    } else if (code === 'unavailable_date') {
+                        setSubmitError('선택하신 날짜는 예약할 수 없습니다. 다른 날짜를 선택해 주세요.');
+                    } else {
+                        // slot_taken · retry_exhausted: 슬롯이 방금 마감됨 → 재조회
+                        setSubmitError('선택하신 시간이 방금 마감되었습니다. 다른 시간을 선택해 주세요.');
+                    }
+                    fetchSlots();
+                    setSelectedSlot('');
+                    return;
+                }
                 setSubmitError('예약에 실패했습니다. 잠시 후 다시 시도해 주세요.');
             })
             .catch(() => setSubmitError('예약에 실패했습니다. 잠시 후 다시 시도해 주세요.'))
@@ -155,7 +168,6 @@ export default function BookingPage() {
     }
 
     if (result) {
-        const bookHref = `/book/${encodeURIComponent(slug)}/r/${result.publicToken}`;
         return (
             <StyledWrap>
                 <SeoHead title={`${info.storeName} 예약 완료`} />
@@ -167,8 +179,7 @@ export default function BookingPage() {
                         <StyledSummaryRow><span>시간</span><StyledSummaryValue>{result.startTime} ~ {result.endTime}</StyledSummaryValue></StyledSummaryRow>
                         <StyledSummaryRow><span>{labels.service}</span><StyledSummaryValue>{result.serviceSummary}</StyledSummaryValue></StyledSummaryRow>
                     </StyledSummary>
-                    <StyledNotice>예약 확인·변경·취소는 아래 링크에서 하실 수 있습니다. 링크를 저장해 주세요.</StyledNotice>
-                    <StyledLink href={bookHref}>내 예약 보기</StyledLink>
+                    <StyledNotice>예약이 정상 접수되었습니다. 위 예약 정보를 확인해 주세요. 변경·취소가 필요하면 매장으로 문의해 주세요.</StyledNotice>
                 </StyledCard>
             </StyledWrap>
         );
@@ -221,7 +232,13 @@ export default function BookingPage() {
                             <>
                                 <StyledSectionLabel>시간 선택</StyledSectionLabel>
                                 {slotsLoading && <StyledMuted>시간을 불러오는 중…</StyledMuted>}
-                                {!slotsLoading && slots.length === 0 && <StyledMuted>선택하신 날짜에 예약 가능한 시간이 없습니다.</StyledMuted>}
+                                {!slotsLoading && slots.length === 0 && (
+                                    <StyledMuted>
+                                        {totalDuration === 0
+                                            ? `선택하신 ${labels.service}는 소요시간이 0분이라 시간 예약을 할 수 없습니다. 다른 ${labels.service}를 선택해 주세요.`
+                                            : '선택하신 날짜에 예약 가능한 시간이 없습니다.'}
+                                    </StyledMuted>
+                                )}
                                 {!slotsLoading && slots.length > 0 && (
                                     <StyledSlotGrid>
                                         {slots.map((slot) => (
@@ -472,20 +489,6 @@ const StyledNextBtn = styled.button`
     font-weight: 700;
     cursor: pointer;
     &:disabled { opacity: 0.45; cursor: not-allowed; }
-`;
-
-const StyledLink = styled.a`
-    margin-top: 8px;
-    display: block;
-    height: 50px;
-    line-height: 50px;
-    text-align: center;
-    border-radius: 12px;
-    background: var(--brand-color, #6526d9);
-    color: #fff;
-    font-size: 16px;
-    font-weight: 700;
-    text-decoration: none;
 `;
 
 const StyledMuted = styled.p`

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -1,10 +1,11 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {useRouter} from 'next/router';
 
 import styled from 'styled-components';
 
 import {getStoreLabels} from '../../features/store-settings/labels';
+import {formatTel, normalizeTel} from '../../features/customers/model';
 import {SeoHead} from '../../components/ui/SeoHead';
 
 interface BookServiceInfo {
@@ -23,10 +24,27 @@ interface BookStoreInfo {
     shopType: string | null;
     services: BookServiceInfo[];
     assignees: BookAssigneeInfo[];
-    settings: {allowAssigneeChoice: boolean; noticeText: string | null};
+    settings: {allowAssigneeChoice: boolean; noticeText: string | null; maxAdvanceDays: number};
+}
+interface ReserveResult {
+    publicToken: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    serviceSummary: string;
 }
 
 const ASSIGNEE_ANY = '__any__';
+
+// 오늘(로컬=KST) 기준 YYYY-MM-DD. date input min/max·기본값용.
+function localDateStr(offsetDays = 0): string {
+    const d = new Date();
+    d.setDate(d.getDate() + offsetDays);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
 
 export default function BookingPage() {
     const router = useRouter();
@@ -38,11 +56,20 @@ export default function BookingPage() {
 
     const [selectedServices, setSelectedServices] = useState<string[]>([]);
     const [assigneeId, setAssigneeId] = useState<string>(ASSIGNEE_ANY);
+    const [date, setDate] = useState<string>('');
+    const [slots, setSlots] = useState<string[]>([]);
+    const [slotsLoading, setSlotsLoading] = useState(false);
+    const [selectedSlot, setSelectedSlot] = useState<string>('');
+
+    const [name, setName] = useState('');
+    const [tel, setTel] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string>('');
+    const [result, setResult] = useState<ReserveResult | null>(null);
 
     useEffect(() => {
         if (!slug) return;
         let alive = true;
-        setLoading(true);
         fetch(`/api/book/${encodeURIComponent(slug)}`)
             .then((res) => {
                 if (res.status === 404) { if (alive) setNotFound(true); return null; }
@@ -56,8 +83,60 @@ export default function BookingPage() {
 
     const labels = useMemo(() => getStoreLabels(info?.shopType ?? null), [info?.shopType]);
 
-    const toggleService = (name: string) => {
-        setSelectedServices((prev) => prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]);
+    const toggleService = (serviceName: string) => {
+        setSelectedServices((prev) => prev.includes(serviceName) ? prev.filter((n) => n !== serviceName) : [...prev, serviceName]);
+        setSelectedSlot('');
+    };
+
+    // 서비스·담당자·날짜가 정해지면 가용 슬롯 조회
+    const fetchSlots = useCallback(() => {
+        if (!slug || !date || selectedServices.length === 0) { setSlots([]); return; }
+        let alive = true;
+        setSlotsLoading(true);
+        const params = new URLSearchParams({date, services: selectedServices.join(',')});
+        if (assigneeId !== ASSIGNEE_ANY) params.set('assignee', assigneeId);
+        fetch(`/api/book/${encodeURIComponent(slug)}/availability?${params.toString()}`)
+            .then((res) => (res.ok ? res.json() : Promise.reject(new Error('slots failed'))))
+            .then((data) => { if (alive) setSlots(Array.isArray(data.slots) ? data.slots : []); })
+            .catch(() => { if (alive) setSlots([]); })
+            .finally(() => { if (alive) setSlotsLoading(false); });
+        return () => { alive = false; };
+    }, [slug, date, selectedServices, assigneeId]);
+
+    // 서비스·담당자·날짜가 바뀌면 슬롯을 다시 불러온다. selectedSlot 초기화는 각 입력 핸들러가 담당.
+    // fetchSlots는 요청 중 로딩 플래그를 세우는 표준 fetch-in-effect 패턴이라 규칙을 로컬 예외 처리.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    useEffect(() => fetchSlots(), [fetchSlots]);
+
+    const totalDuration = useMemo(
+        () => selectedServices.reduce((sum, n) => sum + (info?.services.find((s) => s.name === n)?.duration ?? 0), 0),
+        [selectedServices, info],
+    );
+    const totalPrice = useMemo(
+        () => selectedServices.reduce((sum, n) => sum + (info?.services.find((s) => s.name === n)?.price ?? 0), 0),
+        [selectedServices, info],
+    );
+
+    const telValid = normalizeTel(tel).length >= 10 && normalizeTel(tel).length <= 11;
+    const canSubmit = selectedServices.length > 0 && !!date && !!selectedSlot && name.trim().length > 0 && telValid && !submitting;
+
+    const submit = () => {
+        if (!canSubmit) return;
+        setSubmitting(true);
+        setSubmitError('');
+        fetch(`/api/book/${encodeURIComponent(slug)}/reserve`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({date, startTime: selectedSlot, services: selectedServices, assigneeId: assigneeId !== ASSIGNEE_ANY ? assigneeId : null, name: name.trim(), tel: normalizeTel(tel)}),
+        })
+            .then(async (res) => {
+                const data = await res.json().catch(() => ({}));
+                if (res.status === 201) { setResult(data as ReserveResult); return; }
+                if (res.status === 409) { setSubmitError('선택하신 시간이 방금 마감되었습니다. 다른 시간을 선택해 주세요.'); fetchSlots(); setSelectedSlot(''); return; }
+                setSubmitError('예약에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+            })
+            .catch(() => setSubmitError('예약에 실패했습니다. 잠시 후 다시 시도해 주세요.'))
+            .finally(() => setSubmitting(false));
     };
 
     if (loading) {
@@ -75,7 +154,25 @@ export default function BookingPage() {
         );
     }
 
-    const canNext = selectedServices.length > 0;
+    if (result) {
+        const bookHref = `/book/${encodeURIComponent(slug)}/r/${result.publicToken}`;
+        return (
+            <StyledWrap>
+                <SeoHead title={`${info.storeName} 예약 완료`} />
+                <StyledCard>
+                    <StyledStore>{info.storeName}</StyledStore>
+                    <StyledTitle>예약이 접수되었습니다</StyledTitle>
+                    <StyledSummary>
+                        <StyledSummaryRow><span>날짜</span><strong>{result.date}</strong></StyledSummaryRow>
+                        <StyledSummaryRow><span>시간</span><strong>{result.startTime} ~ {result.endTime}</strong></StyledSummaryRow>
+                        <StyledSummaryRow><span>{labels.service}</span><strong>{result.serviceSummary}</strong></StyledSummaryRow>
+                    </StyledSummary>
+                    <StyledNotice>예약 확인·변경·취소는 아래 링크에서 하실 수 있습니다. 링크를 저장해 주세요.</StyledNotice>
+                    <StyledLink href={bookHref}>내 예약 보기</StyledLink>
+                </StyledCard>
+            </StyledWrap>
+        );
+    }
 
     return (
         <StyledWrap>
@@ -91,7 +188,7 @@ export default function BookingPage() {
                     {info.services.map((s) => {
                         const on = selectedServices.includes(s.name);
                         return (
-                            <StyledServiceCard key={s.name} type="button" $on={on} onClick={() => toggleService(s.name)}>
+                            <StyledServiceCard key={s.name} type="button" $on={on} aria-pressed={on} onClick={() => toggleService(s.name)}>
                                 <StyledServiceName>{s.name}</StyledServiceName>
                                 <StyledServiceMeta>{s.duration}분 · {s.price.toLocaleString()}원</StyledServiceMeta>
                             </StyledServiceCard>
@@ -102,17 +199,67 @@ export default function BookingPage() {
                 {info.settings.allowAssigneeChoice && info.assignees.length > 0 && (
                     <>
                         <StyledSectionLabel>{labels.assignee} 선택</StyledSectionLabel>
-                        <StyledSelect value={assigneeId} onChange={(e) => setAssigneeId(e.target.value)}>
+                        <StyledSelect value={assigneeId} onChange={(e) => { setAssigneeId(e.target.value); setSelectedSlot(''); }}>
                             <option value={ASSIGNEE_ANY}>상관없음</option>
                             {info.assignees.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
                         </StyledSelect>
                     </>
                 )}
 
-                <StyledNextBtn type="button" disabled={!canNext} title={canNext ? '' : `${labels.service}를 선택해 주세요`}>
-                    다음 (시간 선택) — 준비 중
+                {selectedServices.length > 0 && (
+                    <>
+                        <StyledSectionLabel>날짜 선택</StyledSectionLabel>
+                        <StyledDateInput
+                            type="date"
+                            value={date}
+                            min={localDateStr(0)}
+                            max={localDateStr(info.settings.maxAdvanceDays)}
+                            onChange={(e) => { setDate(e.target.value); setSelectedSlot(''); }}
+                        />
+
+                        {date && (
+                            <>
+                                <StyledSectionLabel>시간 선택</StyledSectionLabel>
+                                {slotsLoading && <StyledMuted>시간을 불러오는 중…</StyledMuted>}
+                                {!slotsLoading && slots.length === 0 && <StyledMuted>선택하신 날짜에 예약 가능한 시간이 없습니다.</StyledMuted>}
+                                {!slotsLoading && slots.length > 0 && (
+                                    <StyledSlotGrid>
+                                        {slots.map((slot) => (
+                                            <StyledSlotBtn key={slot} type="button" $on={selectedSlot === slot} aria-pressed={selectedSlot === slot} onClick={() => setSelectedSlot(slot)}>
+                                                {slot}
+                                            </StyledSlotBtn>
+                                        ))}
+                                    </StyledSlotGrid>
+                                )}
+                            </>
+                        )}
+                    </>
+                )}
+
+                {selectedSlot && (
+                    <>
+                        <StyledSectionLabel>예약자 정보</StyledSectionLabel>
+                        <StyledField>
+                            <StyledFieldLabel htmlFor="book-name">이름</StyledFieldLabel>
+                            <StyledTextInput id="book-name" type="text" value={name} maxLength={40} placeholder="이름" onChange={(e) => setName(e.target.value)} />
+                        </StyledField>
+                        <StyledField>
+                            <StyledFieldLabel htmlFor="book-tel">연락처</StyledFieldLabel>
+                            <StyledTextInput id="book-tel" type="tel" inputMode="numeric" value={tel} placeholder="010-0000-0000" onChange={(e) => setTel(e.target.value)} onBlur={() => setTel((t) => formatTel(t))} />
+                        </StyledField>
+
+                        <StyledTotal>
+                            <span>합계</span>
+                            <strong>{totalPrice.toLocaleString()}원 · {totalDuration}분</strong>
+                        </StyledTotal>
+                    </>
+                )}
+
+                {submitError && <StyledError role="alert">{submitError}</StyledError>}
+
+                <StyledNextBtn type="button" disabled={!canSubmit} onClick={submit}>
+                    {submitting ? '예약 중…' : '예약하기'}
                 </StyledNextBtn>
-                <StyledDevNote>* 시간 선택·예약 확정은 다음 단계에서 붙습니다.</StyledDevNote>
             </StyledCard>
         </StyledWrap>
     );
@@ -216,6 +363,95 @@ const StyledSelect = styled.select`
     background: var(--white-color, #fff);
 `;
 
+const StyledDateInput = styled.input`
+    width: 100%;
+    height: 44px;
+    padding: 0 12px;
+    border: 1px solid var(--light-gray-color, #e4e7eb);
+    border-radius: 10px;
+    font-size: 15px;
+    background: var(--white-color, #fff);
+    box-sizing: border-box;
+`;
+
+const StyledSlotGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 8px;
+`;
+
+const StyledSlotBtn = styled.button<{$on: boolean}>`
+    height: 42px;
+    border: 2px solid ${(p) => (p.$on ? 'var(--brand-color, #6526d9)' : 'var(--light-gray-color, #e4e7eb)')};
+    border-radius: 10px;
+    background: ${(p) => (p.$on ? 'var(--brand-color, #6526d9)' : 'var(--white-color, #fff)')};
+    color: ${(p) => (p.$on ? '#fff' : 'var(--black-color, #111)')};
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+`;
+
+const StyledField = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+const StyledFieldLabel = styled.label`
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--dark-gray-color2, #667);
+`;
+
+const StyledTextInput = styled.input`
+    width: 100%;
+    height: 44px;
+    padding: 0 12px;
+    border: 1px solid var(--light-gray-color, #e4e7eb);
+    border-radius: 10px;
+    font-size: 15px;
+    background: var(--white-color, #fff);
+    box-sizing: border-box;
+`;
+
+const StyledTotal = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 8px;
+    padding: 12px;
+    background: var(--aside-bg, #f4f6f8);
+    border-radius: 10px;
+    font-size: 14px;
+    color: var(--dark-gray-color, #444);
+    strong { color: var(--black-color, #111); font-weight: 800; }
+`;
+
+const StyledSummary = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 4px;
+    padding: 16px;
+    background: var(--aside-bg, #f4f6f8);
+    border-radius: 12px;
+`;
+
+const StyledSummaryRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 14px;
+    color: var(--dark-gray-color2, #667);
+    strong { color: var(--black-color, #111); font-weight: 700; text-align: right; }
+`;
+
+const StyledError = styled.p`
+    margin: 8px 0 0;
+    font-size: 13px;
+    color: var(--danger-color, #d64545);
+`;
+
 const StyledNextBtn = styled.button`
     margin-top: 20px;
     height: 50px;
@@ -229,11 +465,18 @@ const StyledNextBtn = styled.button`
     &:disabled { opacity: 0.45; cursor: not-allowed; }
 `;
 
-const StyledDevNote = styled.p`
-    margin: 4px 0 0;
-    font-size: 12px;
-    color: var(--gray-color, #98a);
+const StyledLink = styled.a`
+    margin-top: 8px;
+    display: block;
+    height: 50px;
+    line-height: 50px;
     text-align: center;
+    border-radius: 12px;
+    background: var(--brand-color, #6526d9);
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    text-decoration: none;
 `;
 
 const StyledMuted = styled.p`

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -163,9 +163,9 @@ export default function BookingPage() {
                     <StyledStore>{info.storeName}</StyledStore>
                     <StyledTitle>예약이 접수되었습니다</StyledTitle>
                     <StyledSummary>
-                        <StyledSummaryRow><span>날짜</span><strong>{result.date}</strong></StyledSummaryRow>
-                        <StyledSummaryRow><span>시간</span><strong>{result.startTime} ~ {result.endTime}</strong></StyledSummaryRow>
-                        <StyledSummaryRow><span>{labels.service}</span><strong>{result.serviceSummary}</strong></StyledSummaryRow>
+                        <StyledSummaryRow><span>날짜</span><StyledSummaryValue>{result.date}</StyledSummaryValue></StyledSummaryRow>
+                        <StyledSummaryRow><span>시간</span><StyledSummaryValue>{result.startTime} ~ {result.endTime}</StyledSummaryValue></StyledSummaryRow>
+                        <StyledSummaryRow><span>{labels.service}</span><StyledSummaryValue>{result.serviceSummary}</StyledSummaryValue></StyledSummaryRow>
                     </StyledSummary>
                     <StyledNotice>예약 확인·변경·취소는 아래 링크에서 하실 수 있습니다. 링크를 저장해 주세요.</StyledNotice>
                     <StyledLink href={bookHref}>내 예약 보기</StyledLink>
@@ -250,7 +250,7 @@ export default function BookingPage() {
 
                         <StyledTotal>
                             <span>합계</span>
-                            <strong>{totalPrice.toLocaleString()}원 · {totalDuration}분</strong>
+                            <StyledTotalValue>{totalPrice.toLocaleString()}원 · {totalDuration}분</StyledTotalValue>
                         </StyledTotal>
                     </>
                 )}
@@ -424,7 +424,11 @@ const StyledTotal = styled.div`
     border-radius: 10px;
     font-size: 14px;
     color: var(--dark-gray-color, #444);
-    strong { color: var(--black-color, #111); font-weight: 800; }
+`;
+
+const StyledTotalValue = styled.strong`
+    color: var(--black-color, #111);
+    font-weight: 800;
 `;
 
 const StyledSummary = styled.div`
@@ -443,7 +447,12 @@ const StyledSummaryRow = styled.div`
     gap: 12px;
     font-size: 14px;
     color: var(--dark-gray-color2, #667);
-    strong { color: var(--black-color, #111); font-weight: 700; text-align: right; }
+`;
+
+const StyledSummaryValue = styled.strong`
+    color: var(--black-color, #111);
+    font-weight: 700;
+    text-align: right;
 `;
 
 const StyledError = styled.p`

--- a/index.md
+++ b/index.md
@@ -92,7 +92,7 @@ hair_reservations/
 [^20]: **정책 문서 단일 소스 구조** — 법률 본문은 문서당 파일 하나(`content/policies/{terms,privacy,dpa}.ts`)에만 두고, 제목 메타는 `content/policies/index.ts` 레지스트리(`navTitle`/`docTitle`/`body`)로 관리. 이 본문을 **인라인 페이지**(`/terms`·`/privacy`·`/dpa` → `PolicyPage`)·**보기 레이어**(`PolicyViewLayer`)·**풀페이지**(`/policies/:slug` → `api/policies/[slug].ts`가 `renderPolicyHtml`로 독립 HTML 응답)가 모두 공유 → 한 곳만 고치면 전체 반영. 공통 CSS도 `components/policy/policyCss.ts`(`POLICY_VARS_*`·`POLICY_ELEMENT_CSS`)에서 styled-components(인라인)·`<style>`(풀페이지) 양쪽이 같은 문자열 사용. DPA는 서버 보관(수탁) 개시 시점에 필요하므로 SNS 연동(인증) 이후에만 노출
 [^21]: 회원권 관리는 `Store.useMembershipSystem` 토글 ON일 때만 aside 메뉴·`/settings/membership` 탭 노출. 상품(횟수/기간권) CRUD + 고객 발급·수동 차감까지 구현(Phase 1·2). **결제 연동(예약 결제수단으로 자동 차감, `PaymentMethod.membership`)은 미구현(Phase 3 예정)**
 [^22]: 쿠폰 관리는 `Store.useCouponSystem` 토글 ON일 때만 aside 메뉴·`/settings/coupon` 탭 노출. **Phase 1만 구현** — 상품(정액 amount/정률 rate, maxDiscount·minOrderAmount·validDays·code) CRUD(`/api/coupons` owner, `server/api/coupons.ts`). **발급(직접·코드형, Phase 2)·결제 자동 차감(`PaymentMethod.coupon`, Phase 3)은 미구현.** 회원권 시스템 패턴 미러링
-[^23]: **고객 공개 온라인 예약**(`Store.useOnlineBooking` ON + `bookingSlug` 매장만). 공개 구역은 비로그인 — `proxy.ts`/`_app.tsx`/`LayoutComponent`가 `/book/*`를 인증·게이트에서 제외. 공개 API(`server/api/book/*`)는 **매장 스코프 + 데이터 최소 노출**(고객/예약 정보 절대 미반환). 페이지 `pages/book/[slug].tsx`: 서비스·담당자·날짜·시간 선택 + 이름/연락처 → 예약 생성 → `publicToken` 발급(고객 관리 링크 `/book/[slug]/r/[token]`는 Phase 1d). 슬롯 계산은 `features/booking/availability.ts` 순수함수, 예약 생성은 트랜잭션(Serializable) 슬롯 재검증으로 동시성 방어. **Phase 1b까지 구현**(공개정보·슬롯·예약생성). 노출 서비스 선택(1c)·확인/변경/취소(1d, Phase 2)·알림(1f, Phase 3)·서브도메인 rewrite(1e)는 미구현. 마이그레이션 `0008`(채널·토글·슬러그·규칙)·`0009`(`Reservation.publicToken`·`StoreBookingSettings.bookableServiceIdsJson`)
+[^23]: **고객 공개 온라인 예약**(`Store.useOnlineBooking` ON + `bookingSlug` 매장만). 공개 구역은 비로그인 — `proxy.ts`/`_app.tsx`/`LayoutComponent`가 `/book/*`를 인증·게이트에서 제외. 공개 API(`server/api/book/*`)는 **매장 스코프 + 데이터 최소 노출**(고객/예약 정보 절대 미반환). 페이지 `pages/book/[slug].tsx`: 서비스·담당자·날짜·시간 선택 + 이름/연락처 → 예약 생성 → `publicToken` 발급(고객 관리 링크 `/book/[slug]/r/[token]`는 Phase 1d). 슬롯 계산은 `features/booking/availability.ts` 순수함수, 예약 생성은 트랜잭션(Serializable) 슬롯 재검증으로 동시성 방어. **노출 서비스 선택(1c)**: 오너가 `/settings/booking`에서 공개할 서비스만 선택(`BookingSettings.bookableServiceNames`→DB `bookableServiceIdsJson`), 공개 API가 필터·거부(`not_bookable`). **Phase 1c까지 구현**(공개정보·슬롯·예약생성·노출서비스). 확인/변경/취소(1d, Phase 2)·알림(1f, Phase 3)·서브도메인 rewrite(1e)는 미구현. 마이그레이션 `0008`(채널·토글·슬러그·규칙)·`0009`(`Reservation.publicToken`·`StoreBookingSettings.bookableServiceIdsJson`)
 
 ### 도메인 모델 (`client/features/`)
 
@@ -104,7 +104,7 @@ hair_reservations/
 | `assignees/model.ts` | `Assignee` | id, name, schedule(7일), status[^6], color, phone |
 | `services/model.ts` | `ServiceItem` | name, durationMinutes, category, price |
 | `services/default-services.ts` | - | 업종(ShopType) union + 업종별 기본 서비스·카테고리 색상(Partial, 온보딩용) |
-| `store-settings/model.ts` | `StoreSettings`/`BookingSettings` | businessHours, closedDates, pointSettings(적립률, 충전규칙). `BookingSettings`(공개 예약 규칙: slotIntervalMin·minLeadMinutes·maxAdvanceDays·allowAssigneeChoice·noticeText) + slug 검증(`isValidBookingSlug`) |
+| `store-settings/model.ts` | `StoreSettings`/`BookingSettings` | businessHours, closedDates, pointSettings(적립률, 충전규칙). `BookingSettings`(공개 예약 규칙: slotIntervalMin·minLeadMinutes·maxAdvanceDays·allowAssigneeChoice·noticeText·`bookableServiceNames`[노출 서비스 화이트리스트, null=전체]) + slug 검증(`isValidBookingSlug`)·노출 헬퍼(`parseBookableServiceNames`/`areServicesBookable`) |
 | `booking/availability.ts` | - | 공개 온라인 예약 슬롯 계산 순수 함수(`computeAvailableSlots`/`pickAssigneeForSlot`). 서버 API가 재사용. 영업시간−기존예약−담당자스케줄−소요−최소사전시간, 담당자 용량 모델[^23] |
 | `store-settings/labels.ts` | - | 업종 마스터 목록·category별 표시어(담당자/서비스)·`getStoreLabels`/`sanitizeShopType` ([업종별 라벨](#업종별-라벨-담당자서비스-표시어)) |
 | `local-db/storage.ts` | - | 게스트 모드 로컬 스냅샷 (`takeaseat.local-db.v1`). `shouldUseLocalDb()`로 모드 판정, 게스트 약관 동의 버전 헬퍼(`getGuestTermsVersion`/`setGuestTermsAgreed`) — `lib/local-db`로 re-export |
@@ -198,7 +198,7 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `assignees.ts` | `/api/assignees` | GET(staff) / PUT(owner) / DELETE(owner) | - | 담당자 CRUD + 일정(AssigneeSchedule) upsert. DELETE는 영구 삭제(분리): 예약은 assigneeId=null로 보존, 스케줄은 cascade 삭제 |
 | `assignees-merge.ts` | `/api/assignees/merge` | POST | owner | 담당자 병합 (source→target 예약 재배정 후 source 삭제) |
 | `services.ts` | `/api/services` | GET(staff) / PUT(owner) | - | 서비스 카탈로그 관리 |
-| `store.ts` | `/api/store` | GET(staff) / PUT(owner) | - | 매장 설정 (영업시간, 휴무일, 포인트 설정, 업종, **적립금/회원권 시스템 토글** `usePointSystem`/`useMembershipSystem`) |
+| `store.ts` | `/api/store` | GET(staff) / PUT(owner) | - | 매장 설정 (영업시간, 휴무일, 포인트 설정, 업종, **적립금/회원권 시스템 토글** `usePointSystem`/`useMembershipSystem`, **온라인예약** 토글·슬러그·규칙·노출서비스 `bookableServiceNames`) |
 | `memberships.ts` | `/api/memberships` | GET(staff) / POST·PUT·DELETE(owner) | - | 회원권 상품(횟수/기간권) CRUD + 보유 목록 조회 |
 | `membership-issue.ts` | `/api/membership-issue` | POST(staff) | - | 고객에게 회원권 발급/취소 (상품 스냅샷 → CustomerMembership) |
 | `membership-use.ts` | `/api/membership-use` | POST(staff) | - | 회원권 횟수 수동 차감/복원 (결제 흐름과 독립, MembershipUsage 기록) |

--- a/index.md
+++ b/index.md
@@ -92,23 +92,25 @@ hair_reservations/
 [^20]: **정책 문서 단일 소스 구조** — 법률 본문은 문서당 파일 하나(`content/policies/{terms,privacy,dpa}.ts`)에만 두고, 제목 메타는 `content/policies/index.ts` 레지스트리(`navTitle`/`docTitle`/`body`)로 관리. 이 본문을 **인라인 페이지**(`/terms`·`/privacy`·`/dpa` → `PolicyPage`)·**보기 레이어**(`PolicyViewLayer`)·**풀페이지**(`/policies/:slug` → `api/policies/[slug].ts`가 `renderPolicyHtml`로 독립 HTML 응답)가 모두 공유 → 한 곳만 고치면 전체 반영. 공통 CSS도 `components/policy/policyCss.ts`(`POLICY_VARS_*`·`POLICY_ELEMENT_CSS`)에서 styled-components(인라인)·`<style>`(풀페이지) 양쪽이 같은 문자열 사용. DPA는 서버 보관(수탁) 개시 시점에 필요하므로 SNS 연동(인증) 이후에만 노출
 [^21]: 회원권 관리는 `Store.useMembershipSystem` 토글 ON일 때만 aside 메뉴·`/settings/membership` 탭 노출. 상품(횟수/기간권) CRUD + 고객 발급·수동 차감까지 구현(Phase 1·2). **결제 연동(예약 결제수단으로 자동 차감, `PaymentMethod.membership`)은 미구현(Phase 3 예정)**
 [^22]: 쿠폰 관리는 `Store.useCouponSystem` 토글 ON일 때만 aside 메뉴·`/settings/coupon` 탭 노출. **Phase 1만 구현** — 상품(정액 amount/정률 rate, maxDiscount·minOrderAmount·validDays·code) CRUD(`/api/coupons` owner, `server/api/coupons.ts`). **발급(직접·코드형, Phase 2)·결제 자동 차감(`PaymentMethod.coupon`, Phase 3)은 미구현.** 회원권 시스템 패턴 미러링
+[^23]: **고객 공개 온라인 예약**(`Store.useOnlineBooking` ON + `bookingSlug` 매장만). 공개 구역은 비로그인 — `proxy.ts`/`_app.tsx`/`LayoutComponent`가 `/book/*`를 인증·게이트에서 제외. 공개 API(`server/api/book/*`)는 **매장 스코프 + 데이터 최소 노출**(고객/예약 정보 절대 미반환). 페이지 `pages/book/[slug].tsx`: 서비스·담당자·날짜·시간 선택 + 이름/연락처 → 예약 생성 → `publicToken` 발급(고객 관리 링크 `/book/[slug]/r/[token]`는 Phase 1d). 슬롯 계산은 `features/booking/availability.ts` 순수함수, 예약 생성은 트랜잭션(Serializable) 슬롯 재검증으로 동시성 방어. **Phase 1b까지 구현**(공개정보·슬롯·예약생성). 노출 서비스 선택(1c)·확인/변경/취소(1d, Phase 2)·알림(1f, Phase 3)·서브도메인 rewrite(1e)는 미구현. 마이그레이션 `0008`(채널·토글·슬러그·규칙)·`0009`(`Reservation.publicToken`·`StoreBookingSettings.bookableServiceIdsJson`)
 
 ### 도메인 모델 (`client/features/`)
 
 | 파일 | 모델 | 핵심 필드 |
 |------|------|----------|
-| `reservations/model.ts` | `Reservation` | id, date, startTime/endTime, customerId, assigneeId?, service, status[^4], price, naverBookingId?, channel[^5] |
+| `reservations/model.ts` | `Reservation` | id, date, startTime/endTime, customerId, assigneeId?, service, status[^4], price, naverBookingId?, channel[^5], publicToken?(온라인예약 고객 관리 링크) |
 | `customers/model.ts` | `Customer` | id, name, tel, points, memoTags, pointHistories, allergyNote, claimNote, preferenceNote. 헬퍼: `formatTel`(표시 000-0000-0000)·`normalizeTel`(저장용 숫자만, 단일 출처) |
 | `memberships/model.ts` | `MembershipProduct`/`CustomerMembership` | 회원권(횟수·기간권, 적립금과 별개). product: totalCount?/validDays?/price/status, 발급분: remainingCount/expiresAt?/status |
 | `assignees/model.ts` | `Assignee` | id, name, schedule(7일), status[^6], color, phone |
 | `services/model.ts` | `ServiceItem` | name, durationMinutes, category, price |
 | `services/default-services.ts` | - | 업종(ShopType) union + 업종별 기본 서비스·카테고리 색상(Partial, 온보딩용) |
-| `store-settings/model.ts` | `StoreSettings` | businessHours, closedDates, pointSettings(적립률, 충전규칙) |
+| `store-settings/model.ts` | `StoreSettings`/`BookingSettings` | businessHours, closedDates, pointSettings(적립률, 충전규칙). `BookingSettings`(공개 예약 규칙: slotIntervalMin·minLeadMinutes·maxAdvanceDays·allowAssigneeChoice·noticeText) + slug 검증(`isValidBookingSlug`) |
+| `booking/availability.ts` | - | 공개 온라인 예약 슬롯 계산 순수 함수(`computeAvailableSlots`/`pickAssigneeForSlot`). 서버 API가 재사용. 영업시간−기존예약−담당자스케줄−소요−최소사전시간, 담당자 용량 모델[^23] |
 | `store-settings/labels.ts` | - | 업종 마스터 목록·category별 표시어(담당자/서비스)·`getStoreLabels`/`sanitizeShopType` ([업종별 라벨](#업종별-라벨-담당자서비스-표시어)) |
 | `local-db/storage.ts` | - | 게스트 모드 로컬 스냅샷 (`takeaseat.local-db.v1`). `shouldUseLocalDb()`로 모드 판정, 게스트 약관 동의 버전 헬퍼(`getGuestTermsVersion`/`setGuestTermsAgreed`) — `lib/local-db`로 re-export |
 
 [^4]: status: `active` · `completed` · `cancelled` · `noshow`
-[^5]: channel: `네이버예약` · `현장방문` · `전화예약`
+[^5]: channel: `네이버예약` · `현장방문` · `전화예약` · `온라인예약`(공개 부킹 페이지 경유)
 [^6]: Assignee status: `재직` · `휴직` · `퇴직`
 
 ### 상태관리 (`client/store/`)
@@ -201,6 +203,9 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `membership-issue.ts` | `/api/membership-issue` | POST(staff) | - | 고객에게 회원권 발급/취소 (상품 스냅샷 → CustomerMembership) |
 | `membership-use.ts` | `/api/membership-use` | POST(staff) | - | 회원권 횟수 수동 차감/복원 (결제 흐름과 독립, MembershipUsage 기록) |
 | `coupons.ts` | `/api/coupons` | GET(staff) / POST·PUT·DELETE(owner) | - | 쿠폰 상품(정액/정률) CRUD. 코드형 중복 시 409. 발급분 있으면 DELETE=보관(archive). 발급·결제차감 미구현(Phase 1) |
+| `book/[slug].ts` | `/api/book/[slug]` | GET | **공개(비로그인)** | 온라인예약 매장 공개정보(매장명·서비스·담당자·영업시간·휴무일·규칙). 고객/예약 정보 절대 미노출[^23] |
+| `book/[slug]/availability.ts` | `/api/book/[slug]/availability` | GET | **공개(비로그인)** | 선택 서비스·담당자·날짜의 예약 가능 슬롯 배열. 순수 슬롯 계산(`features/booking/availability.ts`) 재사용, KST 기준 날짜 검증[^23] |
+| `book/[slug]/reserve.ts` | `/api/book/[slug]/reserve` | POST | **공개(비로그인)** | 셀프 예약 생성. 서버 슬롯 재검증(트랜잭션 Serializable) + 고객 upsert(정규화 tel) + 예약 생성(channel=online·`publicToken` 발급) + Slack 알림[^23] |
 | `onboarding.ts` | `/api/onboarding` | POST | owner | 매장 초기 설정 (legacyId 부여). **이미 담당자/서비스가 있으면 409 `ALREADY_SETUP` 거부** |
 | `migrate-local.ts` | `/api/migrate-local` | POST | owner | 게스트 로컬 데이터 전체 이전 (services/assignees/customers/reservations). 기존 데이터 있으면 409 + `confirm` 플래그로 병합 진행 |
 | `naver-booking-sync.ts` | `/api/naver-booking-sync` | POST | owner | 네이버 예약 동기화[^9] |
@@ -307,7 +312,7 @@ Store ─┬── Customer ──── Reservation ──── ReservationPay
 |------|---|
 | `MembershipRole` | owner, manager, staff (`0003_membership_role_manager`에서 manager 재추가 — 운영 등급) |
 | `ReservationStatus` | active, completed, cancelled, noshow |
-| `ReservationChannel` | naver, walk_in, phone |
+| `ReservationChannel` | naver, walk_in, phone, online(공개 온라인 예약) |
 | `AssigneeStatus` | active, on_leave, resigned |
 | `PaymentMethod` | cash, cash_receipt, card, naver_pay, local_currency, local_currency_receipt, voucher, points, discount, naver_deposit |
 | `PointHistoryType` | manual_add, manual_subtract, recharge, payment_use, payment_earn, payment_adjust |

--- a/plan.md
+++ b/plan.md
@@ -51,7 +51,10 @@
     - **`GET /api/book/[slug]/availability`**(`?date&services&assignee`): 날짜 유효성(과거·maxAdvanceDays·휴무일·영업요일) 검증 후 가용 슬롯 배열 반환. KST 기준 today/now 계산.
     - **`POST /api/book/[slug]/reserve`**(`{date,startTime,services[],assigneeId?,name,tel}`): 서버 권위 재검증(트랜잭션 Serializable + 슬롯 재계산 겹침 체크) → customer upsert(정규화 tel로 findFirst, 없으면 legacyId 부여 생성) → 예약 생성(channel=`online`, status=`active`, legacyId 부여, `publicToken` 랜덤). legacyId/token 충돌(P2002) 재시도. Slack 알림. 응답에 `publicToken`.
     - **공개 페이지**(`pages/book/[slug].tsx`): 서비스·담당자 선택 아래에 날짜(native date, min=오늘/max=+maxAdvanceDays)·슬롯 버튼·고객 이름/연락처 폼·예약 확정 → 완료 시 확인 링크(`/book/[slug]/r/[token]`) 안내(페이지 본체는 1d).
-  - **1c**: 노출 서비스 선택(오너). `StoreBookingSettings.bookableServiceIdsJson`(0009에 포함) + BookingManageSection에 서비스 다중선택 + 공개 API가 그 필터 적용. (결정: 노출할 서비스만.)
+  - **1c ✅ 완료(마이그레이션 없음 — 컬럼은 0009에 포함)**: 노출 서비스 선택(오너).
+    - `BookingSettings.bookableServiceNames`(서비스명 화이트리스트, null/[]=전체 노출) + 순수 헬퍼 `parseBookableServiceNames`/`areServicesBookable`(model.ts).
+    - `/api/store` GET/PATCH: `bookableServiceNames` 왕복(DB 컬럼 `bookableServiceIdsJson` 매핑). `BookingManageSection`에 '노출 서비스' 체크박스(전체 선택=null 저장, 미선택 시 전체 노출 안내).
+    - 공개 API: `GET /api/book/[slug]`가 화이트리스트로 서비스 목록 필터(고객 응답엔 화이트리스트 미노출), `availability`·`reserve`가 화이트리스트 밖 서비스 요청은 400 `not_bookable`로 거부.
   - **1d**: 고객 확인·변경·취소(오너 승인형) — Phase 2 내용.
   - **1e**: host 분기 — `book.takeaseat.co.kr/[slug]`(루트) → 내부 `/book/[slug]` rewrite. **단 Cloudflare Worker가 Host를 유지하는지 확인 필요**(현재 앱이 `book.` 호스트를 보는지). Worker 코드 확인 후 설계.
   - **1f**: 알림(Slack) — Phase 3 내용.

--- a/plan.md
+++ b/plan.md
@@ -45,7 +45,12 @@
     - `proxy.ts`(`/book/` isExempt), `_app.tsx`(게스트 리다이렉트·부팅 오버레이 예외), `LayoutComponent`(`/book/`=isBarePage) — 비로그인 공개.
     - `GET /api/book/[slug]`(server/api/book/[slug].ts + pages 재export): 온라인예약 ON 매장만, 매장명·서비스·담당자(허용 시)·영업시간·휴무일·규칙·안내문 **최소 노출**(고객/예약정보 절대 미노출).
     - `pages/book/[slug].tsx`: 매장명·안내문·서비스 다중선택·담당자(+상관없음) 선택. 슬롯/예약은 1b에서.
-  - **1b (다음, 마이그레이션 필요)**: 슬롯 계산 + 예약 생성. `GET /api/book/[slug]/availability`, `POST /api/book/[slug]/reserve`. 마이그레이션 0009: `Reservation.publicToken`(고객 관리 링크). 예약 생성: channel=`online`, status=`active`, legacyId 부여, customer upsert(이름+정규화 tel), 트랜잭션 겹침 재검증.
+  - **1b ✅ 완료(마이그레이션 0009 필요)**: 슬롯 계산 + 예약 생성.
+    - **마이그레이션 0009**: `Reservation.publicToken String? @unique`(고객 관리 링크) + `StoreBookingSettings.bookableServiceIdsJson Json?`(1c에서 배선할 노출 서비스 화이트리스트 컬럼 — 0009에 미리 포함, 배선은 1c). 둘 다 `IF NOT EXISTS` 멱등.
+    - **슬롯 계산 유틸**(`client/features/booking/availability.ts`, 순수·서버 재사용): 영업시간 − 기존 active 예약(네이버 포함) − 담당자 스케줄 − 서비스 총소요 − 최소 사전시간(now+minLead), slotInterval 간격. 담당자 용량 모델(근무·미배정 담당자 수 > 미배정 예약 부하일 때 가용). 담당자 0명 매장은 단일 자원(1)으로 취급.
+    - **`GET /api/book/[slug]/availability`**(`?date&services&assignee`): 날짜 유효성(과거·maxAdvanceDays·휴무일·영업요일) 검증 후 가용 슬롯 배열 반환. KST 기준 today/now 계산.
+    - **`POST /api/book/[slug]/reserve`**(`{date,startTime,services[],assigneeId?,name,tel}`): 서버 권위 재검증(트랜잭션 Serializable + 슬롯 재계산 겹침 체크) → customer upsert(정규화 tel로 findFirst, 없으면 legacyId 부여 생성) → 예약 생성(channel=`online`, status=`active`, legacyId 부여, `publicToken` 랜덤). legacyId/token 충돌(P2002) 재시도. Slack 알림. 응답에 `publicToken`.
+    - **공개 페이지**(`pages/book/[slug].tsx`): 서비스·담당자 선택 아래에 날짜(native date, min=오늘/max=+maxAdvanceDays)·슬롯 버튼·고객 이름/연락처 폼·예약 확정 → 완료 시 확인 링크(`/book/[slug]/r/[token]`) 안내(페이지 본체는 1d).
   - **1c**: 노출 서비스 선택(오너). `StoreBookingSettings.bookableServiceIdsJson`(0009에 포함) + BookingManageSection에 서비스 다중선택 + 공개 API가 그 필터 적용. (결정: 노출할 서비스만.)
   - **1d**: 고객 확인·변경·취소(오너 승인형) — Phase 2 내용.
   - **1e**: host 분기 — `book.takeaseat.co.kr/[slug]`(루트) → 내부 `/book/[slug]` rewrite. **단 Cloudflare Worker가 Host를 유지하는지 확인 필요**(현재 앱이 `book.` 호스트를 보는지). Worker 코드 확인 후 설계.

--- a/server/api/book/[slug].ts
+++ b/server/api/book/[slug].ts
@@ -1,7 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../db/prisma';
-import {DEFAULT_BOOKING_SETTINGS} from '../../../client/features/store-settings/model';
+import {DEFAULT_BOOKING_SETTINGS, parseBookableServiceNames} from '../../../client/features/store-settings/model';
 
 // 공개(비로그인) 예약 매장 정보. 데이터 최소 노출 — 고객/예약 정보는 절대 반환하지 않는다.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -28,6 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         prisma.storeBookingSettings.findUnique({where: {storeId: store.id}}),
     ]);
 
+    // 고객 응답엔 규칙 5개만 노출(화이트리스트는 미노출 — 데이터 최소화).
     const settings = bookingSettings
         ? {
             slotIntervalMin: bookingSettings.slotIntervalMin,
@@ -36,12 +37,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             allowAssigneeChoice: bookingSettings.allowAssigneeChoice,
             noticeText: bookingSettings.noticeText,
         }
-        : DEFAULT_BOOKING_SETTINGS;
+        : {
+            slotIntervalMin: DEFAULT_BOOKING_SETTINGS.slotIntervalMin,
+            minLeadMinutes: DEFAULT_BOOKING_SETTINGS.minLeadMinutes,
+            maxAdvanceDays: DEFAULT_BOOKING_SETTINGS.maxAdvanceDays,
+            allowAssigneeChoice: DEFAULT_BOOKING_SETTINGS.allowAssigneeChoice,
+            noticeText: DEFAULT_BOOKING_SETTINGS.noticeText,
+        };
+
+    // 노출 서비스 화이트리스트(1c): 지정 시 그 서비스만 공개.
+    const whitelist = parseBookableServiceNames(bookingSettings?.bookableServiceIdsJson);
+    const visibleServices = whitelist ? services.filter((s) => whitelist.includes(s.name)) : services;
 
     return res.status(200).json({
         storeName: store.name,
         shopType: store.shopType,
-        services: services.map((s) => ({name: s.name, category: s.category, duration: s.duration, price: s.price})),
+        services: visibleServices.map((s) => ({name: s.name, category: s.category, duration: s.duration, price: s.price})),
         // 담당자 선택을 허용할 때만 목록 노출
         assignees: settings.allowAssigneeChoice ? assignees.map((a) => ({id: a.id, name: a.name, color: a.color})) : [],
         businessHours: businessHours.map((b) => ({dayIndex: b.dayIndex, openTime: b.openTime, closeTime: b.closeTime, enabled: b.enabled})),

--- a/server/api/book/[slug]/availability.ts
+++ b/server/api/book/[slug]/availability.ts
@@ -1,0 +1,79 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {prisma} from '../../../db/prisma';
+import {
+    computeAvailableSlots,
+    type SlotAssignee,
+    type SlotReservation,
+} from '../../../../client/features/booking/availability';
+import {
+    dayIndexOf,
+    evaluateDateWindow,
+    findBookableStore,
+    isValidDateStr,
+    loadBookingSettings,
+} from '../booking-helpers';
+
+// 공개(비로그인) 슬롯 조회. 선택한 서비스·담당자 기준으로 예약 가능한 시작 시각만 반환한다.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'GET') {
+        res.setHeader('Allow', ['GET']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+
+    const slug = typeof req.query.slug === 'string' ? req.query.slug : '';
+    const dateStr = typeof req.query.date === 'string' ? req.query.date : '';
+    const servicesParam = typeof req.query.services === 'string' ? req.query.services : '';
+    const assigneeParam = typeof req.query.assignee === 'string' ? req.query.assignee : '';
+
+    if (!isValidDateStr(dateStr)) return res.status(400).json({error: 'invalid_date'});
+
+    const store = await findBookableStore(slug);
+    if (!store) return res.status(404).json({error: 'not_found'});
+
+    const settings = await loadBookingSettings(store.id);
+
+    const serviceNames = servicesParam.split(',').map((s) => s.trim()).filter(Boolean);
+    if (serviceNames.length === 0) return res.status(400).json({error: 'no_service'});
+
+    const [services, closedRows, businessHour, assigneeRows, reservationRows] = await Promise.all([
+        prisma.service.findMany({where: {storeId: store.id, name: {in: serviceNames}}, select: {name: true, duration: true}}),
+        prisma.storeClosedDate.findMany({where: {storeId: store.id}, select: {date: true}}),
+        prisma.storeBusinessHour.findUnique({where: {storeId_dayIndex: {storeId: store.id, dayIndex: dayIndexOf(dateStr)}}, select: {openTime: true, closeTime: true, enabled: true}}),
+        prisma.assignee.findMany({where: {storeId: store.id, status: 'active'}, select: {id: true, schedules: {select: {dayIndex: true, enabled: true, startTime: true, endTime: true}}}}),
+        prisma.reservation.findMany({where: {storeId: store.id, date: new Date(`${dateStr}T00:00:00`), status: 'active'}, select: {assigneeId: true, startTime: true, endTime: true}}),
+    ]);
+
+    // 모르는 서비스가 섞였으면 거부(공개 API 최소 신뢰)
+    if (services.length !== serviceNames.length) return res.status(400).json({error: 'unknown_service'});
+    const durationMin = services.reduce((sum, s) => sum + s.duration, 0);
+
+    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const window = evaluateDateWindow(dateStr, settings, closedDates);
+    if (!window.ok) return res.status(200).json({date: dateStr, durationMin, slots: []});
+
+    // 담당자 선택 허용 + 실재 담당자일 때만 특정 담당자로 계산
+    const assignees: SlotAssignee[] = assigneeRows.map((a) => ({id: a.id, schedules: a.schedules}));
+    const assigneeId = settings.allowAssigneeChoice && assigneeParam && assignees.some((a) => a.id === assigneeParam)
+        ? assigneeParam
+        : null;
+
+    const reservations: SlotReservation[] = reservationRows.map((r) => ({
+        assigneeId: r.assigneeId,
+        startTime: r.startTime,
+        endTime: r.endTime,
+    }));
+
+    const slots = computeAvailableSlots({
+        dayIndex: dayIndexOf(dateStr),
+        businessHour: businessHour ?? null,
+        durationMin,
+        slotIntervalMin: settings.slotIntervalMin,
+        minStartMinute: window.minStartMinute,
+        reservations,
+        assigneeId,
+        assignees,
+    });
+
+    return res.status(200).json({date: dateStr, durationMin, slots});
+}

--- a/server/api/book/[slug]/availability.ts
+++ b/server/api/book/[slug]/availability.ts
@@ -6,6 +6,7 @@ import {
     type SlotAssignee,
     type SlotReservation,
 } from '../../../../client/features/booking/availability';
+import {areServicesBookable} from '../../../../client/features/store-settings/model';
 import {
     dayIndexOf,
     evaluateDateWindow,
@@ -47,6 +48,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // 모르는 서비스가 섞였으면 거부(공개 API 최소 신뢰)
     if (services.length !== serviceNames.length) return res.status(400).json({error: 'unknown_service'});
+    // 노출 화이트리스트(1c) 밖 서비스는 거부
+    if (!areServicesBookable(serviceNames, settings.bookableServiceNames)) return res.status(400).json({error: 'not_bookable'});
     const durationMin = services.reduce((sum, s) => sum + s.duration, 0);
 
     const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));

--- a/server/api/book/[slug]/availability.ts
+++ b/server/api/book/[slug]/availability.ts
@@ -36,10 +36,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const serviceNames = servicesParam.split(',').map((s) => s.trim()).filter(Boolean);
     if (serviceNames.length === 0) return res.status(400).json({error: 'no_service'});
 
+    const dayIndex = dayIndexOf(dateStr);
     const [services, closedRows, businessHour, assigneeRows, reservationRows] = await Promise.all([
         prisma.service.findMany({where: {storeId: store.id, name: {in: serviceNames}}, select: {name: true, duration: true}}),
         prisma.storeClosedDate.findMany({where: {storeId: store.id}, select: {date: true}}),
-        prisma.storeBusinessHour.findUnique({where: {storeId_dayIndex: {storeId: store.id, dayIndex: dayIndexOf(dateStr)}}, select: {openTime: true, closeTime: true, enabled: true}}),
+        prisma.storeBusinessHour.findUnique({where: {storeId_dayIndex: {storeId: store.id, dayIndex}}, select: {openTime: true, closeTime: true, enabled: true}}),
         prisma.assignee.findMany({where: {storeId: store.id, status: 'active'}, select: {id: true, schedules: {select: {dayIndex: true, enabled: true, startTime: true, endTime: true}}}}),
         prisma.reservation.findMany({where: {storeId: store.id, date: new Date(`${dateStr}T00:00:00`), status: 'active'}, select: {assigneeId: true, startTime: true, endTime: true}}),
     ]);
@@ -65,7 +66,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }));
 
     const slots = computeAvailableSlots({
-        dayIndex: dayIndexOf(dateStr),
+        dayIndex,
         businessHour: businessHour ?? null,
         durationMin,
         slotIntervalMin: settings.slotIntervalMin,

--- a/server/api/book/[slug]/reserve.ts
+++ b/server/api/book/[slug]/reserve.ts
@@ -1,0 +1,173 @@
+import crypto from 'crypto';
+
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {prisma} from '../../../db/prisma';
+import {normalizeTel} from '../../../../client/features/customers/model';
+import {calcEndTime, joinServiceNames} from '../../../../client/features/services/model';
+import {
+    computeAvailableSlots,
+    pickAssigneeForSlot,
+    timeToMinutes,
+    type SlotAssignee,
+    type SlotReservation,
+} from '../../../../client/features/booking/availability';
+import {notifySlackForStore} from '../../../notify/slack';
+import {
+    dayIndexOf,
+    evaluateDateWindow,
+    findBookableStore,
+    isValidDateStr,
+    isValidTimeStr,
+    loadBookingSettings,
+} from '../booking-helpers';
+
+interface ReserveBody {
+    date?: unknown;
+    startTime?: unknown;
+    services?: unknown;
+    assigneeId?: unknown;
+    name?: unknown;
+    tel?: unknown;
+}
+
+function newPublicToken(): string {
+    return crypto.randomBytes(24).toString('base64url');
+}
+
+// 공개(비로그인) 예약 생성. 서버가 슬롯을 권위 있게 재검증하고, 겹침·레이스를 트랜잭션으로 방어한다.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+
+    const slug = typeof req.query.slug === 'string' ? req.query.slug : '';
+    const body = (req.body ?? {}) as ReserveBody;
+
+    const dateStr = body.date;
+    const startTime = body.startTime;
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    const tel = normalizeTel(typeof body.tel === 'string' ? body.tel : '');
+    const serviceNames = Array.isArray(body.services)
+        ? body.services.filter((s): s is string => typeof s === 'string' && s.length > 0)
+        : [];
+    const requestedAssigneeId = typeof body.assigneeId === 'string' && body.assigneeId ? body.assigneeId : null;
+
+    // 입력 검증
+    if (!isValidDateStr(dateStr)) return res.status(400).json({error: 'invalid_date'});
+    if (!isValidTimeStr(startTime)) return res.status(400).json({error: 'invalid_time'});
+    if (!name) return res.status(400).json({error: 'invalid_name'});
+    if (tel.length < 10 || tel.length > 11) return res.status(400).json({error: 'invalid_tel'});
+    if (serviceNames.length === 0) return res.status(400).json({error: 'no_service'});
+
+    const store = await findBookableStore(slug);
+    if (!store) return res.status(404).json({error: 'not_found'});
+
+    const settings = await loadBookingSettings(store.id);
+    const dayIndex = dayIndexOf(dateStr);
+
+    const [services, closedRows, businessHour, assigneeRows] = await Promise.all([
+        prisma.service.findMany({where: {storeId: store.id, name: {in: serviceNames}}, select: {name: true, duration: true, price: true}}),
+        prisma.storeClosedDate.findMany({where: {storeId: store.id}, select: {date: true}}),
+        prisma.storeBusinessHour.findUnique({where: {storeId_dayIndex: {storeId: store.id, dayIndex}}, select: {openTime: true, closeTime: true, enabled: true}}),
+        prisma.assignee.findMany({where: {storeId: store.id, status: 'active'}, select: {id: true, schedules: {select: {dayIndex: true, enabled: true, startTime: true, endTime: true}}}}),
+    ]);
+
+    if (services.length !== serviceNames.length) return res.status(400).json({error: 'unknown_service'});
+    const durationMin = services.reduce((sum, s) => sum + s.duration, 0);
+    const price = services.reduce((sum, s) => sum + s.price, 0);
+    const endTime = calcEndTime(startTime, durationMin);
+    const serviceSummary = joinServiceNames(serviceNames);
+
+    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const window = evaluateDateWindow(dateStr, settings, closedDates);
+    if (!window.ok) return res.status(409).json({error: 'unavailable_date'});
+
+    const assignees: SlotAssignee[] = assigneeRows.map((a) => ({id: a.id, schedules: a.schedules}));
+    const assigneeId = settings.allowAssigneeChoice && requestedAssigneeId && assignees.some((a) => a.id === requestedAssigneeId)
+        ? requestedAssigneeId
+        : null;
+
+    // 겹침 재검증 + 생성을 원자화(Serializable). legacyId/token 충돌 시 재시도.
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            const result = await prisma.$transaction(async (tx) => {
+                const reservationRows = await tx.reservation.findMany({
+                    where: {storeId: store.id, date: new Date(`${dateStr}T00:00:00`), status: 'active'},
+                    select: {assigneeId: true, startTime: true, endTime: true},
+                });
+                const reservations: SlotReservation[] = reservationRows.map((r) => ({
+                    assigneeId: r.assigneeId,
+                    startTime: r.startTime,
+                    endTime: r.endTime,
+                }));
+
+                const slots = computeAvailableSlots({
+                    dayIndex,
+                    businessHour: businessHour ?? null,
+                    durationMin,
+                    slotIntervalMin: settings.slotIntervalMin,
+                    minStartMinute: window.minStartMinute,
+                    reservations,
+                    assigneeId,
+                    assignees,
+                });
+                if (!slots.includes(startTime)) return {conflict: true as const};
+
+                // 상관없음이면 그 슬롯에 실제 배정할 담당자 하나 선택(없으면 미배정)
+                const finalAssigneeId = assigneeId
+                    ?? pickAssigneeForSlot({dayIndex, businessHour: businessHour ?? null, durationMin, slotIntervalMin: settings.slotIntervalMin, reservations, assigneeId: null, assignees, startMinute: timeToMinutes(startTime)});
+
+                // 고객 upsert: 정규화 tel로 조회, 없으면 legacyId 부여 생성
+                let customer = await tx.customer.findFirst({where: {storeId: store.id, tel}, select: {id: true}});
+                if (!customer) {
+                    const maxCustomer = await tx.customer.findFirst({where: {storeId: store.id}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}});
+                    customer = await tx.customer.create({
+                        data: {storeId: store.id, legacyId: (maxCustomer?.legacyId ?? 0) + 1, name, tel},
+                        select: {id: true},
+                    });
+                }
+
+                const maxReservation = await tx.reservation.findFirst({where: {storeId: store.id}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}});
+                const created = await tx.reservation.create({
+                    data: {
+                        storeId: store.id,
+                        legacyId: (maxReservation?.legacyId ?? 0) + 1,
+                        customerId: customer.id,
+                        assigneeId: finalAssigneeId,
+                        date: new Date(`${dateStr}T00:00:00`),
+                        startTime,
+                        endTime,
+                        serviceSummary,
+                        status: 'active',
+                        price,
+                        channel: 'online',
+                        publicToken: newPublicToken(),
+                    },
+                    select: {publicToken: true},
+                });
+
+                return {conflict: false as const, publicToken: created.publicToken};
+            }, {isolationLevel: 'Serializable'});
+
+            if (result.conflict) return res.status(409).json({error: 'slot_taken'});
+
+            await notifySlackForStore(store.id,
+                `🌐 *온라인 예약*\n• 날짜: ${dateStr}`
+                + `\n• 시간: ${startTime}~${endTime}`
+                + `\n• 시술: ${serviceSummary}`
+                + `\n• 고객: ${name}`,
+            );
+
+            return res.status(201).json({publicToken: result.publicToken, date: dateStr, startTime, endTime, serviceSummary, storeName: store.name});
+        } catch (e) {
+            const code = (e as {code?: string}).code;
+            // P2002=unique 충돌(legacyId/token), P2034=직렬화 재시도 → 다음 시도
+            if (code === 'P2002' || code === 'P2034') continue;
+            throw e;
+        }
+    }
+
+    return res.status(409).json({error: 'retry_exhausted'});
+}

--- a/server/api/book/[slug]/reserve.ts
+++ b/server/api/book/[slug]/reserve.ts
@@ -5,6 +5,7 @@ import type {NextApiRequest, NextApiResponse} from 'next';
 import {prisma} from '../../../db/prisma';
 import {normalizeTel} from '../../../../client/features/customers/model';
 import {calcEndTime, joinServiceNames} from '../../../../client/features/services/model';
+import {areServicesBookable} from '../../../../client/features/store-settings/model';
 import {
     computeAvailableSlots,
     pickAssigneeForSlot,
@@ -75,6 +76,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     ]);
 
     if (services.length !== serviceNames.length) return res.status(400).json({error: 'unknown_service'});
+    // 노출 화이트리스트(1c) 밖 서비스는 거부
+    if (!areServicesBookable(serviceNames, settings.bookableServiceNames)) return res.status(400).json({error: 'not_bookable'});
     const durationMin = services.reduce((sum, s) => sum + s.duration, 0);
     const price = services.reduce((sum, s) => sum + s.price, 0);
     const endTime = calcEndTime(startTime, durationMin);

--- a/server/api/book/[slug]/reserve.ts
+++ b/server/api/book/[slug]/reserve.ts
@@ -89,12 +89,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         ? requestedAssigneeId
         : null;
 
+    const date = new Date(`${dateStr}T00:00:00`);
+
     // 겹침 재검증 + 생성을 원자화(Serializable). legacyId/token 충돌 시 재시도.
+    let publicToken: string | null = null;
     for (let attempt = 0; attempt < 3; attempt++) {
         try {
             const result = await prisma.$transaction(async (tx) => {
                 const reservationRows = await tx.reservation.findMany({
-                    where: {storeId: store.id, date: new Date(`${dateStr}T00:00:00`), status: 'active'},
+                    where: {storeId: store.id, date, status: 'active'},
                     select: {assigneeId: true, startTime: true, endTime: true},
                 });
                 const reservations: SlotReservation[] = reservationRows.map((r) => ({
@@ -113,15 +116,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     assigneeId,
                     assignees,
                 });
-                if (!slots.includes(startTime)) return {conflict: true as const};
+                if (!slots.includes(startTime)) return {status: 'slot_taken' as const};
 
                 // 상관없음이면 그 슬롯에 실제 배정할 담당자 하나 선택(없으면 미배정)
                 const finalAssigneeId = assigneeId
-                    ?? pickAssigneeForSlot({dayIndex, businessHour: businessHour ?? null, durationMin, slotIntervalMin: settings.slotIntervalMin, reservations, assigneeId: null, assignees, startMinute: timeToMinutes(startTime)});
+                    ?? pickAssigneeForSlot({dayIndex, durationMin, reservations, assignees, startMinute: timeToMinutes(startTime)});
 
                 // 고객 upsert: 정규화 tel로 조회, 없으면 legacyId 부여 생성
                 let customer = await tx.customer.findFirst({where: {storeId: store.id, tel}, select: {id: true}});
-                if (!customer) {
+                if (customer) {
+                    // 더블클릭·재시도 중복 방지: 같은 고객이 같은 슬롯에 이미 active 예약이 있으면 거부
+                    const dup = await tx.reservation.findFirst({
+                        where: {storeId: store.id, customerId: customer.id, date, startTime, status: 'active'},
+                        select: {id: true},
+                    });
+                    if (dup) return {status: 'duplicate' as const};
+                } else {
                     const maxCustomer = await tx.customer.findFirst({where: {storeId: store.id}, orderBy: {legacyId: 'desc'}, select: {legacyId: true}});
                     customer = await tx.customer.create({
                         data: {storeId: store.id, legacyId: (maxCustomer?.legacyId ?? 0) + 1, name, tel},
@@ -136,7 +146,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                         legacyId: (maxReservation?.legacyId ?? 0) + 1,
                         customerId: customer.id,
                         assigneeId: finalAssigneeId,
-                        date: new Date(`${dateStr}T00:00:00`),
+                        date,
                         startTime,
                         endTime,
                         serviceSummary,
@@ -148,19 +158,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     select: {publicToken: true},
                 });
 
-                return {conflict: false as const, publicToken: created.publicToken};
+                return {status: 'ok' as const, publicToken: created.publicToken};
             }, {isolationLevel: 'Serializable'});
 
-            if (result.conflict) return res.status(409).json({error: 'slot_taken'});
-
-            await notifySlackForStore(store.id,
-                `🌐 *온라인 예약*\n• 날짜: ${dateStr}`
-                + `\n• 시간: ${startTime}~${endTime}`
-                + `\n• 시술: ${serviceSummary}`
-                + `\n• 고객: ${name}`,
-            );
-
-            return res.status(201).json({publicToken: result.publicToken, date: dateStr, startTime, endTime, serviceSummary, storeName: store.name});
+            if (result.status === 'slot_taken') return res.status(409).json({error: 'slot_taken'});
+            if (result.status === 'duplicate') return res.status(409).json({error: 'duplicate'});
+            publicToken = result.publicToken;
+            break;
         } catch (e) {
             const code = (e as {code?: string}).code;
             // P2002=unique 충돌(legacyId/token), P2034=직렬화 재시도 → 다음 시도
@@ -169,5 +173,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
     }
 
-    return res.status(409).json({error: 'retry_exhausted'});
+    if (!publicToken) return res.status(409).json({error: 'retry_exhausted'});
+
+    // 알림은 커밋 성공 후 별도 격리 — 실패해도 예약 성공(201)에는 영향 주지 않는다.
+    try {
+        await notifySlackForStore(store.id,
+            `🌐 *온라인 예약*\n• 날짜: ${dateStr}`
+            + `\n• 시간: ${startTime}~${endTime}`
+            + `\n• 시술: ${serviceSummary}`
+            + `\n• 고객: ${name}`,
+        );
+    } catch { /* 알림 실패는 무시 */ }
+
+    return res.status(201).json({publicToken, date: dateStr, startTime, endTime, serviceSummary, storeName: store.name});
 }

--- a/server/api/book/booking-helpers.ts
+++ b/server/api/book/booking-helpers.ts
@@ -1,0 +1,94 @@
+// 공개 온라인 예약 API 공용 헬퍼(availability·reserve 공유).
+import {prisma} from '../../db/prisma';
+import {DEFAULT_BOOKING_SETTINGS} from '../../../client/features/store-settings/model';
+import type {BookingSettings} from '../../../client/features/store-settings/model';
+
+const KST_OFFSET_MIN = 9 * 60; // Asia/Seoul (UTC+9), 이 앱은 한국 전용
+const MINUTES_PER_DAY = 24 * 60;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_RE = /^\d{2}:\d{2}$/;
+
+export function isValidDateStr(v: unknown): v is string {
+    return typeof v === 'string' && DATE_RE.test(v);
+}
+
+export function isValidTimeStr(v: unknown): v is string {
+    return typeof v === 'string' && TIME_RE.test(v);
+}
+
+// 자정 UTC 기준 일련번호(달력일 비교용). dayIndex 산출·날짜 범위 비교에 쓴다.
+function dayNumber(dateStr: string): number {
+    return Math.floor(Date.parse(`${dateStr}T00:00:00Z`) / (MINUTES_PER_DAY * 60000));
+}
+
+// 해당 달력일의 요일(0=일 … 6=토). 시간대 영향 없이 UTC 정오로 계산.
+export function dayIndexOf(dateStr: string): number {
+    return new Date(`${dateStr}T12:00:00Z`).getUTCDay();
+}
+
+// KST 기준 "오늘"(YYYY-MM-DD)과 자정 이후 경과 분.
+export function nowKst(): {todayStr: string; minutesOfDay: number} {
+    const shifted = new Date(Date.now() + KST_OFFSET_MIN * 60000);
+    return {
+        todayStr: shifted.toISOString().slice(0, 10),
+        minutesOfDay: shifted.getUTCHours() * 60 + shifted.getUTCMinutes(),
+    };
+}
+
+export interface DateWindow {
+    ok: boolean;
+    reason?: 'past' | 'too_far' | 'closed';
+    minStartMinute: number; // 슬롯 계산에 넘길 최소 시작 분(자정 기준)
+}
+
+// 예약 날짜가 [오늘 … 오늘+maxAdvanceDays] 범위·비휴무인지 판정하고,
+// 최소 사전시간(now+minLead)을 반영한 minStartMinute를 돌려준다.
+export function evaluateDateWindow(
+    dateStr: string,
+    settings: Pick<BookingSettings, 'minLeadMinutes' | 'maxAdvanceDays'>,
+    closedDates: string[],
+): DateWindow {
+    const {todayStr, minutesOfDay} = nowKst();
+    const todayNum = dayNumber(todayStr);
+    const targetNum = dayNumber(dateStr);
+
+    if (targetNum < todayNum) return {ok: false, reason: 'past', minStartMinute: 0};
+    if (targetNum > todayNum + settings.maxAdvanceDays) return {ok: false, reason: 'too_far', minStartMinute: 0};
+    if (closedDates.includes(dateStr)) return {ok: false, reason: 'closed', minStartMinute: 0};
+
+    const nowAbsolute = todayNum * MINUTES_PER_DAY + minutesOfDay;
+    const earliestAbsolute = nowAbsolute + settings.minLeadMinutes;
+    const targetStartAbsolute = targetNum * MINUTES_PER_DAY;
+    const minStartMinute = Math.max(0, earliestAbsolute - targetStartAbsolute);
+
+    return {ok: true, minStartMinute};
+}
+
+export interface PublicStore {
+    id: string;
+    name: string;
+    shopType: string | null;
+}
+
+// 온라인 예약이 켜진 매장만 조회. 없으면 null.
+export async function findBookableStore(slug: string): Promise<PublicStore | null> {
+    if (!slug) return null;
+    return prisma.store.findFirst({
+        where: {bookingSlug: slug.toLowerCase(), useOnlineBooking: true},
+        select: {id: true, name: true, shopType: true},
+    });
+}
+
+// 매장 예약 규칙(없으면 기본값).
+export async function loadBookingSettings(storeId: string): Promise<BookingSettings> {
+    const row = await prisma.storeBookingSettings.findUnique({where: {storeId}});
+    if (!row) return DEFAULT_BOOKING_SETTINGS;
+    return {
+        slotIntervalMin: row.slotIntervalMin,
+        minLeadMinutes: row.minLeadMinutes,
+        maxAdvanceDays: row.maxAdvanceDays,
+        allowAssigneeChoice: row.allowAssigneeChoice,
+        noticeText: row.noticeText,
+    };
+}

--- a/server/api/book/booking-helpers.ts
+++ b/server/api/book/booking-helpers.ts
@@ -1,6 +1,6 @@
 // 공개 온라인 예약 API 공용 헬퍼(availability·reserve 공유).
 import {prisma} from '../../db/prisma';
-import {DEFAULT_BOOKING_SETTINGS} from '../../../client/features/store-settings/model';
+import {DEFAULT_BOOKING_SETTINGS, parseBookableServiceNames} from '../../../client/features/store-settings/model';
 import type {BookingSettings} from '../../../client/features/store-settings/model';
 
 const KST_OFFSET_MIN = 9 * 60; // Asia/Seoul (UTC+9), 이 앱은 한국 전용
@@ -92,5 +92,6 @@ export async function loadBookingSettings(storeId: string): Promise<BookingSetti
         maxAdvanceDays: row.maxAdvanceDays,
         allowAssigneeChoice: row.allowAssigneeChoice,
         noticeText: row.noticeText,
+        bookableServiceNames: parseBookableServiceNames(row.bookableServiceIdsJson),
     };
 }

--- a/server/api/book/booking-helpers.ts
+++ b/server/api/book/booking-helpers.ts
@@ -22,9 +22,11 @@ function dayNumber(dateStr: string): number {
     return Math.floor(Date.parse(`${dateStr}T00:00:00Z`) / (MINUTES_PER_DAY * 60000));
 }
 
-// 해당 달력일의 요일(0=일 … 6=토). 시간대 영향 없이 UTC 정오로 계산.
+// 해당 달력일의 스케줄 인덱스(0=월 … 6=일). 앱이 AssigneeSchedule.dayIndex·StoreBusinessHour.dayIndex를
+// (getDay()+6)%7 = 월=0 규칙으로 저장하므로 동일 규칙으로 맞춘다(요일 어긋남 방지).
+// 시간대 영향 없이 UTC 정오로 계산.
 export function dayIndexOf(dateStr: string): number {
-    return new Date(`${dateStr}T12:00:00Z`).getUTCDay();
+    return (new Date(`${dateStr}T12:00:00Z`).getUTCDay() + 6) % 7;
 }
 
 // KST 기준 "오늘"(YYYY-MM-DD)과 자정 이후 경과 분.

--- a/server/api/store.ts
+++ b/server/api/store.ts
@@ -4,7 +4,7 @@ import {prisma} from '../db/prisma';
 import {getApiSession, requireRole} from '../auth/api-session';
 import {dbStoreToFrontend} from '../db/mappers';
 import type {StoreSettings, BookingSettings} from '../../client/features/store-settings/model';
-import {DEFAULT_STORE_SETTINGS, DEFAULT_BOOKING_SETTINGS, isValidBookingSlug} from '../../client/features/store-settings/model';
+import {DEFAULT_STORE_SETTINGS, DEFAULT_BOOKING_SETTINGS, isValidBookingSlug, parseBookableServiceNames} from '../../client/features/store-settings/model';
 import {sanitizeShopType} from '../../client/features/store-settings/labels';
 
 function isValidTime(value: unknown): value is string {
@@ -60,6 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     maxAdvanceDays: bs.maxAdvanceDays,
                     allowAssigneeChoice: bs.allowAssigneeChoice,
                     noticeText: bs.noticeText,
+                    bookableServiceNames: parseBookableServiceNames(bs.bookableServiceIdsJson),
                 };
             }
         } catch {
@@ -197,12 +198,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (bookingSettings !== undefined) {
             const b = bookingSettings as Partial<BookingSettings>;
             const okInt = (v: unknown, min: number, max: number) => typeof v === 'number' && Number.isInteger(v) && v >= min && v <= max;
+            const okServiceNames = b.bookableServiceNames === undefined
+                || b.bookableServiceNames === null
+                || (Array.isArray(b.bookableServiceNames) && b.bookableServiceNames.every((n) => typeof n === 'string'));
             if (
                 !okInt(b.slotIntervalMin, 5, 240)
                 || !okInt(b.minLeadMinutes, 0, 43200)
                 || !okInt(b.maxAdvanceDays, 1, 365)
                 || typeof b.allowAssigneeChoice !== 'boolean'
                 || (b.noticeText !== null && b.noticeText !== undefined && typeof b.noticeText !== 'string')
+                || !okServiceNames
             ) {
                 return res.status(400).json({error: 'Invalid bookingSettings'});
             }
@@ -212,6 +217,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 maxAdvanceDays: b.maxAdvanceDays!,
                 allowAssigneeChoice: b.allowAssigneeChoice,
                 noticeText: (b.noticeText ?? null) as string | null,
+                bookableServiceNames: (b.bookableServiceNames ?? null) as string[] | null,
             };
         }
 
@@ -237,10 +243,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         if (nextBooking !== undefined) {
+            // BookingSettings.bookableServiceNames ↔ DB 컬럼 bookableServiceIdsJson 로 매핑.
+            const {bookableServiceNames, ...rules} = nextBooking;
+            const bookingData = {...rules, bookableServiceIdsJson: bookableServiceNames ?? []};
             await prisma.storeBookingSettings.upsert({
                 where: {storeId: session.storeId},
-                update: {...nextBooking},
-                create: {storeId: session.storeId, ...nextBooking},
+                update: bookingData,
+                create: {storeId: session.storeId, ...bookingData},
             });
         }
 

--- a/server/prisma/migrations/0009_online_booking_reserve/migration.sql
+++ b/server/prisma/migrations/0009_online_booking_reserve/migration.sql
@@ -1,0 +1,9 @@
+-- 고객 공개 온라인 예약(Phase 1b): 예약 관리 토큰 + (1c) 노출 서비스 화이트리스트 컬럼.
+-- IF NOT EXISTS: Supabase 등에서 수동 선반영했어도 migrate deploy 가 충돌 없이 통과하도록.
+
+-- 고객 예약 관리 링크용 추측 불가 토큰 (per-예약)
+ALTER TABLE "Reservation" ADD COLUMN IF NOT EXISTS "publicToken" TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS "Reservation_publicToken_key" ON "Reservation"("publicToken");
+
+-- (1c) 공개 노출 서비스 화이트리스트(서비스명 배열). null=전체 노출. 1b에선 컬럼만, 배선은 1c.
+ALTER TABLE "StoreBookingSettings" ADD COLUMN IF NOT EXISTS "bookableServiceIdsJson" JSONB;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -211,6 +211,7 @@ model Reservation {
   naverBookingUrl  String?
   naverDeposit     Int?
   channel          ReservationChannel        @default(phone)
+  publicToken      String?                   @unique
   createdAt        DateTime                  @default(now())
   updatedAt        DateTime                  @updatedAt
   pointHistories   CustomerPointHistory[]
@@ -292,6 +293,8 @@ model StoreBookingSettings {
   maxAdvanceDays      Int      @default(30)
   allowAssigneeChoice Boolean  @default(true)
   noticeText          String?
+  // (1c) 공개 노출 서비스 화이트리스트(서비스명 배열). null/미지정 = 전체 노출. 배선은 1c.
+  bookableServiceIdsJson Json?
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
   store               Store    @relation(fields: [storeId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## 개요
고객이 로그인 없이 매장 공개 페이지에서 직접 예약하는 온라인 예약의 **Phase 1b(슬롯 계산 + 예약 생성)**·**1c(노출 서비스 선택)**를 구현합니다.

## 변경 사항

### Phase 1b — 슬롯 계산 + 예약 생성
- **마이그레이션 0009**: `Reservation.publicToken`(고객 관리 링크용 unique) + `StoreBookingSettings.bookableServiceIdsJson`(1c 노출 서비스 컬럼). 둘 다 `IF NOT EXISTS` 멱등.
- **슬롯 계산 순수 유틸** (`features/booking/availability.ts`): 영업시간 − 기존 active 예약(네이버 포함) − 담당자 스케줄 − 서비스 총소요 − 최소 사전시간, slotInterval 간격. 담당자 용량 모델(근무·미배정 담당자 수 > 미배정 예약 부하일 때 가용), 담당자 0명 매장은 단일 자원.
- **`GET /api/book/[slug]/availability`**: 선택 서비스·담당자·날짜의 가용 슬롯. KST 기준 날짜 검증(과거·maxAdvanceDays·휴무일·영업요일).
- **`POST /api/book/[slug]/reserve`**: 서버 권위 슬롯 재검증(트랜잭션 Serializable) + 고객 upsert(정규화 tel) + 예약 생성(channel=`online`·`publicToken`) + 중복 예약 가드 + Slack 알림(격리). legacyId/token·직렬화 충돌 재시도.
- **공개 페이지** (`pages/book/[slug].tsx`): 날짜·시간 슬롯·예약자 폼 → 예약 확정 → 접수 확인.

### Phase 1c — 노출 서비스 선택(오너)
- `BookingSettings.bookableServiceNames`(화이트리스트, null/[]=전체) + 헬퍼 `parseBookableServiceNames`·`areServicesBookable`.
- `/api/store` GET·PATCH 왕복 저장, `BookingManageSection`에 '노출 서비스' 체크박스.
- 공개 API가 화이트리스트로 서비스 필터(고객 응답엔 미노출) + 밖 서비스는 `400 not_bookable` 거부.

## 코드리뷰 반영
2회 코드리뷰로 다음을 수정: 요일(dayIndex) 저장규칙 불일치(월=0) off-by-one, 담당자 용량모델 정합, styled 태그 셀렉터 제거, Slack 알림 격리(커밋 후·실패 무시), 중복 예약 가드, 완료화면 미구현 링크(404) 제거, 409 문구 코드별 분기, 0분 서비스 안내.

## 검증
- ✅ 타입체크·`next build` 통과, ESLint 클린
- ✅ 슬롯 계산 단위테스트 12개 + 화이트리스트 10개 통과
- ✅ API 라우트 스모크(405/400 경로) 정상
- ⚠️ DB 없는 환경이라 실제 예약 생성 E2E는 미구동 — 핵심 순수 로직을 단위테스트로 검증

## ⚠️ 배포 주의 (마이그레이션 먼저)
`0009` 마이그레이션(`publicToken`·`bookableServiceIdsJson`)을 **머지(자동 배포) 전에 Supabase에서 수동 적용**해야 합니다. 미적용 시 컬럼 부재로 500. (1b·1c 모두 0009 하나로 커버)

## 남은 단계 (별도 PR)
1d(고객 확인·변경·취소, Phase 2) · 1e(서브도메인 rewrite) · 1f(Slack 알림 확장, Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXZxAQiTSRtY27qPkwWKUK)_