### PR TITLE
refactor(settings): 왼쪽 메뉴 '매장 관리'를 매출 아래로 이동

### DIFF
--- a/client/components/layout/Aside.tsx
+++ b/client/components/layout/Aside.tsx
@@ -49,11 +49,11 @@ import {
 
 const SETTINGS_SUBMENU = [
     {tab: 'revenue', href: '/settings/revenue', label: '매출', icon: 'revenue'},
+    {tab: 'store', href: '/settings/store', label: '매장 관리', icon: 'store'},
     {tab: 'point', href: '/settings/point', label: '적립금 관리', icon: 'point'},
     {tab: 'membership', href: '/settings/membership', label: '회원권 관리', icon: 'membership'},
     {tab: 'coupon', href: '/settings/coupon', label: '쿠폰 관리', icon: 'coupon'},
     {tab: 'booking', href: '/settings/booking', label: '고객 예약 설정', icon: 'booking'},
-    {tab: 'store', href: '/settings/store', label: '매장 관리', icon: 'store'},
     {tab: 'service', href: '/settings/service', label: '서비스 관리', icon: 'service'},
     {tab: 'assignee', href: '/settings/assignee', label: '담당자 관리', icon: 'assignee'},
     {tab: 'customers', href: '/address', label: '고객 명단', icon: 'customers'},

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 요약
설정 왼쪽 메뉴에서 **매장 관리**를 매출 바로 아래(적립금·회원권·쿠폰·고객 예약 설정보다 위)로 이동.

## 변경
- `Aside` SETTINGS_SUBMENU 순서: 매출 → **매장 관리** → 적립금 → 회원권 → 쿠폰 → 고객 예약 설정 → 서비스 관리 → 담당자 관리 → …
- `client/package.json` → 0.35.1 (patch).

## 검증
- 타입체크 0 · 빌드 성공. (메뉴 배열 순서만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyHseLxmcfg2BKCLsvcGFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyHseLxmcfg2BKCLsvcGFJ)_