### PR TITLE
fix(admin): 온라인 예약 상세 진입 + 확정대기 배지 + 채널 표시 오류

### DIFF
--- a/client/components/calendar/overlays/ReservationViewSection.tsx
+++ b/client/components/calendar/overlays/ReservationViewSection.tsx
@@ -49,6 +49,7 @@ export function ReservationViewSection({
     const isCancelled = reservation.status === 'cancelled';
     const isCompleted = reservation.status === 'completed';
     const isNoshow = reservation.status === 'noshow';
+    const isRequested = reservation.status === 'requested';
     const customerMemoTags = customer?.memoTags ?? [];
 
     return (
@@ -71,6 +72,12 @@ export function ReservationViewSection({
                         <>
                             <StyledTerm>상태</StyledTerm>
                             <StyledDesc><ReservationStatusBadge $type="completed">완료</ReservationStatusBadge></StyledDesc>
+                        </>
+                    )}
+                    {isRequested && (
+                        <>
+                            <StyledTerm>상태</StyledTerm>
+                            <StyledDesc><ReservationStatusBadge $type="requested">확정대기</ReservationStatusBadge></StyledDesc>
                         </>
                     )}
                     <StyledTerm>날짜</StyledTerm>
@@ -151,7 +158,7 @@ export function ReservationViewSection({
                                 </StyledBookingNotice>
                             </>
                         ) : (
-                            <StyledChannelTag>{reservation.channel === '현장방문' ? '현장방문' : '전화예약'}</StyledChannelTag>
+                            <StyledChannelTag>{reservation.channel ?? '전화예약'}</StyledChannelTag>
                         )}
                     </StyledDesc>
                 </StyledDetailList>

--- a/client/components/calendar/views/TimelineReservationCard.tsx
+++ b/client/components/calendar/views/TimelineReservationCard.tsx
@@ -76,7 +76,7 @@ export function TimelineReservationCard({
                 <StyledTimelineServiceList service={reservation.service}
                                           serviceColorMap={serviceColorMap}
                                           keyPrefix={reservation.id} />
-                {reservation.status === 'requested' ? ' (신청)' : reservation.status === 'cancelled' ? ' (취소)' : reservation.status === 'noshow' ? ' (노쇼)' : hasCompletedPayment(reservation) ? ' (결제완료)' : ''}
+                {reservation.status === 'requested' ? ' (확정대기)' : reservation.status === 'cancelled' ? ' (취소)' : reservation.status === 'noshow' ? ' (노쇼)' : hasCompletedPayment(reservation) ? ' (결제완료)' : ''}
             </strong>
             {preview && <span className="sub">{preview.date} {preview.startTime}~{preview.endTime}</span>}
             {customerName && (
@@ -125,7 +125,7 @@ export function TimelineDragGhost({
                 <StyledTimelineServiceList service={reservation.service}
                                           serviceColorMap={serviceColorMap}
                                           keyPrefix={`ghost-${reservation.id}`} />
-                {reservation.status === 'requested' ? ' (신청)' : reservation.status === 'cancelled' ? ' (취소)' : reservation.status === 'noshow' ? ' (노쇼)' : hasCompletedPayment(reservation) ? ' (결제완료)' : ''}
+                {reservation.status === 'requested' ? ' (확정대기)' : reservation.status === 'cancelled' ? ' (취소)' : reservation.status === 'noshow' ? ' (노쇼)' : hasCompletedPayment(reservation) ? ' (결제완료)' : ''}
             </strong>
             <span className="sub">{preview.date} {preview.startTime}~{preview.endTime}</span>
             {customerName && (

--- a/client/components/layout/BookingRequestNotification.tsx
+++ b/client/components/layout/BookingRequestNotification.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import {useBookingRequests, type BookingRequestDto} from '../../hooks/useBookingRequests';
 import {LabelBadge} from '../ui/LabelBadge';
+import {useCalendarStore} from '../../store/calendarStore';
 
 function formatMd(dateStr: string): string {
     if (!dateStr || !dateStr.includes('-')) return dateStr || '-';
@@ -14,9 +15,20 @@ function formatMd(dateStr: string): string {
 // 오너용 온라인 예약 변경/취소 요청 승인 벨. 대기 요청이 있을 때만 노출된다.
 export const BookingRequestNotification = () => {
     const {requests, loading, refetch, decide} = useBookingRequests();
+    const openReservationDetail = useCalendarStore((s) => s.openReservationDetail);
+    const reservationMap = useCalendarStore((s) => s.reservationMap);
     const [open, setOpen] = useState(false);
     const [busyId, setBusyId] = useState<string>('');
     const containerRef = useRef<HTMLDivElement>(null);
+
+    // 벨 항목 클릭 → legacyId로 예약을 찾아 상세 레이어를 연다(미래 날짜 예약도 상세 접근 가능).
+    const openDetail = useCallback((req: BookingRequestDto) => {
+        if (req.legacyId == null) return;
+        for (const list of Object.values(reservationMap)) {
+            const found = list.find((r) => r.id === req.legacyId);
+            if (found) { openReservationDetail(found); setOpen(false); return; }
+        }
+    }, [reservationMap, openReservationDetail]);
 
     useEffect(() => {
         if (!open) return;
@@ -69,20 +81,22 @@ export const BookingRequestNotification = () => {
                         {!loading && requests.length === 0 && <StyledEmpty>대기 중인 요청이 없습니다</StyledEmpty>}
                         {requests.map((req) => (
                             <StyledItem key={req.id}>
-                                <StyledItemHead>
-                                    <StyledCustomer>{req.customerName || '고객'}</StyledCustomer>
-                                    {req.kind === 'new' && <LabelBadge $tone="warning" $shape="pill">신규 예약 신청</LabelBadge>}
-                                    {req.kind === 'change' && <LabelBadge $tone="purple" $shape="pill">변경 요청</LabelBadge>}
-                                    {req.kind === 'cancel' && <LabelBadge $tone="danger" $shape="pill">취소 요청</LabelBadge>}
-                                </StyledItemHead>
-                                <StyledItemLine>
-                                    {req.kind === 'new' ? '신청' : '현재'}: {formatMd(req.current.date)} {req.current.startTime}~{req.current.endTime} ({req.current.serviceSummary})
-                                </StyledItemLine>
-                                {req.kind === 'change' && req.requestedChange && (
-                                    <StyledItemLine $accent>
-                                        변경: {formatMd(req.requestedChange.date)} {req.requestedChange.startTime}~{req.requestedChange.endTime} ({req.requestedChange.serviceSummary})
+                                <StyledItemBody type="button" onClick={() => openDetail(req)} title="예약 상세 보기">
+                                    <StyledItemHead>
+                                        <StyledCustomer>{req.customerName || '고객'}</StyledCustomer>
+                                        {req.kind === 'new' && <LabelBadge $tone="warning" $shape="pill">신규 예약 신청</LabelBadge>}
+                                        {req.kind === 'change' && <LabelBadge $tone="purple" $shape="pill">변경 요청</LabelBadge>}
+                                        {req.kind === 'cancel' && <LabelBadge $tone="danger" $shape="pill">취소 요청</LabelBadge>}
+                                    </StyledItemHead>
+                                    <StyledItemLine>
+                                        {req.kind === 'new' ? '신청' : '현재'}: {formatMd(req.current.date)} {req.current.startTime}~{req.current.endTime} ({req.current.serviceSummary})
                                     </StyledItemLine>
-                                )}
+                                    {req.kind === 'change' && req.requestedChange && (
+                                        <StyledItemLine $accent>
+                                            변경: {formatMd(req.requestedChange.date)} {req.requestedChange.startTime}~{req.requestedChange.endTime} ({req.requestedChange.serviceSummary})
+                                        </StyledItemLine>
+                                    )}
+                                </StyledItemBody>
                                 <StyledItemActions>
                                     <StyledRejectBtn type="button" disabled={!!busyId} onClick={() => onDecide(req, 'reject')}>거절</StyledRejectBtn>
                                     <StyledApproveBtn type="button" disabled={!!busyId} onClick={() => onDecide(req, 'approve')}>수락</StyledApproveBtn>
@@ -175,6 +189,18 @@ const StyledItem = styled.div`
     gap: 4px;
     padding: 12px 14px;
     border-bottom: 1px solid var(--light-gray-color, #f1f3f5);
+`;
+
+const StyledItemBody = styled.button`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: none;
+    text-align: left;
+    cursor: pointer;
 `;
 
 const StyledItemHead = styled.div`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/plan.md
+++ b/plan.md
@@ -4,7 +4,18 @@
 
 ---
 
-## 진행 중 — 요청사항 textarea 세로 정렬 (#116)
+## 진행 중 — 온라인 예약 상세 진입·확정대기 배지·채널 표시 (#118)
+
+> 3건: (1) 예약 요청 벨 항목 클릭→상세 레이어(미래 날짜는 캘린더 미노출→벨로 접근), (2) 확정대기 배지, (3) 온라인예약이 전화예약으로 뜨는 버그.
+
+### 수정
+- `ReservationViewSection`: 예약경로 하드코딩(현장방문?:전화예약) → 실제 `reservation.channel`. requested면 "확정대기" 배지(스타일 기존 존재).
+- `BookingRequestNotification`: 항목 본문 클릭 → legacyId로 reservationMap에서 찾아 `openReservationDetail` + 패널 닫기.
+- `TimelineReservationCard`: "(신청)"→"(확정대기)".
+
+---
+
+## 완료 — 요청사항 textarea 세로 정렬 (#116)
 
 > 버그: 메모 textarea 세로 정렬 틀어짐. 원인: formControlStyle의 height:32px(input용)가 textarea에 먹음.
 


### PR DESCRIPTION
## 변경 3건

### 1) 예약 요청 벨에서 상세 레이어 진입
- 온라인 예약이 미래 날짜면 오늘 캘린더에 안 보여, 예약 요청 벨(`BookingRequestNotification`)로만 확인 가능했음.
- 벨 항목 본문 클릭 → `legacyId`로 `reservationMap`에서 예약을 찾아 **예약 상세 레이어(`openReservationDetail`)** 를 열고 패널 닫음. (상세에서 #115의 '예약확정' 버튼으로 확정 가능)

### 2) '확정대기' 상태 배지
- 예약 상세(`ReservationViewSection`)에 취소·노쇼·완료처럼 **requested → "확정대기" 배지** 추가(배지 스타일 `requested`는 기존 존재).
- 캘린더 카드 문구 `(신청)` → `(확정대기)`.

### 3) 온라인예약이 '전화예약'으로 뜨는 버그
- 예약경로 표시가 `channel === '현장방문' ? '현장방문' : '전화예약'`로 하드코딩 → 온라인예약이 전화예약으로 폴백.
- 실제 `reservation.channel` 표시로 수정(데이터/매퍼는 정상: db `online`→`온라인예약`).

## 변경 파일
- `client/components/layout/BookingRequestNotification.tsx`
- `client/components/calendar/overlays/ReservationViewSection.tsx`
- `client/components/calendar/views/TimelineReservationCard.tsx`
- `client/package.json` — 0.31.1 → 0.31.2. `plan.md`.

## 검증
- 타입체크(`tsc --noEmit`) 통과, **프로덕션 빌드 통과.** 스키마 변경 없음.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmFv2fBktnmxDdvL5m1Wpj)_