### PR TITLE
fix: 예약 조회 include→select 하드닝 (배포순서 장애 재발방지)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.22.0",
+    "version": "0.22.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/index.md
+++ b/index.md
@@ -267,7 +267,7 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `prisma.ts` | Prisma 클라이언트 싱글턴 (PrismaPg driver adapter 사용) |
 | `mappers.ts` | DB ↔ 프론트엔드 변환 함수[^13] |
 
-[^13]: `dbReservationToFrontend()`, `dbCustomerToFrontend()`, `dbAssigneeToFrontend()`, `dbServiceToFrontend()`, `dbStoreToFrontend()` 등. legacyId(number) ↔ CUID(string) 변환 포함. `legacyId`가 null이면 프론트 id가 깨지므로 생성 시 반드시 부여할 것
+[^13]: `dbReservationToFrontend()`, `dbCustomerToFrontend()`, `dbAssigneeToFrontend()`, `dbServiceToFrontend()`, `dbStoreToFrontend()` 등. legacyId(number) ↔ CUID(string) 변환 포함. `legacyId`가 null이면 프론트 id가 깨지므로 생성 시 반드시 부여할 것. **예약 조회는 `prisma-includes.ts`의 명시적 `select`(`reservationSelect`/`reservationSelectWithNames`)만 사용** — `include`(전체 컬럼 SELECT)는 금지. 새 컬럼을 추가한 뒤 마이그레이션이 미적용된 채 배포되면 `include`가 없는 컬럼까지 SELECT하다 전체 예약 조회가 500나기 때문(2026-07 `publicToken` 배포순서 사고 재발방지)
 
 ---
 

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,20 @@
 
 ---
 
+## 완료 — 배포순서 장애 재발방지 (예약 조회 select 하드닝)
+
+> 배경: PR #80(온라인예약 1b·1c) 머지 후 마이그레이션 0009(`Reservation.publicToken`) 미적용 상태로 자동 배포 → 메인 캘린더/예약 API가 500(앱 전체 다운). 원인: 예약 조회가 Prisma `include`(모델 전체 컬럼 SELECT)라, DB에 없는 새 컬럼(`publicToken`)까지 SELECT하다 "column does not exist"로 실패.
+
+### 구현
+- `server/db/prisma-includes.ts`: `reservationInclude`/`reservationIncludeWithNames`(include) → **명시적 `select`** `reservationSelect`/`reservationSelectWithNames`로 교체. 프런트 매퍼가 실제 쓰는 컬럼만 나열(신규 컬럼은 이 목록에 넣기 전까지 미조회 → 배포가 마이그레이션 순서에 독립).
+- 호출부 전부 `include:` → `select:` 전환: `reservations.ts`(6곳), `naver-booking-sync.ts`(2곳), **`page-data/index.ts`(메인 캘린더 SSR — 실제 장애 쿼리)**.
+- 검증: 타입체크가 select 완전성 보증(매퍼/호출부가 쓰는 필드 누락 시 컴파일 에러), build 통과. 배포는 컬럼을 늘리지 않고 줄이기만 하므로 마이그레이션 상태와 무관하게 안전.
+
+### 남은 권장(후속)
+- 네이버 동기화·백필·마이그레이션 경로의 `create`/`update`(암묵적 전체 컬럼 RETURNING)는 앱 전체 다운은 아니나 동일 위험 존재 → 필요 시 select 명시. 신규 마이그레이션(예: 0010)은 여전히 "**적용 먼저, 배포 나중**" 원칙 유지.
+
+---
+
 ## 계획 중 — 고객 공개 예약 시스템 (Online Booking)
 
 > 결정(사용자): **셀프 예약 생성 + 고객 변경/취소 요청**, **인증 없이 이름+연락처**, **담당자 선택(+무관)**, **알림·취소까지** 풀 범위.

--- a/server/api/naver-booking-sync.ts
+++ b/server/api/naver-booking-sync.ts
@@ -9,7 +9,7 @@ import {listNaverBookingEmails, listNaverCancellationEmails, getEmailContent} fr
 import {parseNaverBookingEmail, parseNaverCancellationEmail} from './gmail/naver-booking-parser';
 import type {NaverBookingData} from './gmail/naver-booking-parser';
 import {dbReservationToFrontend} from '../db/mappers';
