### PR TITLE
fix(settings): 예약 설정 레이아웃 + 시술명 공통칩 + 체크박스 크기

### DIFF
--- a/client/components/settings/BookingManageSection.tsx
+++ b/client/components/settings/BookingManageSection.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 import styled from 'styled-components';
 
@@ -6,6 +6,8 @@ import {useToastStore} from '../../store/toastStore';
 import {useCalendarStore} from '../../store/calendarStore';
 import {DEFAULT_BOOKING_SETTINGS, isValidBookingSlug} from '../../features/store-settings/model';
 import type {BookingSettings} from '../../features/store-settings/model';
+import {buildServiceColorMap} from '../../utils/services';
+import {ServiceChipList} from '../ui/ServiceChip';
 import {StyledSettingsCard, StyledSettingsCardTitle, StyledSettingsHint, StyledSaveBtn} from './settings-styles';
 
 const BOOKING_HOST = process.env.NEXT_PUBLIC_BOOKING_HOST ?? 'book.takeaseat.co.kr';
@@ -14,6 +16,12 @@ const SLOT_OPTIONS = [10, 15, 20, 30, 60];
 export function BookingManageSection() {
     const toast = useToastStore((s) => s.show);
     const serviceCatalog = useCalendarStore((s) => s.serviceCatalog);
+    const categoryBaseColorMap = useCalendarStore((s) => s.categoryBaseColorMap);
+    // 노출 서비스 목록의 시술명을 캘린더 공통 색상 칩(ServiceChipList)으로 표시.
+    const serviceColorMap = useMemo(
+        () => buildServiceColorMap(serviceCatalog, categoryBaseColorMap),
+        [serviceCatalog, categoryBaseColorMap],
+    );
 
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -222,7 +230,7 @@ export function BookingManageSection() {
                                     onChange={() => toggleServiceExposure(s.name)}
                                     disabled={loading}
                                 />
-                                <span>{s.name}</span>
+                                <ServiceChipList serviceNames={[s.name]} serviceColorMap={serviceColorMap} keyPrefix={`book-svc-${idx}`} />
                             </StyledServiceCheckRow>
                         ))}
                     </StyledServiceCheckList>

--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -358,7 +358,9 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
 };
 
 const StyledBookingWrap = styled.div`
+    grid-column: 1 / -1;
     margin-top: 24px;
+    min-width: 0;
 `;
 
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/styles/globalStyle.ts
+++ b/client/styles/globalStyle.ts
@@ -226,6 +226,17 @@ export const GlobalStyle = createGlobalStyle`
         width: 100%;
     }
 
+    /* 체크박스·라디오는 위 input{width:100%} 대상에서 제외하고, 폰트에 맞춰 키운다. */
+    input[type="checkbox"],
+    input[type="radio"] {
+        width: 18px;
+        height: 18px;
+        flex-shrink: 0;
+        margin: 0;
+        accent-color: var(--brand-color);
+        cursor: pointer;
+    }
+
     .a11y {
         overflow: hidden;
         position: absolute;


### PR DESCRIPTION
## 변경 (3)
1. **예약 설정 패널 데스크탑 레이아웃 틀어짐** — `StoreManageSection` 2열 그리드에서 `StyledBookingWrap`이 반쪽 칸에 갇히던 문제 → `grid-column: 1 / -1` + `min-width: 0`.
2. **노출 서비스 목록 시술명 → 공통 색상 칩** — plain span → 캘린더 공통 `ServiceChipList`(색상 칩). 선택 체크박스는 유지.
3. **체크박스·라디오 전역 크기 확대** — `globalStyle`의 `input{width:100%}`가 체크박스까지 늘려 비율이 어색했음 → `input[type=checkbox]/[type=radio]` 18px + `flex-shrink:0` + `accent-color`(브랜드). 서비스 전반 적용.

버전 0.24.2.

## 참고
- CSS/컴포넌트 변경(로직 영향 없음). 타입체크 통과.
- 로컬 확인 어려워 배포 후 실기기 확인 예정(특히 모바일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)