### PR TITLE
fix(booking): 알림 벨 예약 요청 클릭 시 상세 레이어 안 뜨던 문제

### DIFF
--- a/client/components/layout/BookingRequestNotification.tsx
+++ b/client/components/layout/BookingRequestNotification.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import {useBookingRequests, type BookingRequestDto} from '../../hooks/useBookingRequests';
 import {LabelBadge} from '../ui/LabelBadge';
 import {useCalendarStore} from '../../store/calendarStore';
+import {groupByDate, type ReservationMap} from '../../utils/reservations';
 
 function formatMd(dateStr: string): string {
     if (!dateStr || !dateStr.includes('-')) return dateStr || '-';
@@ -17,19 +18,36 @@ export const BookingRequestNotification = () => {
     const {requests, loading, refetch, decide} = useBookingRequests();
     const openReservationDetail = useCalendarStore((s) => s.openReservationDetail);
     const reservationMap = useCalendarStore((s) => s.reservationMap);
+    const setReservationMap = useCalendarStore((s) => s.setReservationMap);
+    const setReservationHistory = useCalendarStore((s) => s.setReservationHistory);
     const useOnlineBooking = useCalendarStore((s) => s.useOnlineBooking);
     const [open, setOpen] = useState(false);
     const [busyId, setBusyId] = useState<string>('');
     const containerRef = useRef<HTMLDivElement>(null);
 
     // 벨 항목 클릭 → legacyId로 예약을 찾아 상세 레이어를 연다(미래 날짜 예약도 상세 접근 가능).
-    const openDetail = useCallback((req: BookingRequestDto) => {
+    // reservationMap이 오래돼(페이지 로드 후 들어온 신규 예약이 맵에 없을 수 있음) 못 찾으면
+    // 예약을 다시 불러와 재시도한다. (예전엔 못 찾으면 조용히 실패 → 상세가 안 떴다)
+    const openDetail = useCallback(async (req: BookingRequestDto) => {
         if (req.legacyId == null) return;
-        for (const list of Object.values(reservationMap)) {
-            const found = list.find((r) => r.id === req.legacyId);
-            if (found) { openReservationDetail(found); setOpen(false); return; }
-        }
-    }, [reservationMap, openReservationDetail]);
+        const findAndOpen = (map: ReservationMap): boolean => {
+            for (const list of Object.values(map)) {
+                const found = list.find((r) => r.id === req.legacyId);
+                if (found) { openReservationDetail(found); setOpen(false); return true; }
+            }
+            return false;
+        };
+        if (findAndOpen(reservationMap)) return;
+        try {
+            const res = await fetch('/api/reservations');
+            if (!res.ok) return;
+            const data = await res.json();
+            const nextMap = groupByDate(Array.isArray(data.reservations) ? data.reservations : []);
+            setReservationMap(nextMap); // 전역 상세 오버레이도 이 맵에서 조회하므로 먼저 갱신
+            if (Array.isArray(data.history)) setReservationHistory(data.history);
+            findAndOpen(nextMap);
+        } catch { /* 네트워크 실패 무시 */ }
+    }, [reservationMap, openReservationDetail, setReservationMap, setReservationHistory]);
 
     useEffect(() => {
         if (!open) return;

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 요약
헤더 알림 벨 → 예약 신청/변경/취소 요청 항목을 눌러도 **예약 상세 레이어가 안 뜨던 버그** 수정.

## 원인
`BookingRequestNotification.openDetail`이 `reservationMap`에서 `legacyId`로 예약을 찾는데, **못 찾으면 아무것도 안 하고 조용히 리턴**했습니다. 페이지 로드 후 새로 들어온 예약은 `reservationMap`(로드 시점 스냅샷)에 없어, 벨엔 보여도 상세가 안 열렸습니다. 전역 상세 오버레이도 같은 맵에서 조회하므로 이중으로 막혔습니다.

## 수정
- 맵에서 못 찾으면 **`/api/reservations`를 다시 불러와 맵을 갱신한 뒤 재시도**하도록 변경(전역 오버레이 조회 대상도 함께 갱신).
- 서버에 존재하는 예약이면 항상 상세가 열립니다.

- `client/package.json` → 0.35.2 (patch).

## 검증
- 타입체크 0 · 빌드 성공.
- ⚠️ 인증+실시간 온라인 예약 상태가 필요해 로컬 재현이 어려워, 로직/타입/빌드로 검증했습니다. 배포 후 실계정에서 "새 예약 신청 → 벨 클릭 → 상세" 흐름 한 번 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyHseLxmcfg2BKCLsvcGFJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyHseLxmcfg2BKCLsvcGFJ)_