### PR TITLE
feat(admin): 예약 상세 레이어에서 온라인 예약 '예약확정' 버튼

### DIFF
--- a/client/components/calendar/overlays/ReservationDetail.tsx
+++ b/client/components/calendar/overlays/ReservationDetail.tsx
@@ -474,6 +474,21 @@ export const ReservationDetail = ({
     const isCompleted = sourceReservation.status === 'completed';
     const isNoshow = sourceReservation.status === 'noshow';
     const isInactive = isCancelled || isNoshow || isCompleted;
+    // 온라인 예약 신청(확정 대기). 상세 레이어에서 바로 확정/거절할 수 있게 한다.
+    const isRequested = sourceReservation.status === 'requested';
+
+    // 예약확정/거절 → 오너 승인 API(book-requests) 재사용. legacyId로 대상 지정.
+    // 성공 시 새로고침으로 캘린더·요청벨을 갱신(오너 벨과 동일 패턴).
+    const decideBooking = (decision: 'approve' | 'reject') => {
+        if (decision === 'reject' && !window.confirm('이 예약 신청을 거절할까요? 거절하면 취소됩니다.')) return;
+        fetch('/api/book-requests', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({legacyId: sourceReservation.id, decision}),
+        })
+            .then((res) => { if (res.ok) window.location.reload(); else setError({field: 'general', message: '처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'}); })
+            .catch(() => setError({field: 'general', message: '처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'}));
+    };
     const isNaverBooking = Boolean(sourceReservation.naverBookingId);
     const dialogLabel = MODE_LABELS[mode] ?? '예약 상세';
     const headerService = mode === 'view' ? draftReservation.service : form.service;
@@ -668,9 +683,12 @@ export const ReservationDetail = ({
                     <ReservationDetailFooterActions
                         mode={mode}
                         isInactive={isInactive}
+                        isRequested={isRequested}
                         isCompleted={isCompleted}
                         paymentCompleted={paymentCompleted}
                         isNaverBooking={isNaverBooking}
+                        onConfirmBooking={() => decideBooking('approve')}
+                        onRejectBooking={() => decideBooking('reject')}
                         onOpenCompleting={() => {
                             if (!hasCompletedPayment(sourceReservation)) {
                                 setError({field: 'general', message: '결제 완료된 예약만 완료 처리할 수 있습니다.'});

--- a/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
+++ b/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
@@ -6,10 +6,13 @@ import type {ReservationDetailMode} from './reservationDetailTypes';
 type ReservationDetailFooterActionsProps = {
     mode: ReservationDetailMode;
     isInactive: boolean;
+    isRequested: boolean;
     isCompleted: boolean;
     paymentCompleted: boolean;
     isNaverBooking: boolean;
     canDelete: boolean;
+    onConfirmBooking: () => void;
+    onRejectBooking: () => void;
     onOpenCompleting: () => void;
     onOpenCancelling: () => void;
     onOpenNoshow: () => void;
@@ -32,10 +35,13 @@ type ReservationDetailFooterActionsProps = {
 export function ReservationDetailFooterActions({
                                                    mode,
                                                    isInactive,
+                                                   isRequested,
                                                    isCompleted,
                                                    paymentCompleted,
                                                    isNaverBooking,
                                                    canDelete,
+                                                   onConfirmBooking,
+                                                   onRejectBooking,
                                                    onOpenCompleting,
                                                    onOpenCancelling,
                                                    onOpenNoshow,
@@ -55,6 +61,19 @@ export function ReservationDetailFooterActions({
                                                    onBackToView,
                                                }: ReservationDetailFooterActionsProps) {
     if (mode === 'view') {
+        // 온라인 예약 신청(확정 대기): 결제·완료 등 활성 액션 대신 예약확정/거절만 노출.
+        if (isRequested) {
+            return (
+                <>
+                    <StyledActionButton type="button"
+                                        $primary
+                                        onClick={onConfirmBooking}>예약확정</StyledActionButton>
+                    <StyledActionButton type="button"
+                                        $dangerOutline
+                                        onClick={onRejectBooking}>거절</StyledActionButton>
+                </>
+            );
+        }
         if (isInactive) {
             return (
                 <>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/plan.md
+++ b/plan.md
@@ -4,7 +4,24 @@
 
 ---
 
-## 진행 중 — 예약 변경 UI 픽커화 + 조회/변경/취소 디자인 정렬 (#112)
+## 진행 중 — 관리자 예약 상세 '예약확정' (#114)
+
+> 배치 6: 온라인 예약(requested)을 예약 상세 레이어에서 확정/거절.
+
+### 구현
+- `POST /api/book-requests`가 `legacyId`로도 대상 지정(기존 cuid `id` 유지). update where를 `reservation.id`로 고정.
+- `ReservationDetailFooterActions` view 모드: `isRequested`면 예약확정/거절만 노출.
+- `ReservationDetail`: `status==='requested'` 판정 + decideBooking(approve/reject by legacyId) → 성공 시 reload(벨과 동일). 거절은 confirm.
+
+### 검증
+- 타입체크·빌드.
+
+### 배치 완료
+- 1·3·4·5(#110/#111 ✅), 2·3(#112/#113 ✅), 6(#114 진행).
+
+---
+
+## 완료 — 예약 변경 UI 픽커화 + 조회/변경/취소 디자인 정렬 (#112)
 
 > 배치 2·3: `/r/[token]` 변경 폼을 예약 화면과 동일한 픽커 UI로, 디자인 가이드(토큰) 정렬.
 

--- a/server/api/book-requests.ts
+++ b/server/api/book-requests.ts
@@ -11,6 +11,7 @@ import {getApiSession, requireRole} from '../auth/api-session';
 
 interface DecideBody {
     id?: unknown;
+    legacyId?: unknown;
     decision?: unknown;
 }
 
@@ -104,12 +105,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (!requireRole(session, 'staff', res)) return;
 
         const body = (req.body ?? {}) as DecideBody;
+        // 오너 벨은 cuid(id), 예약 상세 레이어는 클라 Reservation의 legacyId로 대상 지정.
         const id = typeof body.id === 'string' ? body.id : '';
+        const legacyId = typeof body.legacyId === 'number' ? body.legacyId : null;
         const decision = body.decision === 'approve' || body.decision === 'reject' ? body.decision : null;
-        if (!id || !decision) return res.status(400).json({error: 'invalid_input'});
+        if ((!id && legacyId === null) || !decision) return res.status(400).json({error: 'invalid_input'});
 
         const reservation = await prisma.reservation.findFirst({
-            where: {id, storeId: session.storeId},
+            where: {storeId: session.storeId, ...(id ? {id} : {legacyId: legacyId as number})},
             select: PENDING_SELECT,
         });
         if (!reservation) return res.status(404).json({error: 'not_found'});
@@ -121,19 +124,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // 신규 예약 신청 확정/거절
         if (kind === 'new') {
             const status = decision === 'approve' ? 'active' : 'cancelled';
-            await prisma.reservation.update({where: {id}, data: {status}});
+            await prisma.reservation.update({where: {id: reservation.id}, data: {status}});
             return res.status(200).json({ok: true, applied: decision === 'approve' ? 'confirmed' : 'rejected'});
         }
 
         // 변경/취소 요청 거절 → 요청만 폐기(예약 유지)
         if (decision === 'reject') {
-            await prisma.reservation.update({where: {id}, data: CLEAR_PENDING});
+            await prisma.reservation.update({where: {id: reservation.id}, data: CLEAR_PENDING});
             return res.status(200).json({ok: true, applied: 'rejected'});
         }
 
         // 취소 요청 수락
         if (kind === 'cancel') {
-            await prisma.reservation.update({where: {id}, data: {status: 'cancelled', ...CLEAR_PENDING}});
+            await prisma.reservation.update({where: {id: reservation.id}, data: {status: 'cancelled', ...CLEAR_PENDING}});
             return res.status(200).json({ok: true, applied: 'cancelled'});
         }
 


### PR DESCRIPTION
배치 요청 6.

## 변경
매장 관리(캘린더)에서 온라인 예약이 들어오면(`status='requested'`, 캘린더에 이미 노출됨) **예약 상세 레이어에서 바로 확정/거절**할 수 있게.

- `ReservationDetailFooterActions` view 모드: `isRequested`면 결제·완료 등 활성 예약 액션 대신 **예약확정 / 거절**만 노출.
- `ReservationDetail`: `status==='requested'` 판정 + `decideBooking(approve/reject)` → 오너 승인 API(`/api/book-requests`) 재사용. 확정=`active`, 거절=취소. 성공 시 새로고침(오너 벨과 동일 패턴), 거절은 `confirm`.
- 클라 `Reservation`은 cuid가 없어 **`legacyId`로 대상 지정**하도록 `POST /api/book-requests` 확장(기존 `id` 유지, `update` where를 `reservation.id`로 고정).

## 변경 파일
- `server/api/book-requests.ts` — legacyId 지원.
- `client/components/calendar/overlays/ReservationDetailFooterActions.tsx` — isRequested 분기.
- `client/components/calendar/overlays/ReservationDetail.tsx` — 확정/거절 핸들러.
- `client/package.json` — 0.30.0 → 0.31.0. `plan.md`.

## 검증
- 타입체크(`tsc --noEmit`) 통과, **프로덕션 빌드 통과.** 스키마 변경 없음.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_