### PR TITLE
fix(book): 요청사항 textarea 세로 정렬 수정

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -720,12 +720,17 @@ const StyledTextInput = styled.input`
 
 const StyledTextArea = styled.textarea`
     ${formControlStyle};
+    /* formControlStyle의 height:32px(input용) 고정을 덮어 rows/패딩이 먹도록 한다. */
+    display: block;
     width: 100%;
+    height: auto;
+    min-height: 76px;
     padding: 10px 12px;
     font-size: var(--small-font);
     line-height: 1.5;
     resize: vertical;
     font-family: inherit;
+    vertical-align: top;
 `;
 
 const StyledFieldHint = styled.span`

--- a/plan.md
+++ b/plan.md
@@ -4,7 +4,16 @@
 
 ---
 
-## 진행 중 — 관리자 예약 상세 '예약확정' (#114)
+## 진행 중 — 요청사항 textarea 세로 정렬 (#116)
+
+> 버그: 메모 textarea 세로 정렬 틀어짐. 원인: formControlStyle의 height:32px(input용)가 textarea에 먹음.
+
+### 수정
+- `StyledTextArea`에 display:block, height:auto, min-height:76px, vertical-align:top로 고정 높이 덮음.
+
+---
+
+## 완료 — 관리자 예약 상세 '예약확정' (#114)
 
 > 배치 6: 온라인 예약(requested)을 예약 상세 레이어에서 확정/거절.
 


### PR DESCRIPTION
## 버그
신규 예약 요청사항(메모) textarea 텍스트/placeholder 세로 정렬이 틀어짐.

## 원인
`StyledTextArea`가 상속하는 `formControlStyle`에 **`height: 32px`**(input용 고정)가 있어 textarea에도 32px가 먹음 → `rows={3}`·padding이 무시되고 32px 박스에 눌림.

## 수정
`StyledTextArea`에 `display:block; height:auto; min-height:76px; vertical-align:top` 지정으로 고정 높이를 덮음.

## 변경 파일
- `client/pages/book/[slug].tsx`
- `client/package.json` — 0.31.0 → 0.31.1. `plan.md`.

## 검증
- 타입체크·프로덕션 빌드 통과.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_