### PR TITLE
style(settings): 수정 진입 시 취소/저장 버튼 헤더 이동 + 매장관리 PC 2열 배치

### DIFF
--- a/client/components/settings/PointSettingsTab.tsx
+++ b/client/components/settings/PointSettingsTab.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import {useCalendarStore} from '../../store/calendarStore';
 import {formControlStyle} from '../ui/FormControls';
-import {StyledEditBtn, StyledSaveBtn, StyledCancelBtn} from './settings-styles';
+import {StyledEditBtn, StyledSaveBtn, StyledCancelBtn, StyledHeaderActions} from './settings-styles';
 
 type CalendarState = ReturnType<typeof useCalendarStore.getState>;
 type StoreSettings = CalendarState['storeSettings'];
@@ -28,7 +28,7 @@ export const PointSettingsTab = ({pointSettingsDraft, setPointSettingsDraft, isE
                     <StyledPolicyTitle>적립 방식</StyledPolicyTitle>
                     <StyledPolicyDesc>적립금이 쌓이는 기본 방식을 설정합니다.</StyledPolicyDesc>
                 </div>
-                {!isEditingPolicy && (
+                {!isEditingPolicy ? (
                     <StyledEditBtn
                         type="button"
                         onClick={() => {
@@ -38,6 +38,28 @@ export const PointSettingsTab = ({pointSettingsDraft, setPointSettingsDraft, isE
                     >
                         수정
                     </StyledEditBtn>
+                ) : (
+                    <StyledHeaderActions>
+                        <StyledCancelBtn
+                            type="button"
+                            onClick={() => {
+                                setPointSettingsDraft(storeSettings.pointSettings);
+                                setIsEditingPolicy(false);
+                            }}
+                        >
+                            취소
+                        </StyledCancelBtn>
+                        <StyledSaveBtn
+                            type="button"
+                            onClick={() => {
+                                updateStorePointSettings(pointSettingsDraft);
+                                setIsEditingPolicy(false);
+                            }}
+                            disabled={!isPolicyDirty}
+                        >
+                            저장
+                        </StyledSaveBtn>
+                    </StyledHeaderActions>
                 )}
             </StyledPolicyHeader>
             <StyledPolicyOptions>
@@ -94,29 +116,6 @@ export const PointSettingsTab = ({pointSettingsDraft, setPointSettingsDraft, isE
                     </StyledPolicyOption>
                 </StyledPolicyBlock>
             </StyledPolicyOptions>
-            {isEditingPolicy && (
-                <StyledPolicyActionRow>
-                    <StyledCancelBtn
-                        type="button"
-                        onClick={() => {
-                            setPointSettingsDraft(storeSettings.pointSettings);
-                            setIsEditingPolicy(false);
-                        }}
-                    >
-                        취소
-                    </StyledCancelBtn>
-                    <StyledSaveBtn
-                        type="button"
-                        onClick={() => {
-                            updateStorePointSettings(pointSettingsDraft);
-                            setIsEditingPolicy(false);
-                        }}
-                        disabled={!isPolicyDirty}
-                    >
-                        저장
-                    </StyledSaveBtn>
-                </StyledPolicyActionRow>
-            )}
         </StyledPolicyCard>
         {pointSettingsDraft.enableRecharge && (
             <StyledPolicyCard>
@@ -379,8 +378,3 @@ const StyledRechargePercent = styled.span`
     line-height: 1.4;
 `;
 
-const StyledPolicyActionRow = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-`;

--- a/client/components/settings/StoreManageSection.tsx
+++ b/client/components/settings/StoreManageSection.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 
 import styled from 'styled-components';
 
-import {EMPTY_TEXT, StyledEditBtn, StyledDeleteBtn, StyledSaveBtn, StyledCancelBtn, StyledEmpty} from './settings-styles';
+import {EMPTY_TEXT, StyledEditBtn, StyledDeleteBtn, StyledSaveBtn, StyledCancelBtn, StyledEmpty, StyledHeaderActions} from './settings-styles';
 
 import {useCalendarStore} from '../../store/calendarStore';
 import {PageHero} from '../ui/PageHero';
@@ -130,8 +130,23 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
             <StyledStoreCard>
                 <StyledStoreCardHeader>
                     <StyledStoreCardTitle>매장 정보</StyledStoreCardTitle>
-                    {!isEditingStoreInfo && (
+                    {!isEditingStoreInfo ? (
                         <StyledEditBtn type="button" onClick={() => setIsEditingStoreInfo(true)}>수정</StyledEditBtn>
+                    ) : (
+                        <StyledHeaderActions>
+                            <StyledCancelBtn
+                                type="button"
+                                onClick={() => {
+                                    setEditStoreName(storeName);
+                                    setEditShopType(getPrimaryIndustry(shopType)?.value ?? '');
+                                    setStoreInfoError('');
+                                    setIsEditingStoreInfo(false);
+                                }}
+                            >
+                                취소
+                            </StyledCancelBtn>
+                            <StyledSaveBtn type="button" onClick={handleSaveStoreInfo}>저장</StyledSaveBtn>
+                        </StyledHeaderActions>
                     )}
                 </StyledStoreCardHeader>
                 {isEditingStoreInfo ? (
@@ -169,20 +184,6 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                                 </StyledIndustrySelect>
                             </StyledRangeInputWrap>
                         </StyledStoreFieldGrid>
-                        <StyledStoreActionRow>
-                            <StyledCancelBtn
-                                type="button"
-                                onClick={() => {
-                                    setEditStoreName(storeName);
-                                    setEditShopType(getPrimaryIndustry(shopType)?.value ?? '');
-                                    setStoreInfoError('');
-                                    setIsEditingStoreInfo(false);
-                                }}
-                            >
-                                취소
-                            </StyledCancelBtn>
-                            <StyledSaveBtn type="button" onClick={handleSaveStoreInfo}>저장</StyledSaveBtn>
-                        </StyledStoreActionRow>
                     </>
                 ) : (
                     <StyledStoreInfoRow>
@@ -198,8 +199,21 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
             <StyledStoreCard>
                 <StyledStoreCardHeader>
                     <StyledStoreCardTitle>영업시간</StyledStoreCardTitle>
-                    {!isEditingBusinessHours && (
+                    {!isEditingBusinessHours ? (
                         <StyledEditBtn type="button" onClick={() => setIsEditingBusinessHours(true)}>수정</StyledEditBtn>
+                    ) : (
+                        <StyledHeaderActions>
+                            <StyledCancelBtn
+                                type="button"
+                                onClick={() => {
+                                    setBusinessHours(storeSettings.businessHours);
+                                    setIsEditingBusinessHours(false);
+                                }}
+                            >
+                                취소
+                            </StyledCancelBtn>
+                            <StyledSaveBtn type="button" onClick={handleSaveBusinessHours} disabled={!isBusinessHoursDirty}>저장</StyledSaveBtn>
+                        </StyledHeaderActions>
                     )}
                 </StyledStoreCardHeader>
                 <StyledStoreFieldGrid>
@@ -224,27 +238,26 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                         />
                     </StyledRangeInputWrap>
                 </StyledStoreFieldGrid>
-                {isEditingBusinessHours && (
-                    <StyledStoreActionRow>
-                        <StyledCancelBtn
-                            type="button"
-                            onClick={() => {
-                                setBusinessHours(storeSettings.businessHours);
-                                setIsEditingBusinessHours(false);
-                            }}
-                        >
-                            취소
-                        </StyledCancelBtn>
-                        <StyledSaveBtn type="button" onClick={handleSaveBusinessHours} disabled={!isBusinessHoursDirty}>저장</StyledSaveBtn>
-                    </StyledStoreActionRow>
-                )}
             </StyledStoreCard>
 
             <StyledStoreCard>
                 <StyledStoreCardHeader>
                     <StyledStoreCardTitle>정기 휴무</StyledStoreCardTitle>
-                    {!isEditingClosedWeekdays && (
+                    {!isEditingClosedWeekdays ? (
                         <StyledEditBtn type="button" onClick={() => setIsEditingClosedWeekdays(true)}>수정</StyledEditBtn>
+                    ) : (
+                        <StyledHeaderActions>
+                            <StyledCancelBtn
+                                type="button"
+                                onClick={() => {
+                                    setClosedWeekdays(storeSettings.closedWeekdays ?? []);
+                                    setIsEditingClosedWeekdays(false);
+                                }}
+                            >
+                                취소
+                            </StyledCancelBtn>
+                            <StyledSaveBtn type="button" onClick={handleSaveClosedWeekdays} disabled={!isClosedWeekdaysDirty}>저장</StyledSaveBtn>
+                        </StyledHeaderActions>
                     )}
                 </StyledStoreCardHeader>
                 <StyledWeekdayHint>매주 쉬는 요일을 선택하면 고객 예약 페이지에서 해당 요일은 예약할 수 없습니다.</StyledWeekdayHint>
@@ -272,27 +285,28 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                 {sortedClosedWeekdays.length === 0 && !isEditingClosedWeekdays && (
                     <StyledEmpty>정기 휴무 없음</StyledEmpty>
                 )}
-                {isEditingClosedWeekdays && (
-                    <StyledStoreActionRow>
-                        <StyledCancelBtn
-                            type="button"
-                            onClick={() => {
-                                setClosedWeekdays(storeSettings.closedWeekdays ?? []);
-                                setIsEditingClosedWeekdays(false);
-                            }}
-                        >
-                            취소
-                        </StyledCancelBtn>
-                        <StyledSaveBtn type="button" onClick={handleSaveClosedWeekdays} disabled={!isClosedWeekdaysDirty}>저장</StyledSaveBtn>
-                    </StyledStoreActionRow>
-                )}
             </StyledStoreCard>
 
             <StyledStoreCard>
                 <StyledStoreCardHeader>
                     <StyledStoreCardTitle>휴업일</StyledStoreCardTitle>
-                    {!isEditingClosedDates && (
+                    {!isEditingClosedDates ? (
                         <StyledEditBtn type="button" onClick={() => setIsEditingClosedDates(true)}>수정</StyledEditBtn>
+                    ) : (
+                        <StyledHeaderActions>
+                            <StyledCancelBtn
+                                type="button"
+                                onClick={() => {
+                                    setClosedDates(storeSettings.closedDates);
+                                    setClosedDateInput('');
+                                    setClosedDateError('');
+                                    setIsEditingClosedDates(false);
+                                }}
+                            >
+                                취소
+                            </StyledCancelBtn>
+                            <StyledSaveBtn type="button" onClick={handleSaveClosedDates} disabled={!isClosedDatesDirty}>저장</StyledSaveBtn>
+                        </StyledHeaderActions>
                     )}
                 </StyledStoreCardHeader>
                 {isEditingClosedDates && (
@@ -330,22 +344,6 @@ export const StoreManageSection = ({formatDateLabel}: StoreManageSectionProps) =
                             </StyledClosedDateItem>
                         ))}
                     </StyledClosedDateList>
-                )}
-                {isEditingClosedDates && (
-                    <StyledStoreActionRow>
-                        <StyledCancelBtn
-                            type="button"
-                            onClick={() => {
-                                setClosedDates(storeSettings.closedDates);
-                                setClosedDateInput('');
-                                setClosedDateError('');
-                                setIsEditingClosedDates(false);
-                            }}
-                        >
-                            취소
-                        </StyledCancelBtn>
-                        <StyledSaveBtn type="button" onClick={handleSaveClosedDates} disabled={!isClosedDatesDirty}>저장</StyledSaveBtn>
-                    </StyledStoreActionRow>
                 )}
             </StyledStoreCard>
 
@@ -438,8 +436,8 @@ const StyledStoreSection = styled.div`
     grid-template-columns: 1fr 1fr;
     gap: 12px;
 
-    > :first-child,
-    > :nth-child(2) { grid-column: 1 / -1; }
+    /* PC: PageHero만 전체 폭. 매장정보+영업시간 / 정기휴무+휴업일이 각각 한 줄 2열로 나란히. */
+    > :first-child { grid-column: 1 / -1; }
 
     @media (max-width: 640px) {
         grid-template-columns: 1fr;
@@ -556,12 +554,6 @@ const StyledStoreFieldGrid = styled.div`
     @media (max-width: 640px) {
         grid-template-columns: 1fr;
     }
-`;
-
-const StyledStoreActionRow = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
 `;
 
 const StyledClosedDateAddRow = styled.div`

--- a/client/components/settings/settings-styles.ts
+++ b/client/components/settings/settings-styles.ts
@@ -79,6 +79,17 @@ export const StyledSelect = styled.select`
     }
 `;
 
+// 카드 헤더(제목 옆) 우측에 취소/저장 버튼을 나란히 놓는 래퍼.
+// 헤더 안에서는 모바일 stretch(flex:1)를 끄고 내용 크기 유지.
+export const StyledHeaderActions = styled.div`
+    display: flex;
+    gap: 6px;
+
+    & > button {
+        flex: 0 0 auto;
+    }
+`;
+
 export const StyledSettingsCard = styled.div`
     border: 1px solid var(--light-gray-color);
     border-radius: var(--radius-lg);

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 개요
설정 화면에서 "수정" 진입 시 카드 하단에 뜨던 **취소/저장 버튼을 헤더 우측(수정 버튼과 동일한 위치)으로 이동**하고, PC에서 매장관리 카드 배치를 2열로 정리했습니다.

## 주요 변경사항

### 취소/저장 버튼 위치 이동 (수정 자리로)
- **매장 관리 4개 카드**(매장정보·영업시간·정기휴무·휴업일): 수정 클릭 시 헤더 우측에 취소/저장 노출, 기존 하단 액션 행(`StyledStoreActionRow`) 제거.
- **적립금 관리 '적립 방식' 카드**: 동일하게 헤더로 이동, 하단 `StyledPolicyActionRow` 제거.
- 전 앱에서 이 "헤더 수정 → 하단 취소/저장" 패턴을 쓰는 곳을 전수 조사한 결과 위 5개 카드뿐이었고, 나머지(회원권·쿠폰 상품 폼, 담당자·서비스·닉네임 인라인 편집, 고객상세 모달 등)는 이미 모달·인라인 형태라 대상에서 제외.

### 공용 스타일
- `settings-styles.ts`에 `StyledHeaderActions` 추가 — 헤더 안에서 취소/저장을 나란히 배치하고 모바일 stretch(flex:1)를 무효화. 두 화면이 공유.

### 매장관리 PC 레이아웃
- 그리드 전체 폭 규칙을 PageHero만 적용하도록 조정 → PC에서 **매장정보+영업시간**이 한 줄, **정기휴무+휴업일**이 한 줄(각 2열). 모바일은 기존대로 1열.

## 검증
- 타입체크 통과.
- 로컬에서 실제 앱을 PC 폭(1280px)으로 구동해 오너 로그인 후 확인: DOM 좌표로 2열 배치(매장정보·영업시간 동일 top / 정기휴무·휴업일 동일 top) 확인, 4개 카드 + 적립 방식 카드 모두 수정 진입 시 헤더에 취소·저장 노출 확인(스크린샷).

## 관련
후속 UI 개선 (정기 휴무 기능 PR #132 머지 이후).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7MzNmY8ipAGMXCoGkg3NS

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7MzNmY8ipAGMXCoGkg3NS)_