### PR TITLE
fix(booking): 알림 벨 콜드 로드 시 비던 문제 + 클릭 시 상세 레이어

### DIFF
--- a/client/components/layout/BookingRequestNotification.tsx
+++ b/client/components/layout/BookingRequestNotification.tsx
@@ -5,7 +5,8 @@ import styled from 'styled-components';
 import {useBookingRequests, type BookingRequestDto} from '../../hooks/useBookingRequests';
 import {LabelBadge} from '../ui/LabelBadge';
 import {useCalendarStore} from '../../store/calendarStore';
-import {groupByDate, type ReservationMap} from '../../utils/reservations';
+import {groupByDate, type Reservation, type ReservationMap} from '../../utils/reservations';
+import {ReservationDetail} from '../calendar/overlays/ReservationDetail';
 
 function formatMd(dateStr: string): string {
     if (!dateStr || !dateStr.includes('-')) return dateStr || '-';
@@ -16,38 +17,52 @@ function formatMd(dateStr: string): string {
 // 오너용 온라인 예약 변경/취소 요청 승인 벨. 대기 요청이 있을 때만 노출된다.
 export const BookingRequestNotification = () => {
     const {requests, loading, refetch, decide} = useBookingRequests();
-    const openReservationDetail = useCalendarStore((s) => s.openReservationDetail);
     const reservationMap = useCalendarStore((s) => s.reservationMap);
     const setReservationMap = useCalendarStore((s) => s.setReservationMap);
+    const customerMap = useCalendarStore((s) => s.customerMap);
+    const reservationHistory = useCalendarStore((s) => s.reservationHistory);
     const setReservationHistory = useCalendarStore((s) => s.setReservationHistory);
+    const openCustomerDetail = useCalendarStore((s) => s.openCustomerDetail);
+    const updateReservation = useCalendarStore((s) => s.updateReservation);
+    const cancelReservation = useCalendarStore((s) => s.cancelReservation);
+    const restoreReservation = useCalendarStore((s) => s.restoreReservation);
+    const deleteReservation = useCalendarStore((s) => s.deleteReservation);
     const useOnlineBooking = useCalendarStore((s) => s.useOnlineBooking);
     const [open, setOpen] = useState(false);
     const [busyId, setBusyId] = useState<string>('');
+    // 벨이 직접 여는 상세 대상(예약 객체). 페이지의 오버레이 렌더러에 의존하지 않고
+    // 벨 자신이 ReservationDetail을 렌더한다 — 어느 페이지(달력·고객명단 등)에서든 동일하게 열린다.
+    const [detailReservation, setDetailReservation] = useState<Reservation | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
     // 벨 항목 클릭 → legacyId로 예약을 찾아 상세 레이어를 연다(미래 날짜 예약도 상세 접근 가능).
-    // reservationMap이 오래돼(페이지 로드 후 들어온 신규 예약이 맵에 없을 수 있음) 못 찾으면
-    // 예약을 다시 불러와 재시도한다. (예전엔 못 찾으면 조용히 실패 → 상세가 안 떴다)
+    // 예전엔 전역 스토어(openReservationDetail)로 열어 "그 페이지가 오버레이를 렌더하는지"에 의존했다.
+    // 달력(id→reservationMap 조회) 등 일부 페이지에선 대기 예약이 맵에 없어 안 떴다.
+    // 이제 벨이 예약 객체를 직접 들고 상세를 렌더하므로 페이지·맵 상태와 무관하게 열린다.
+    const findInMap = (map: ReservationMap, legacyId: number): Reservation | null => {
+        for (const list of Object.values(map)) {
+            const found = list.find((r) => r.id === legacyId);
+            if (found) return found;
+        }
+        return null;
+    };
     const openDetail = useCallback(async (req: BookingRequestDto) => {
         if (req.legacyId == null) return;
-        const findAndOpen = (map: ReservationMap): boolean => {
-            for (const list of Object.values(map)) {
-                const found = list.find((r) => r.id === req.legacyId);
-                if (found) { openReservationDetail(found); setOpen(false); return true; }
-            }
-            return false;
-        };
-        if (findAndOpen(reservationMap)) return;
+        const inMap = findInMap(reservationMap, req.legacyId);
+        if (inMap) { setDetailReservation(inMap); setOpen(false); return; }
+        // 맵에 없으면(페이지 로드 후 들어온 신규 예약) 다시 불러와 찾는다.
         try {
             const res = await fetch('/api/reservations');
             if (!res.ok) return;
             const data = await res.json();
-            const nextMap = groupByDate(Array.isArray(data.reservations) ? data.reservations : []);
-            setReservationMap(nextMap); // 전역 상세 오버레이도 이 맵에서 조회하므로 먼저 갱신
+            const list: Reservation[] = Array.isArray(data.reservations) ? data.reservations : [];
+            const nextMap = groupByDate(list);
+            setReservationMap(nextMap); // 앱 전역 상태도 최신으로 맞춰둔다.
             if (Array.isArray(data.history)) setReservationHistory(data.history);
-            findAndOpen(nextMap);
+            const found = list.find((r) => r.id === req.legacyId) ?? null;
+            if (found) { setDetailReservation(found); setOpen(false); }
         } catch { /* 네트워크 실패 무시 */ }
-    }, [reservationMap, openReservationDetail, setReservationMap, setReservationHistory]);
+    }, [reservationMap, setReservationMap, setReservationHistory]);
 
     useEffect(() => {
         if (!open) return;
@@ -80,6 +95,7 @@ export const BookingRequestNotification = () => {
     const count = requests.length;
 
     return (
+        <>
         <StyledContainer ref={containerRef}>
             <StyledBellButton type="button" onClick={() => setOpen((v) => !v)}
                               aria-label={count > 0 ? `예약 요청 ${count}건` : '예약 요청'}>
@@ -127,6 +143,24 @@ export const BookingRequestNotification = () => {
                 </StyledPanel>
             )}
         </StyledContainer>
+
+        {/* 벨이 직접 여는 상세 오버레이. ReservationDetail은 createPortal로 body에 렌더돼
+            어느 페이지에서든 동일하게 뜬다(페이지별 오버레이 렌더러 의존 제거). */}
+        {detailReservation && (
+            <ReservationDetail
+                reservation={detailReservation}
+                customerMap={customerMap}
+                reservationMap={reservationMap}
+                history={reservationHistory}
+                onClose={() => setDetailReservation(null)}
+                onCustomerClick={openCustomerDetail}
+                onUpdate={(prev, updated) => { updateReservation(prev, updated); setDetailReservation(updated); }}
+                onCancel={(target, status) => { cancelReservation(target, status); setDetailReservation(null); }}
+                onRestore={restoreReservation}
+                onDelete={(target) => { deleteReservation(target); setDetailReservation(null); }}
+            />
+        )}
+        </>
     );
 };
 

--- a/client/hooks/useBookingRequests.ts
+++ b/client/hooks/useBookingRequests.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 
-import {shouldUseLocalDb} from '../lib/local-db';
+import {useSession} from 'next-auth/react';
 
 // 고객이 보낸 온라인 예약 변경/취소 요청(오너 승인 대기)을 불러오고 수락/거절한다.
 export interface BookingRequestDto {
@@ -17,19 +17,27 @@ export interface BookingRequestDto {
 export function useBookingRequests() {
     const [requests, setRequests] = useState<BookingRequestDto[]>([]);
     const [loading, setLoading] = useState(false);
+    const {data: session, status} = useSession();
+
+    // 인증이 확정된(역할·매장 보유) 오너만 호출한다. 예전엔 sessionStorage 플래그(shouldUseLocalDb)로
+    // 게이트했는데, 그 플래그는 부모(_app) 이펙트에서 설정돼 벨(자식) 마운트 이펙트보다 늦게 켜진다.
+    // 그래서 콜드 로드 땐 플래그 미설정 창에서 호출이 취소되고 재조회도 안 돼 벨이 늘 비어 보였다.
+    // 세션 상태에 반응하도록 바꿔, 인증 확정 시 refetch 신원이 바뀌며 자동 재조회된다.
+    const authed = status === 'authenticated' && !!session?.user?.role && !!session.user?.storeId;
 
     const refetch = useCallback(() => {
-        // 게스트/로컬DB 모드(비로그인)에선 서버 세션이 없어 401만 나므로 호출하지 않는다.
-        if (shouldUseLocalDb()) { setRequests([]); return; }
+        // 게스트/미인증에선 서버 세션이 없어 401만 나므로 호출하지 않는다.
+        if (!authed) { setRequests([]); return; }
         setLoading(true);
         fetch('/api/book-requests')
             .then((res) => (res.ok ? res.json() : Promise.reject(new Error('load failed'))))
             .then((data) => setRequests(Array.isArray(data.requests) ? data.requests : []))
             .catch(() => setRequests([]))
             .finally(() => setLoading(false));
-    }, []);
+    }, [authed]);
 
-    // 마운트 시 최초 로드. refetch가 로딩 플래그를 세우는 표준 fetch-in-effect 패턴이라 규칙 로컬 예외.
+    // 마운트 시 + 인증 상태 변화 시 로드(refetch가 authed에 의존 → 인증 확정되면 재실행).
+    // refetch가 로딩 플래그를 세우는 표준 fetch-in-effect 패턴이라 규칙 로컬 예외.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     useEffect(() => { refetch(); }, [refetch]);
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 문제 (오너 리포트)
"고객 예약 페이지로 들어온 예약이 달력에서 **없는 걸로 뜬다**. 고객명단 갔다가 달력으로 돌아오면 뜨는데, 달력에서 **강력 새로고침하면 사라진다**."

## 원인 (로컬 재현으로 확정) — 2가지
1. **알림 벨이 콜드 로드 직후 비어 있음 (인증 타이밍 경쟁).** `useBookingRequests`는 마운트 시 한 번만 조회하는데, 이 호출이 `sessionStorage` 인증 플래그로 게이트된다. 그 플래그는 부모(`_app`) 이펙트에서 켜지고 벨(자식) 마운트 이펙트는 그보다 **먼저** 실행된다 → 플래그 미설정 창에서 최초 조회가 취소되고 **재조회가 없어** 벨이 늘 비어 보인다. 페이지 전환 시 재마운트되며 (그땐 플래그 설정됨) 채워진다 → "새로고침하면 없어지고, 갔다 오면 뜨는" 증상.
2. **벨에서 클릭해도 상세 레이어가 (달력에서) 안 열림.** 벨이 전역 스토어(`openReservationDetail`)로 열어, "그 페이지가 오버레이를 렌더하는지"에 의존했다. 달력은 그 경로로 안 떴다.

## 수정
1. `useBookingRequests`가 `sessionStorage` 플래그 대신 **세션 상태(`useSession`)에 반응**하게 변경 → 인증 확정 시 자동 재조회. 콜드 로드 직후에도 벨이 채워진다.
2. 벨이 **예약 객체를 직접 들고 `ReservationDetail`을 스스로 렌더**(createPortal → body) → 페이지·맵 상태와 무관하게, 일반 예약 상세처럼 열린다. (날짜 이동 없음.)
- `client/package.json` → 0.36.1 (patch).

## 검증 (로컬 재현, 실제 클릭)
오너 세션 + 미래 날짜 온라인('requested') 예약 시드 → 표준 빌드 구동 → 헤드리스 브라우저.
- **진짜 콜드 하드로드(인증 shim 없음)**: 네비게이션 없이 벨이 자동으로 채워짐(뱃지 "2", 부팅 중 `/api/book-requests` 실제 발생). ✅
- 벨 패널에 대기 요청 2건(미래 8/15 포함) 표시. ✅
- 미래 요청 클릭 → 상세 레이어(확정대기·날짜·시술·고객·예약확정/거절) **정상 오픈**, 달력 날짜 이동 없음. ✅
- 앱 콘솔 에러 없음. 빌드·타입체크·린트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyHseLxmcfg2BKCLsvcGFJ