### PR TITLE
chore: minimumReleaseAge 명시로 배포 실패 재발 방지

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "0.22.4",
+    "version": "0.22.5",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+# 갓 배포된 패키지 설치 차단(공급망 보안). Cloud Build(pnpm 11)가 강제하는 24h(1440분)
+# 정책을 로컬에도 명시 — pnpm update가 신규 패키지를 lockfile에 넣어 배포가 깨지는 재발 방지(#87).
+minimumReleaseAge: 1440
 allowBuilds:
   '@prisma/engines': true
   prisma: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+# 갓 배포된 패키지 설치 차단(공급망 보안). Cloud Build(pnpm 11)가 강제하는 24h(1440분)
+# 정책을 로컬에도 명시 — pnpm update가 신규 패키지를 lockfile에 넣어 배포가 깨지는 재발 방지(#87).
+minimumReleaseAge: 1440
 allowBuilds:
   '@prisma/engines': true
   prisma: true


### PR DESCRIPTION
## 배경
#87(Cloud Build 배포 실패)의 근본 원인은 **로컬 pnpm이 `minimumReleaseAge` 정책을 적용하지 않아** `pnpm update`가 갓 게시된 transitive를 lockfile에 넣은 것. CI·로컬은 통과하고 Docker(pnpm 11, 정책 활성)에서만 배포가 거부됐다.

## 변경사항
- 두 독립 pnpm 프로젝트의 `pnpm-workspace.yaml`에 `minimumReleaseAge: 1440`(24h, 관측 컷오프와 동일) 명시:
  - `pnpm-workspace.yaml` (루트: server + prisma 툴링)
  - `client/pnpm-workspace.yaml` (Next 앱)
- 버전 0.22.4 → 0.22.5

## 검증
- 루트·client `pnpm install --frozen-lockfile` 모두 exit 0 (설정 정상 인식, 현재 lockfile 정책 통과).
- **정책 실동작 확인**: 정책 하에서 `pnpm update electron-to-chromium`이 오늘자 최신 `1.5.392`(24h 미만) 대신 `1.5.391`(24h 초과 최신)을 선택 → 로컬에서도 정책이 강제됨을 확인. (테스트 후 lockfile 원복)

## 효과
- 앞으로 `pnpm update`/`install`이 게시 24h 미만 패키지를 lockfile에 넣지 않아, Docker 정책 위반으로 배포가 깨지는 일이 원천 차단된다.

Closes #89

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_