-import {reservationIncludeWithNames} from '../db/prisma-includes';
+import {reservationSelectWithNames} from '../db/prisma-includes';
 import {calcEndTime, getLastNaverSyncTimestamp} from './gmail/helpers';
 import {findByNameContains} from '../utils/string-matching';
 import {notifySlackOps} from '../notify/slack';
@@ -384,7 +384,7 @@ async function cancelReservationByBookingId(
 ): Promise<{status: 'cancelled'; legacyId: number; appointmentDate: string; appointmentTime: string; customerName: string; assigneeName: string} | {status: 'skipped'}> {
     const reservation = await prisma.reservation.findFirst({
         where: {storeId, naverBookingId: bookingId},
-        include: reservationIncludeWithNames,
+        select: reservationSelectWithNames,
     });
 
     if (!reservation) return {status: 'skipped'};
@@ -406,7 +406,7 @@ async function cancelReservationByBookingId(
     const updatedReservation = await prisma.reservation.update({
         where: {id: reservation.id},
         data: {status: 'cancelled'},
-        include: reservationIncludeWithNames,
+        select: reservationSelectWithNames,
     });
 
     const after = dbReservationToFrontend(updatedReservation);

--- a/server/api/reservations.ts
+++ b/server/api/reservations.ts
@@ -9,7 +9,7 @@ import {
     frontendPaymentMethodToDb,
     frontendChannelToDb,
 } from '../db/mappers';
-import {reservationInclude} from '../db/prisma-includes';
+import {reservationSelect} from '../db/prisma-includes';
 import {notifySlackForStore} from '../notify/slack';
 import type {Reservation, ReservationStatus} from '../../client/features/reservations/model';
 import {hasCompletedPayment} from '../../client/features/reservations/model';
@@ -40,7 +40,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const [dbReservations, dbHistories] = await Promise.all([
             prisma.reservation.findMany({
                 where: {storeId: session.storeId},
-                include: reservationInclude,
+                select: reservationSelect,
             }),
             prisma.reservationHistory.findMany({
                 where: {storeId: session.storeId},
@@ -92,7 +92,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     ? {createMany: {data: paymentEntries}}
                     : undefined,
             },
-            include: reservationInclude,
+            select: reservationSelect,
         });
 
         await notifySlackForStore(session.storeId,
@@ -191,7 +191,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     paymentCompleted: updated.paymentCompleted ?? false,
                     pointEarned: updated.pointEarned ?? 0,
                 },
-                include: reservationInclude,
+                select: reservationSelect,
             }),
             prisma.reservationPaymentEntry.deleteMany({where: {reservationId: dbReservation.id}}),
             ...(paymentEntries.length > 0
@@ -241,7 +241,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         const dbReservation = await prisma.reservation.findUnique({
             where: {storeId_legacyId: {storeId: session.storeId, legacyId: id}},
-            include: reservationInclude,
+            select: reservationSelect,
         });
 
         if (!dbReservation) {
@@ -255,7 +255,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             const updatedReservation = await tx.reservation.update({
                 where: {id: dbReservation.id},
                 data: {status: frontendReservationStatusToDb(status)},
-                include: reservationInclude,
+                select: reservationSelect,
             });
 
             const afterFront = dbReservationToFrontend(updatedReservation);
@@ -304,7 +304,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         const dbReservation = await prisma.reservation.findUnique({
             where: {storeId_legacyId: {storeId: session.storeId, legacyId: id}},
-            include: reservationInclude,
+            select: reservationSelect,
         });
 
         if (!dbReservation) {

--- a/server/db/prisma-includes.ts
+++ b/server/db/prisma-includes.ts
@@ -1,11 +1,56 @@
-export const reservationInclude = {
-    paymentEntries: true,
+// 예약 조회는 명시적 select만 쓴다(include= 전체 컬럼 SELECT 금지).
+//
+// 이유(재발 방지): Prisma의 include는 모델의 모든 스칼라 컬럼을 SELECT한다. 그래서 Reservation에
+// 새 컬럼을 추가한 뒤 마이그레이션이 아직 실 DB에 적용되지 않은 채 코드가 배포되면
+// "column does not exist"로 전체 예약 조회가 500난다(2026-07 온라인예약 publicToken 사고).
+// 명시적 select는 여기 나열한 컬럼만 조회하므로, 새 컬럼을 추가해도 이 목록에 넣기 전까지는
+// 배포를 깨뜨리지 않는다(코드 배포 ↔ 마이그레이션 순서 독립). 새 컬럼이 프런트에 필요해지면
+// 그때 이 목록에 추가하고, 해당 마이그레이션이 선적용됐는지 확인한다.
+
+// dbReservationToFrontend가 필요로 하는 스칼라 + 관계. id는 update/delete/이력 기록에 쓰인다.
+export const reservationSelect = {
+    id: true,
+    legacyId: true,
+    date: true,
+    startTime: true,
+    endTime: true,
+    serviceSummary: true,
+    customerId: true,
+    assigneeId: true,
+    status: true,
+    price: true,
+    memo: true,
+    paymentCompleted: true,
+    pointEarned: true,
+    naverBookingId: true,
+    naverBookingUrl: true,
+    naverDeposit: true,
+    channel: true,
+    paymentEntries: {select: {method: true, amount: true}},
     customer: {select: {legacyId: true}},
     assignee: {select: {legacyId: true}},
 } as const;
 
-export const reservationIncludeWithNames = {
-    paymentEntries: true,
+// 네이버 동기화 알림 등에서 고객/담당자 이름이 추가로 필요한 경우.
+export const reservationSelectWithNames = {
+    id: true,
+    legacyId: true,
+    date: true,
+    startTime: true,
+    endTime: true,
+    serviceSummary: true,
+    customerId: true,
+    assigneeId: true,
+    status: true,
+    price: true,
+    memo: true,
+    paymentCompleted: true,
+    pointEarned: true,
+    naverBookingId: true,
+    naverBookingUrl: true,
+    naverDeposit: true,
+    channel: true,
+    paymentEntries: {select: {method: true, amount: true}},
     customer: {select: {legacyId: true, name: true}},
     assignee: {select: {legacyId: true, name: true}},
 } as const;

--- a/server/page-data/index.ts
+++ b/server/page-data/index.ts
@@ -3,6 +3,7 @@ import {decode} from 'next-auth/jwt';
 
 import {prisma} from '../db/prisma';
 import {dbCustomerToFrontend, dbReservationToFrontend, dbHistoryToFrontend} from '../db/mappers';
+import {reservationSelect} from '../db/prisma-includes';
 
 export async function getPageSession(ctx: GetServerSidePropsContext) {
     const secureName = '__Secure-authjs.session-token';
@@ -30,11 +31,7 @@ export async function loadPageData(storeId: string) {
     const [dbReservations, dbCustomers, dbHistories] = await Promise.all([
         prisma.reservation.findMany({
             where: {storeId},
-            include: {
-                paymentEntries: true,
-                customer: {select: {legacyId: true}},
-                assignee: {select: {legacyId: true}},
-            },
+            select: reservationSelect,
         }),
         prisma.customer.findMany({
             where: {storeId},


### PR DESCRIPTION
Closes #81

## 배경
PR #80(온라인예약 1b·1c) 머지 후 마이그레이션 0009(`Reservation.publicToken`) 미적용 상태로 자동 배포 → **메인 캘린더/예약 API가 500(앱 전체 다운)**. 원인: 예약 조회가 Prisma `include`(모델 전체 컬럼 SELECT)라, DB에 없는 새 컬럼(`publicToken`)까지 SELECT하다 `column does not exist`로 실패.

## 변경
- `server/db/prisma-includes.ts`: `reservationInclude`/`…WithNames`(include) → **명시적 `select`** `reservationSelect`/`reservationSelectWithNames`. 프런트 매퍼가 실제 쓰는 컬럼만 나열.
- 호출부 `include:` → `select:` 전환: `reservations.ts`(6), `naver-booking-sync.ts`(2), **`page-data/index.ts`(메인 캘린더 SSR — 실제 장애 쿼리)**.

## 효과
`Reservation`에 새 컬럼을 추가해도 그 컬럼을 `select` 목록에 넣기 전까지는 조회하지 않으므로, **마이그레이션 미적용 상태로 배포돼도 메인 앱이 죽지 않는다**(코드 배포 ↔ 마이그레이션 순서 독립). 이 변경 자체는 조회 컬럼을 줄이기만 하므로 **DB 상태와 무관하게 즉시 배포 안전**.

## 검증
- ✅ 타입체크가 select 완전성 보증(매퍼/호출부 필드 누락 시 컴파일 에러), `next build`·lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXZxAQiTSRtY27qPkwWKUK)_