### PR TITLE
feat(reservation): 예약 추가 고객 입력 통합 + 추천 번호 노출

### DIFF
--- a/client/components/calendar/overlays/ReservationCreate.tsx
+++ b/client/components/calendar/overlays/ReservationCreate.tsx
@@ -49,9 +49,7 @@ export const ReservationCreate = ({initial, customerMap, onClose, onSave}: Reser
         customerId,
         customerQuery,
         showSuggestions,
-        customerMode,
-        newCustomerName,
-        newCustomerTel,
+        customerTel,
         assigneeId,
         selectedServices,
         form,
@@ -59,9 +57,7 @@ export const ReservationCreate = ({initial, customerMap, onClose, onSave}: Reser
         filteredCustomers,
         totalDuration,
         totalPrice,
-        setCustomerMode,
-        setNewCustomerName,
-        setNewCustomerTel,
+        setCustomerTel,
         handleCustomerSelect,
         handleCustomerInputChange,
         handleCustomerFocus,
@@ -104,21 +100,17 @@ export const ReservationCreate = ({initial, customerMap, onClose, onSave}: Reser
             <StyledBody><StyledBodyInner>
                 <StyledCreateForm>
                     <ReservationCreateCustomerFields
-                        customerMode={customerMode}
                         customerId={customerId}
                         customerQuery={customerQuery}
                         showSuggestions={showSuggestions}
                         filteredCustomers={filteredCustomers}
-                        newCustomerName={newCustomerName}
-                        newCustomerTel={newCustomerTel}
+                        customerTel={customerTel}
                         customerErrorMessage={customerErrorMessage}
-                        onChangeCustomerMode={setCustomerMode}
                         onChangeCustomerQuery={handleCustomerInputChange}
                         onFocusCustomerQuery={handleCustomerFocus}
                         onBlurCustomerQuery={handleCustomerBlur}
                         onSelectCustomer={handleCustomerSelect}
-                        onChangeNewCustomerName={setNewCustomerName}
-                        onChangeNewCustomerTel={setNewCustomerTel}
+                        onChangeCustomerTel={setCustomerTel}
                     />
                     <ReservationFormFields
                         idPrefix="create"

--- a/client/components/calendar/overlays/ReservationCreateCustomerFields.tsx
+++ b/client/components/calendar/overlays/ReservationCreateCustomerFields.tsx
@@ -5,128 +5,94 @@ import styled from 'styled-components';
 import type {Customer} from '../../../utils/customers';
 import {StyledInlineError} from './ModalStyles';
 import {CustomerAutocomplete} from '../../customers/CustomerAutocomplete';
-
-type CustomerMode = 'existing' | 'new';
+import {formControlStyle} from '../../ui/FormControls';
 
 interface ReservationCreateCustomerFieldsProps {
-    customerMode: CustomerMode;
     customerId: number;
     customerQuery: string;
     showSuggestions: boolean;
     filteredCustomers: Customer[];
-    newCustomerName: string;
-    newCustomerTel: string;
+    customerTel: string;
     customerErrorMessage?: string;
-    onChangeCustomerMode: (mode: CustomerMode) => void;
     onChangeCustomerQuery: (value: string) => void;
     onFocusCustomerQuery: () => void;
     onBlurCustomerQuery: () => void;
     onSelectCustomer: (id: number) => void;
-    onChangeNewCustomerName: (value: string) => void;
-    onChangeNewCustomerTel: (value: string) => void;
+    onChangeCustomerTel: (value: string) => void;
 }
 
+// 예약 추가 고객 입력. 기존/신규 탭 없이 단일 입력으로 통합.
+// - 고객명: 자동완성. 추천에서 고르면 기존 고객(연락처 자동 채움), 새 이름을 쓰면 신규.
+// - 연락처: 항상 노출. 기존 선택 시 자동 채움, 신규 시 수동 입력.
 export function ReservationCreateCustomerFields({
-    customerMode,
     customerId,
     customerQuery,
     showSuggestions,
     filteredCustomers,
-    newCustomerName,
-    newCustomerTel,
+    customerTel,
     customerErrorMessage,
-    onChangeCustomerMode,
     onChangeCustomerQuery,
     onFocusCustomerQuery,
     onBlurCustomerQuery,
     onSelectCustomer,
-    onChangeNewCustomerName,
-    onChangeNewCustomerTel,
+    onChangeCustomerTel,
 }: ReservationCreateCustomerFieldsProps) {
     return (
-        <>
-            <StyledCustomerModeTabs>
-                <StyledCustomerModeButton
-                    type="button"
-                    $active={customerMode === 'existing'}
-                    onClick={() => onChangeCustomerMode('existing')}
-                >
-                    기존 고객
-                </StyledCustomerModeButton>
-                <StyledCustomerModeButton
-                    type="button"
-                    $active={customerMode === 'new'}
-                    onClick={() => onChangeCustomerMode('new')}
-                >
-                    신규 고객
-                </StyledCustomerModeButton>
-            </StyledCustomerModeTabs>
-            {customerMode === 'existing' ? (
-                <div>
-                    <CustomerAutocomplete
-                        id="create-customer"
-                        query={customerQuery}
-                        showSuggestions={showSuggestions}
-                        filteredCustomers={filteredCustomers}
-                        selectedId={customerId}
-                        onChangeQuery={onChangeCustomerQuery}
-                        onFocus={onFocusCustomerQuery}
-                        onBlur={onBlurCustomerQuery}
-                        onSelect={onSelectCustomer}
-                    />
-                    {customerErrorMessage && <StyledInlineError>{customerErrorMessage}</StyledInlineError>}
-                </div>
-            ) : (
-                <StyledNewCustomerFields>
-                    <label htmlFor="create-new-customer-name">
-                        <strong>고객명</strong>
-                        <input
-                            id="create-new-customer-name"
-                            type="text"
-                            placeholder="신규 고객명"
-                            value={newCustomerName}
-                            onChange={(e) => onChangeNewCustomerName(e.target.value)}
-                        />
-                    </label>
-                    <label htmlFor="create-new-customer-tel">
-                        <strong>연락처</strong>
-                        <input
-                            id="create-new-customer-tel"
-                            type="tel"
-                            placeholder="01012345678"
-                            value={newCustomerTel}
-                            onChange={(e) => onChangeNewCustomerTel(e.target.value)}
-                        />
-                    </label>
-                    {customerErrorMessage && <StyledInlineError>{customerErrorMessage}</StyledInlineError>}
-                </StyledNewCustomerFields>
-            )}
-        </>
+        <StyledCustomerFields>
+            <CustomerAutocomplete
+                id="create-customer"
+                label="고객명"
+                placeholder="고객명 검색 또는 신규 입력"
+                query={customerQuery}
+                showSuggestions={showSuggestions}
+                filteredCustomers={filteredCustomers}
+                selectedId={customerId}
+                onChangeQuery={onChangeCustomerQuery}
+                onFocus={onFocusCustomerQuery}
+                onBlur={onBlurCustomerQuery}
+                onSelect={onSelectCustomer}
+            />
+            <StyledTelField htmlFor="create-customer-tel">
+                <strong>연락처</strong>
+                <StyledTelInput
+                    id="create-customer-tel"
+                    type="tel"
+                    inputMode="numeric"
+                    autoComplete="off"
+                    placeholder="01012345678"
+                    value={customerTel}
+                    onChange={(e) => onChangeCustomerTel(e.target.value)}
+                />
+            </StyledTelField>
+            {customerErrorMessage && <StyledInlineError>{customerErrorMessage}</StyledInlineError>}
+        </StyledCustomerFields>
     );
 }
 
-const StyledCustomerModeTabs = styled.div`
+const StyledCustomerFields = styled.div`
   display: flex;
+  flex-direction: column;
   gap: 8px;
 `;
 
-const StyledCustomerModeButton = styled.button<{ $active: boolean }>`
-  min-height: 30px;
-  padding: 0 12px;
-  border: 1px solid ${({$active}) => $active ? 'var(--blue-color)' : 'var(--light-gray-color)'};
-  border-radius: 999px;
-  background: ${({$active}) => $active ? 'var(--blue-color)' : 'var(--white-color)'};
-  color: ${({$active}) => $active ? 'var(--white-color)' : 'var(--dark-gray-color)'};
-  font-size: 12px;
-`;
+const StyledTelField = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 
-const StyledNewCustomerFields = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-
-  @media (max-width: 480px) {
-    grid-template-columns: 1fr;
+  > strong {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
   }
 `;
 
+const StyledTelInput = styled.input`
+  ${formControlStyle};
+  height: 36px;
+  padding: 0 10px;
+  font-size: 13px;
+  color: var(--black-color);
+  width: 100%;
+  min-width: 0;
+`;

--- a/client/components/calendar/overlays/useReservationCreateForm.ts
+++ b/client/components/calendar/overlays/useReservationCreateForm.ts
@@ -11,7 +11,6 @@ import {getAssigneeAvailabilityState, splitAssigneesByStatus} from '../../../uti
 import {buildCatalogMap, calcEndTime, joinServiceNames, sumDurationMinutes, sumPrice} from '../../../utils/services';
 import {useStoreLabels} from '../../../hooks/useStoreLabels';
 import type {ReservationDetailFormState, ReservationFieldError} from './ReservationDetailSections';
-type CustomerMode = 'existing' | 'new';
 
 const KOREAN_MOBILE_PHONE_PATTERN = /^01[016789]\d{7,8}$/;
 
@@ -55,9 +54,10 @@ export function useReservationCreateForm({
     const [customerQuery, setCustomerQuery] = useState('');
     const [showSuggestions, setShowSuggestions] = useState(false);
     const blurTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-    const [customerMode, setCustomerMode] = useState<CustomerMode>('existing');
-    const [newCustomerName, setNewCustomerName] = useState('');
-    const [newCustomerTel, setNewCustomerTel] = useState('');
+    // 기존/신규 탭을 없애고 단일 입력으로 통합.
+    // 고객명 = customerQuery, 연락처 = customerTel(항상 노출).
+    // 기존 고객 선택 시 customerId≠0 + 이름·연락처 자동 채움. 새 이름 입력 시 customerId=0(신규).
+    const [customerTel, setCustomerTel] = useState('');
     const [selectedServices, setSelectedServices] = useState<string[]>([]);
     const [isPriceManual, setIsPriceManual] = useState(false);
     const [form, setForm] = useState({
@@ -85,6 +85,7 @@ export function useReservationCreateForm({
         if (customer) {
             setCustomerId(id);
             setCustomerQuery(customer.name);
+            setCustomerTel(customer.tel); // 기존 고객 선택 → 연락처 자동 채움
         }
         setShowSuggestions(false);
         setError(null);
@@ -92,7 +93,12 @@ export function useReservationCreateForm({
 
     const handleCustomerInputChange = (value: string) => {
         setCustomerQuery(value);
-        setCustomerId(0);
+        // 기존 선택 상태에서 이름을 다시 입력하면 신규로 전환 → 자동 채운 연락처를 비워
+        // 수동 입력을 받는다. 이미 신규(customerId=0)면 수동 입력한 연락처를 건드리지 않는다.
+        if (customerId !== 0) {
+            setCustomerId(0);
+            setCustomerTel('');
+        }
         setShowSuggestions(true);
         setError(null);
     };
@@ -156,14 +162,16 @@ export function useReservationCreateForm({
     };
 
     const validate = (): ReservationFieldError | null => {
-        const normalizedNewCustomerTel = newCustomerTel.replace(/\D/g, '');
+        const normalizedTel = customerTel.replace(/\D/g, '');
+        const isNewCustomer = customerId === 0;
 
         if (activeAssignees.length > 0 && !form.assigneeId) return {field: 'assignee', message: `${labels.assignee}를 선택해주세요.`};
-        if (customerMode === 'existing' && !customerId) return {field: 'customer', message: '고객을 선택해주세요.'};
-        if (customerMode === 'new' && !newCustomerName.trim()) return {field: 'customer', message: '신규 고객명을 입력해주세요.'};
-        if (customerMode === 'new' && !newCustomerTel.trim()) return {field: 'customer', message: '신규 고객 연락처를 입력해주세요.'};
-        if (customerMode === 'new' && !KOREAN_MOBILE_PHONE_PATTERN.test(normalizedNewCustomerTel)) {
-            return {field: 'customer', message: '신규 고객 연락처 형식을 확인해주세요.'};
+        // 기존 고객(customerId≠0)은 추천에서 선택된 상태 → 이름·연락처는 자동 채움.
+        // 신규(customerId==0)만 이름·연락처를 직접 검증한다.
+        if (!customerQuery.trim()) return {field: 'customer', message: '고객명을 입력해주세요.'};
+        if (isNewCustomer && !customerTel.trim()) return {field: 'customer', message: '연락처를 입력해주세요.'};
+        if (isNewCustomer && !KOREAN_MOBILE_PHONE_PATTERN.test(normalizedTel)) {
+            return {field: 'customer', message: '연락처 형식을 확인해주세요.'};
         }
         if (selectedServices.length === 0) return {field: 'service', message: `${labels.service}를 선택해주세요.`};
         if (!form.date) return {field: 'date', message: '날짜를 선택해주세요.'};
@@ -202,11 +210,12 @@ export function useReservationCreateForm({
         //  legacyId 0 한 칸에 덮어써지는 치명적 버그가 있었음)
         let resolvedCustomerId = customerId;
 
-        if (customerMode === 'new') {
+        // customerId==0 → 추천에서 고른 기존 고객이 없으므로 신규로 생성.
+        if (customerId === 0) {
             const nextCustomer: Customer = {
                 id: nextCustomerId,
-                name: newCustomerName.trim(),
-                tel: normalizeTel(newCustomerTel),
+                name: customerQuery.trim(),
+                tel: normalizeTel(customerTel),
                 points: 0,
                 pointHistories: [],
             };
@@ -241,9 +250,7 @@ export function useReservationCreateForm({
         customerId,
         customerQuery,
         showSuggestions,
-        customerMode,
-        newCustomerName,
-        newCustomerTel,
+        customerTel,
         assigneeId: form.assigneeId,
         selectedServices,
         form,
@@ -251,16 +258,8 @@ export function useReservationCreateForm({
         filteredCustomers,
         totalDuration,
         totalPrice,
-        setCustomerMode: (mode: CustomerMode) => {
-            setCustomerMode(mode);
-            setError(null);
-        },
-        setNewCustomerName: (value: string) => {
-            setNewCustomerName(value);
-            setError(null);
-        },
-        setNewCustomerTel: (value: string) => {
-            setNewCustomerTel(value);
+        setCustomerTel: (value: string) => {
+            setCustomerTel(value);
             setError(null);
         },
         handleCustomerSelect,

--- a/client/components/customers/CustomerAutocomplete.tsx
+++ b/client/components/customers/CustomerAutocomplete.tsx
@@ -144,11 +144,14 @@ const StyledSuggestionItem = styled.li`
   }
 `;
 
-const StyledSuggestionName = styled.span``;
+const StyledSuggestionName = styled.span`
+  font-weight: 500;
+`;
 
 const StyledSuggestionTel = styled.span`
-  font-size: 11px;
-  color: var(--gray-color);
+  font-size: 12px;
+  color: var(--dark-gray-color2);
+  font-variant-numeric: tabular-nums;
 `;
 
 const StyledNoResult = styled.li`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/plan.md
+++ b/plan.md
@@ -4,7 +4,22 @@
 
 ---
 
-## 진행 중 — 고객 전화번호 중복 경고 + 병합 유도 (#98)
+## 진행 중 — 예약 추가 고객 입력 UX (#100)
+
+> 요청: (1) 고객 추천 목록에 전화번호가 안 보임(색이 너무 옅음) → 동명이인 구분 불가. (2) 기존/신규 탭 없이 연락처 란 상시 노출 — 기존 선택 시 이름·연락처 자동 채움, 새 이름 입력 시 연락처 수동.
+
+### 구현
+- `CustomerAutocomplete.tsx`: 추천 번호 색 `--gray-color`→`--dark-gray-color2`, 12px·tabular-nums로 또렷하게. 이름 weight 500.
+- `useReservationCreateForm.ts`: `customerMode`/`newCustomerName`/`newCustomerTel` 제거, 단일 `customerTel`. 이름=`customerQuery`. 기존선택=`customerId≠0`(연락처 자동 채움), 새이름=`customerId=0`(이름 재입력 시 선택 해제+연락처 비움). validate/handleSave 단일 경로(신규만 번호 형식 검사).
+- `ReservationCreateCustomerFields.tsx`: 탭 제거, 고객명(자동완성)+연락처(상시) 2필드.
+- `ReservationCreate.tsx`: props 배선 갱신.
+
+### 검증
+- 타입체크·lint 통과. 프로덕션 빌드로 확인.
+
+---
+
+## 완료 — 고객 전화번호 중복 경고 + 병합 유도 (#98)
 
 > 배경: 고객 정보 레이어에서 이름·전화번호 수정 시, 같은 매장 내 다른 고객이 이미 그 번호를 써도 무검증 저장 → 동일 번호 고객이 조용히 중복. 서버 PUT은 legacyId 단건 저장뿐이고 `(storeId, tel)`은 인덱스(비-unique). 기존 병합 제안은 마스킹 이름만 감지.
 


### PR DESCRIPTION
## 변경
예약 추가 시 고객 입력 UX 2건.

### 1) 고객 추천 목록에 전화번호가 또렷이 보이도록
- `CustomerAutocomplete` 추천 항목의 번호가 이미 렌더되고 있었으나 색이 `--gray-color`(hsl 86%)로 거의 안 보여 "이름만" 뜨는 것처럼 보였다 → 동명이인 구분 불가.
- 번호 색 `--dark-gray-color2`, 12px·`tabular-nums`로 또렷하게. 이름 weight 500.
- (이 컴포넌트는 회원권·포인트 등에서도 공용 → 전반 가독성 개선)

### 2) 기존/신규 탭 제거, 연락처 란 상시 노출
- 기존: `기존 고객`/`신규 고객` 탭(`customerMode`)으로 분리 → 신규는 탭 전환 필요.
- 변경: **탭 제거. 고객명(자동완성) + 연락처(항상 노출) 단일 입력.**
  - 추천에서 **기존 고객 선택 → 이름·연락처 자동 채움**(`customerId≠0`).
  - **새 이름 입력 → 선택 해제 + 연락처 비움**(수동 입력, `customerId=0` → 저장 시 신규 생성).
  - 이미 신규 입력 중이면(customerId=0) 수동 입력한 연락처는 건드리지 않음.
- validate/handleSave를 단일 경로로 통합. 신규(customerId=0)만 번호 형식(`01[016789]…`) 검사, 기존 선택은 레코드 사용.

## 변경 파일
- `client/components/customers/CustomerAutocomplete.tsx` — 추천 번호 색·가독성.
- `client/components/calendar/overlays/useReservationCreateForm.ts` — `customerMode`/`newCustomerName`/`newCustomerTel` → 단일 `customerTel`. 선택/입력/검증/저장 통합.
- `client/components/calendar/overlays/ReservationCreateCustomerFields.tsx` — 탭 제거, 2필드 구성.
- `client/components/calendar/overlays/ReservationCreate.tsx` — props 배선.
- `client/package.json` — 0.25.0 → 0.26.0.
- `plan.md`.

## 검증
- 타입체크(`tsc --noEmit`)·lint 0 error, **프로덕션 빌드(`pnpm build`) 통과.**
- 추천에서 번호 노출 확인, 기존 선택=자동채움 / 새 이름=수동입력으로 예약 추가 경로 확인.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_