### PR TITLE
feat(settings): 예약 URL 영역에 "예약 페이지 열어보기" 링크 추가

### DIFF
--- a/client/components/settings/BookingManageSection.tsx
+++ b/client/components/settings/BookingManageSection.tsx
@@ -154,6 +154,11 @@ export function BookingManageSection() {
                     {!slugFormatInvalid && checkState === 'invalid' && <StyledError>형식을 확인해 주세요.</StyledError>}
                 </StyledField>
                 <StyledUrlPreview>공개 주소: <strong>{publicUrl}</strong></StyledUrlPreview>
+                {slugValid && (
+                    <StyledPreviewLink href={`/book/${trimmedSlug}`} target="_blank" rel="noopener noreferrer">
+                        예약 페이지 열어보기 ↗
+                    </StyledPreviewLink>
+                )}
             </StyledSettingsCard>
 
             <StyledSettingsCard>
@@ -388,6 +393,22 @@ const StyledUrlPreview = styled.p`
     font-size: 13px;
     color: var(--dark-gray-color2);
     word-break: break-all;
+`;
+
+// 저장된 슬러그로 실제 작동하는 예약 페이지(/book/[slug])를 새 탭에서 바로 확인.
+// 서브도메인(book.*)은 #77 전까지 미작동이라, 링크는 현재 오리진의 /book 경로로 연다.
+const StyledPreviewLink = styled.a`
+    display: inline-flex;
+    align-items: center;
+    margin-top: 8px;
+    padding: 7px 12px;
+    border: 1px solid var(--brand-color);
+    border-radius: var(--radius-md);
+    background: var(--brand-color-bg);
+    color: var(--brand-color);
+    font-size: 12px;
+    font-weight: 700;
+    text-decoration: none;
 `;
 
 const StyledFooter = styled.div`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 변경
매장 설정 → 예약 설정의 **공개 예약 주소** 아래에 **"예약 페이지 열어보기 ↗"** 링크 추가. 오너가 바로 새 탭에서 셀프 확인 가능.

- 링크는 **현재 오리진의 `/book/[slug]`(실제 작동하는 주소)** 로 연다.
- ⚠️ 표시되는 `book.*` 서브도메인 주소는 **#77(서브도메인 rewrite) 전까지 미작동**이라, 확인 링크는 작동 경로로 걸었다.
- slug가 유효할 때만 노출. 버전 0.24.3.

## 후속 제안
- 표시되는 "공개 주소"도 지금은 `book.*`(미작동)이라, **#77을 하거나** 그 전까진 표시 주소도 작동 URL로 바꾸는 걸 검토 필요(오너가 고객에게 공유할 주소이므로).

## 검증
- 타입체크 통과. CSS/컴포넌트 변경(로직 영향 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_