### PR TITLE
온라인 예약 승인/거절/취소 UX 개선 및 사유 저장

### DIFF
--- a/client/components/calendar/overlays/ReservationDetail.tsx
+++ b/client/components/calendar/overlays/ReservationDetail.tsx
@@ -463,7 +463,7 @@ export const ReservationDetail = ({
 
         if (mode === 'confirming' || mode === 'pastConfirm') {
             setMode('editing');
-        } else if (mode === 'editing' || mode === 'cancelling' || mode === 'noshow' || mode === 'payment') {
+        } else if (mode === 'editing' || mode === 'cancelling' || mode === 'noshow' || mode === 'payment' || mode === 'rejecting') {
             handleCancel();
         } else {
             onClose();
@@ -480,7 +480,6 @@ export const ReservationDetail = ({
     // 예약확정/거절 → 오너 승인 API(book-requests) 재사용. legacyId로 대상 지정.
     // 성공 시 새로고침으로 캘린더·요청벨을 갱신(오너 벨과 동일 패턴).
     const decideBooking = (decision: 'approve' | 'reject') => {
-        if (decision === 'reject' && !window.confirm('이 예약 신청을 거절할까요? 거절하면 취소됩니다.')) return;
         fetch('/api/book-requests', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
@@ -678,6 +677,19 @@ export const ReservationDetail = ({
                 />
             )}
 
+            {mode === 'rejecting' && (
+                <ReservationStaticDiffSection
+                    message="이 예약 신청을 거절하시겠습니까? 거절하면 취소됩니다."
+                    color="var(--danger-color)"
+                    items={[
+                        {label: labels.service, value: reservation.service},
+                        {label: '날짜', value: reservation.date},
+                        {label: '시간', value: `${reservation.startTime} ~ ${reservation.endTime}`},
+                        {label: '고객명', value: customer?.name ?? '-'},
+                    ]}
+                />
+            )}
+
             <ReservationFooter
                 actions={(
                     <ReservationDetailFooterActions
@@ -688,7 +700,8 @@ export const ReservationDetail = ({
                         paymentCompleted={paymentCompleted}
                         isNaverBooking={isNaverBooking}
                         onConfirmBooking={() => decideBooking('approve')}
-                        onRejectBooking={() => decideBooking('reject')}
+                        onRejectBooking={() => setMode('rejecting')}
+                        onRejectReservation={() => decideBooking('reject')}
                         onOpenCompleting={() => {
                             if (!hasCompletedPayment(sourceReservation)) {
                                 setError({field: 'general', message: '결제 완료된 예약만 완료 처리할 수 있습니다.'});

--- a/client/components/calendar/overlays/ReservationDetail.tsx
+++ b/client/components/calendar/overlays/ReservationDetail.tsx
@@ -7,7 +7,7 @@ import {useCalendarStore} from '../../../store/calendarStore';
 import {useStoreLabels} from '../../../hooks/useStoreLabels';
 
 import type {PaymentEntry, PaymentMethod, Reservation, ReservationHistoryEntry, ReservationMap, ReservationStatus} from '../../../utils/reservations';
-import {findOverlap, hasCompletedPayment} from '../../../utils/reservations';
+import {findOverlap, hasCompletedPayment, isOnlineReservation} from '../../../utils/reservations';
 import {isNewCustomerVisit} from '../../../utils/customers';
 import type {CustomerMap} from '../../../utils/customers';
 import {buildAssigneeNameMap, getAssigneeAvailabilityState, getAssigneeColor, splitAssigneesByStatus} from '../../../utils/assignees';
@@ -493,7 +493,7 @@ export const ReservationDetail = ({
     };
     const isNaverBooking = Boolean(sourceReservation.naverBookingId);
     // 온라인 예약(고객 예약 페이지 경유)만 사유가 고객 조회 페이지에 노출된다.
-    const isOnlineBooking = sourceReservation.channel === '온라인예약';
+    const isOnlineBooking = isOnlineReservation(sourceReservation);
     // 승인/거절/취소 확인 레이어의 사유 입력(선택). 미입력 시 고객 페이지가 기본문구로 대체.
     const decisionReasonInput = {
         label: '사유 (선택)',

--- a/client/components/calendar/overlays/ReservationDetail.tsx
+++ b/client/components/calendar/overlays/ReservationDetail.tsx
@@ -82,7 +82,7 @@ interface ReservationDetailProps {
     onClose: () => void;
     onCustomerClick: (customerId: number) => void;
     onUpdate: (prev: Reservation, updated: Reservation) => void;
-    onCancel: (reservation: Reservation, status?: ReservationStatus) => void;
+    onCancel: (reservation: Reservation, status?: ReservationStatus, reason?: string) => void;
     onRestore: (reservation: Reservation) => void;
     onDelete?: (reservation: Reservation) => void;
 }
@@ -151,6 +151,8 @@ export const ReservationDetail = ({
     }, undefined);
 
     const [mode, setMode] = useState<ReservationDetailMode>('view');
+    // 온라인 예약 승인/거절/취소 사유(선택). 확인 레이어를 열 때 초기화한다.
+    const [decisionReason, setDecisionReason] = useState('');
     const [isHistoryOpen, setIsHistoryOpen] = useState(false);
     const [isRestoringOpen, setIsRestoringOpen] = useState(false);
     const initialForm = buildReservationFormState(sourceReservation);
@@ -463,7 +465,7 @@ export const ReservationDetail = ({
 
         if (mode === 'confirming' || mode === 'pastConfirm') {
             setMode('editing');
-        } else if (mode === 'editing' || mode === 'cancelling' || mode === 'noshow' || mode === 'payment' || mode === 'rejecting') {
+        } else if (mode === 'editing' || mode === 'cancelling' || mode === 'noshow' || mode === 'payment' || mode === 'approving' || mode === 'rejecting') {
             handleCancel();
         } else {
             onClose();
@@ -480,15 +482,27 @@ export const ReservationDetail = ({
     // 예약확정/거절 → 오너 승인 API(book-requests) 재사용. legacyId로 대상 지정.
     // 성공 시 새로고침으로 캘린더·요청벨을 갱신(오너 벨과 동일 패턴).
     const decideBooking = (decision: 'approve' | 'reject') => {
+        const reason = decisionReason.trim();
         fetch('/api/book-requests', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({legacyId: sourceReservation.id, decision}),
+            body: JSON.stringify({legacyId: sourceReservation.id, decision, ...(reason ? {reason} : {})}),
         })
             .then((res) => { if (res.ok) window.location.reload(); else setError({field: 'general', message: '처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'}); })
             .catch(() => setError({field: 'general', message: '처리에 실패했습니다. 잠시 후 다시 시도해 주세요.'}));
     };
     const isNaverBooking = Boolean(sourceReservation.naverBookingId);
+    // 온라인 예약(고객 예약 페이지 경유)만 사유가 고객 조회 페이지에 노출된다.
+    const isOnlineBooking = sourceReservation.channel === '온라인예약';
+    // 승인/거절/취소 확인 레이어의 사유 입력(선택). 미입력 시 고객 페이지가 기본문구로 대체.
+    const decisionReasonInput = {
+        label: '사유 (선택)',
+        placeholder: '고객 조회 페이지에 표시됩니다. 미입력 시 기본 안내로 대체됩니다.',
+        value: decisionReason,
+        onChange: setDecisionReason,
+    };
+    // 확인 레이어를 열 때 사유를 초기화한다.
+    const openWithReason = (next: ReservationDetailMode) => { setDecisionReason(''); setMode(next); };
     const dialogLabel = MODE_LABELS[mode] ?? '예약 상세';
     const headerService = mode === 'view' ? draftReservation.service : form.service;
     const dialogTitle = mode === 'editing'
@@ -587,6 +601,7 @@ export const ReservationDetail = ({
                         {label: '시간', value: `${reservation.startTime} ~ ${reservation.endTime}`},
                         {label: '고객명', value: customer?.name ?? '-'},
                     ]}
+                    reason={isOnlineBooking ? decisionReasonInput : undefined}
                 />
             )}
 
@@ -677,6 +692,20 @@ export const ReservationDetail = ({
                 />
             )}
 
+            {mode === 'approving' && (
+                <ReservationStaticDiffSection
+                    message="이 예약 신청을 확정할까요?"
+                    color="var(--blue-color)"
+                    items={[
+                        {label: labels.service, value: reservation.service},
+                        {label: '날짜', value: reservation.date},
+                        {label: '시간', value: `${reservation.startTime} ~ ${reservation.endTime}`},
+                        {label: '고객명', value: customer?.name ?? '-'},
+                    ]}
+                    reason={decisionReasonInput}
+                />
+            )}
+
             {mode === 'rejecting' && (
                 <ReservationStaticDiffSection
                     message="이 예약 신청을 거절하시겠습니까? 거절하면 취소됩니다."
@@ -687,6 +716,7 @@ export const ReservationDetail = ({
                         {label: '시간', value: `${reservation.startTime} ~ ${reservation.endTime}`},
                         {label: '고객명', value: customer?.name ?? '-'},
                     ]}
+                    reason={decisionReasonInput}
                 />
             )}
 
@@ -699,8 +729,9 @@ export const ReservationDetail = ({
                         isCompleted={isCompleted}
                         paymentCompleted={paymentCompleted}
                         isNaverBooking={isNaverBooking}
-                        onConfirmBooking={() => decideBooking('approve')}
-                        onRejectBooking={() => setMode('rejecting')}
+                        onConfirmBooking={() => openWithReason('approving')}
+                        onApproveReservation={() => decideBooking('approve')}
+                        onRejectBooking={() => openWithReason('rejecting')}
                         onRejectReservation={() => decideBooking('reject')}
                         onOpenCompleting={() => {
                             if (!hasCompletedPayment(sourceReservation)) {
@@ -710,7 +741,7 @@ export const ReservationDetail = ({
                             setError(null);
                             setMode('completing');
                         }}
-                        onOpenCancelling={() => setMode('cancelling')}
+                        onOpenCancelling={() => openWithReason('cancelling')}
                         onOpenNoshow={() => setMode('noshow')}
                         onOpenPayment={() => {
                             setPaymentEntries(getPaymentEntryDrafts(sourceReservation, displayPrice, sourceReservation.naverDeposit ?? 0));
@@ -726,7 +757,7 @@ export const ReservationDetail = ({
                         onCancelEdit={handleCancel}
                         onConfirmRequest={handleConfirmRequest}
                         onConfirmSave={handleConfirmSave}
-                        onCancelReservation={() => onCancel(sourceReservation)}
+                        onCancelReservation={() => onCancel(sourceReservation, 'cancelled', isOnlineBooking ? (decisionReason.trim() || undefined) : undefined)}
                         onNoshowReservation={() => onCancel(sourceReservation, 'noshow')}
                         onOpenRestoring={() => setIsRestoringOpen(true)}
                         onRestoreReservation={() => onRestore(sourceReservation)}

--- a/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
+++ b/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
@@ -12,6 +12,7 @@ type ReservationDetailFooterActionsProps = {
     isNaverBooking: boolean;
     canDelete: boolean;
     onConfirmBooking: () => void;
+    onApproveReservation: () => void;
     onRejectBooking: () => void;
     onRejectReservation: () => void;
     onOpenCompleting: () => void;
@@ -42,6 +43,7 @@ export function ReservationDetailFooterActions({
                                                    isNaverBooking,
                                                    canDelete,
                                                    onConfirmBooking,
+                                                   onApproveReservation,
                                                    onRejectBooking,
                                                    onRejectReservation,
                                                    onOpenCompleting,
@@ -193,6 +195,18 @@ export function ReservationDetailFooterActions({
                 <StyledActionButton type="button"
                                     $primary
                                     onClick={onNoshowReservation}>확인</StyledActionButton>
+            </>
+        );
+    }
+
+    if (mode === 'approving') {
+        return (
+            <>
+                <StyledActionButton type="button"
+                                    onClick={onBackToView}>취소</StyledActionButton>
+                <StyledActionButton type="button"
+                                    $primary
+                                    onClick={onApproveReservation}>예약확정</StyledActionButton>
             </>
         );
     }

--- a/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
+++ b/client/components/calendar/overlays/ReservationDetailFooterActions.tsx
@@ -13,6 +13,7 @@ type ReservationDetailFooterActionsProps = {
     canDelete: boolean;
     onConfirmBooking: () => void;
     onRejectBooking: () => void;
+    onRejectReservation: () => void;
     onOpenCompleting: () => void;
     onOpenCancelling: () => void;
     onOpenNoshow: () => void;
@@ -42,6 +43,7 @@ export function ReservationDetailFooterActions({
                                                    canDelete,
                                                    onConfirmBooking,
                                                    onRejectBooking,
+                                                   onRejectReservation,
                                                    onOpenCompleting,
                                                    onOpenCancelling,
                                                    onOpenNoshow,
@@ -191,6 +193,18 @@ export function ReservationDetailFooterActions({
                 <StyledActionButton type="button"
                                     $primary
                                     onClick={onNoshowReservation}>확인</StyledActionButton>
+            </>
+        );
+    }
+
+    if (mode === 'rejecting') {
+        return (
+            <>
+                <StyledActionButton type="button"
+                                    onClick={onBackToView}>취소</StyledActionButton>
+                <StyledActionButton type="button"
+                                    $danger
+                                    onClick={onRejectReservation}>거절</StyledActionButton>
             </>
         );
     }

--- a/client/components/calendar/overlays/ReservationDetailSections.tsx
+++ b/client/components/calendar/overlays/ReservationDetailSections.tsx
@@ -313,13 +313,22 @@ export const ReservationDiffSection = ({message, color, diffs}: ReservationDiffS
     </StyledBodyInner></StyledBody>
 );
 
+interface ReservationReasonInput {
+    label: string;
+    placeholder: string;
+    value: string;
+    onChange: (value: string) => void;
+}
+
 interface ReservationStaticDiffSectionProps {
     message: string;
     color: string;
     items: Array<{label: string; value: string}>;
+    // 온라인 예약 승인/거절/취소 사유(선택). 있으면 항목 아래 입력칸을 노출한다.
+    reason?: ReservationReasonInput;
 }
 
-export const ReservationStaticDiffSection = ({message, color, items}: ReservationStaticDiffSectionProps) => (
+export const ReservationStaticDiffSection = ({message, color, items, reason}: ReservationStaticDiffSectionProps) => (
     <StyledBody><StyledBodyInner>
         <StyledModalMessage $color={color}>{message}</StyledModalMessage>
         <StyledDiffList>
@@ -330,6 +339,18 @@ export const ReservationStaticDiffSection = ({message, color, items}: Reservatio
                 </StyledDiffGrid>
             ))}
         </StyledDiffList>
+        {reason && (
+            <StyledReasonLabel>
+                <span>{reason.label}</span>
+                <StyledReasonTextarea
+                    rows={2}
+                    maxLength={300}
+                    value={reason.value}
+                    placeholder={reason.placeholder}
+                    onChange={(e) => reason.onChange(e.target.value)}
+                />
+            </StyledReasonLabel>
+        )}
     </StyledBodyInner></StyledBody>
 );
 
@@ -349,6 +370,29 @@ const StyledDiffList = styled.div`
     padding: 12px;
     background-color: var(--black-color-10);
     border-radius: var(--radius-md);
+`;
+
+const StyledReasonLabel = styled.label`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
+`;
+
+const StyledReasonTextarea = styled.textarea`
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+    color: var(--black-color);
+    &:focus { outline: none; border-color: var(--brand-color); }
 `;
 
 const StyledMemoSection = styled.div`

--- a/client/components/calendar/overlays/ReservationDetailSections.tsx
+++ b/client/components/calendar/overlays/ReservationDetailSections.tsx
@@ -6,6 +6,7 @@ import {getAssigneeStatus, isAssigneeBookable, sortAssignees} from '../../../uti
 import type {ReservationChannel} from '../../../utils/reservations';
 import type {CustomerMemoTag} from '../../../utils/customers';
 import {ColorTag} from '../../ui/ColorTag';
+import {formControlStyle} from '../../ui/FormControls';
 import {useStoreLabels} from '../../../hooks/useStoreLabels';
 
 import {
@@ -383,16 +384,12 @@ const StyledReasonLabel = styled.label`
 `;
 
 const StyledReasonTextarea = styled.textarea`
+    ${formControlStyle};
     width: 100%;
-    box-sizing: border-box;
+    height: auto;
     padding: 8px 10px;
-    border: 1px solid var(--light-gray-color);
-    border-radius: var(--radius-md);
-    font-size: 13px;
     line-height: 1.5;
     resize: vertical;
-    color: var(--black-color);
-    &:focus { outline: none; border-color: var(--brand-color); }
 `;
 
 const StyledMemoSection = styled.div`

--- a/client/components/calendar/overlays/reservationDetailTypes.ts
+++ b/client/components/calendar/overlays/reservationDetailTypes.ts
@@ -9,6 +9,7 @@ export type ReservationDetailMode =
     | 'cancelling'
     | 'noshow'
     | 'payment'
+    | 'rejecting'
     | 'deleting';
 
 export type ReservationDiffItem = {

--- a/client/components/calendar/overlays/reservationDetailTypes.ts
+++ b/client/components/calendar/overlays/reservationDetailTypes.ts
@@ -9,6 +9,7 @@ export type ReservationDetailMode =
     | 'cancelling'
     | 'noshow'
     | 'payment'
+    | 'approving'
     | 'rejecting'
     | 'deleting';
 

--- a/client/components/calendar/overlays/reservationDetailUtils.ts
+++ b/client/components/calendar/overlays/reservationDetailUtils.ts
@@ -201,6 +201,7 @@ export const MODE_LABELS: Partial<Record<ReservationDetailMode, string>> = {
     cancelling: '예약 취소',
     noshow: '노쇼 처리',
     payment: '결제 처리',
+    rejecting: '예약 거절',
 };
 
 export function resolveReservationPrice(reservation: Reservation): number {

--- a/client/components/calendar/overlays/reservationDetailUtils.ts
+++ b/client/components/calendar/overlays/reservationDetailUtils.ts
@@ -201,6 +201,7 @@ export const MODE_LABELS: Partial<Record<ReservationDetailMode, string>> = {
     cancelling: '예약 취소',
     noshow: '노쇼 처리',
     payment: '결제 처리',
+    approving: '예약 확정',
     rejecting: '예약 거절',
 };
 

--- a/client/components/calendar/views/Timeline.tsx
+++ b/client/components/calendar/views/Timeline.tsx
@@ -60,9 +60,10 @@ export const Timeline = ({
 
     const dateKey = toDateKey(fullYear, month, date);
     // 타임라인(일별/주별/3일)에서는 취소된 예약을 숨긴다(블록·건수 부풀림 방지).
+    // 단, 고객 예약 페이지 경유(온라인) 취소 건은 기록 추적을 위해 취소 상태로 남긴다.
     const reservations = (reservationMap[dateKey] || []).filter((reservation) => (
         (calendarAssigneeId == null || (calendarAssigneeId === 0 ? !reservation.assigneeId : reservation.assigneeId === calendarAssigneeId))
-        && reservation.status !== 'cancelled'
+        && (reservation.status !== 'cancelled' || reservation.channel === '온라인예약')
     ));
     const serviceColorMap = useMemo(
         () => buildServiceColorMap(serviceCatalog, categoryBaseColorMap),

--- a/client/components/calendar/views/Timeline.tsx
+++ b/client/components/calendar/views/Timeline.tsx
@@ -20,7 +20,7 @@ import {buildServiceColorMap} from '../../../utils/services';
 import {getTimelineRange} from '../../../utils/timelineRange';
 
 import type {Reservation} from '../../../utils/reservations';
-import {toDateKey} from '../../../utils/reservations';
+import {isOnlineReservation, toDateKey} from '../../../utils/reservations';
 import {TimelineCluster} from './TimelineCluster';
 import {TimelineClusterLayer, type TimelineClusterData} from './TimelineClusterLayer';
 import {
@@ -63,7 +63,7 @@ export const Timeline = ({
     // 단, 고객 예약 페이지 경유(온라인) 취소 건은 기록 추적을 위해 취소 상태로 남긴다.
     const reservations = (reservationMap[dateKey] || []).filter((reservation) => (
         (calendarAssigneeId == null || (calendarAssigneeId === 0 ? !reservation.assigneeId : reservation.assigneeId === calendarAssigneeId))
-        && (reservation.status !== 'cancelled' || reservation.channel === '온라인예약')
+        && (reservation.status !== 'cancelled' || isOnlineReservation(reservation))
     ));
     const serviceColorMap = useMemo(
         () => buildServiceColorMap(serviceCatalog, categoryBaseColorMap),

--- a/client/features/booking/i18n.ts
+++ b/client/features/booking/i18n.ts
@@ -280,6 +280,10 @@ export interface BookI18n {
     alreadyPending: string;
     requestFailed: string;
     storeLoadFailed: string;
+    // 오너가 남긴 승인/취소 사유(있으면 원문 표시). 없으면 상태별 기본문구로 대체.
+    decisionReasonLabel: string;
+    decisionApprovedDefault: string;
+    decisionCancelledDefault: string;
     // 완료화면/조회 상태 라벨은 statusLabelL/lookupStatusL 사용
 }
 
@@ -358,6 +362,9 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         alreadyPending: '이미 처리 대기 중인 요청이 있습니다.',
         requestFailed: '요청에 실패했습니다. 잠시 후 다시 시도해 주세요.',
         storeLoadFailed: '예약 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        decisionReasonLabel: '매장 안내',
+        decisionApprovedDefault: '예약이 승인되었습니다.',
+        decisionCancelledDefault: '예약이 취소되었습니다.',
     },
     en: {
         loading: 'Loading…',
@@ -433,6 +440,9 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         alreadyPending: 'There is already a request being processed.',
         requestFailed: 'Request failed. Please try again shortly.',
         storeLoadFailed: 'Could not load reservation info. Please try again shortly.',
+        decisionReasonLabel: 'Message from the store',
+        decisionApprovedDefault: 'Your reservation has been confirmed.',
+        decisionCancelledDefault: 'Your reservation has been cancelled.',
     },
     zh: {
         loading: '加载中…',
@@ -508,6 +518,9 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         alreadyPending: '已有正在处理中的申请。',
         requestFailed: '申请失败，请稍后再试。',
         storeLoadFailed: '无法加载预约信息，请稍后再试。',
+        decisionReasonLabel: '门店说明',
+        decisionApprovedDefault: '您的预约已确认。',
+        decisionCancelledDefault: '您的预约已取消。',
     },
     ja: {
         loading: '読み込み中…',
@@ -583,5 +596,8 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         alreadyPending: '既に処理待ちの申請があります。',
         requestFailed: '申請に失敗しました。しばらくしてから再度お試しください。',
         storeLoadFailed: '予約情報を読み込めませんでした。しばらくしてから再度お試しください。',
+        decisionReasonLabel: '店舗からのご案内',
+        decisionApprovedDefault: 'ご予約が確定しました。',
+        decisionCancelledDefault: 'ご予約がキャンセルされました。',
     },
 };

--- a/client/features/reservations/model.ts
+++ b/client/features/reservations/model.ts
@@ -42,6 +42,11 @@ export function hasCompletedPayment(reservation: Reservation): boolean {
         || reservation.paymentCompleted === true;
 }
 
+// 고객 예약 페이지 경유(온라인) 예약인지. 승인/거절/취소 사유 노출·타임라인 취소 유지의 판별자.
+export function isOnlineReservation(reservation: Pick<Reservation, 'channel'>): boolean {
+    return reservation.channel === '온라인예약';
+}
+
 export function groupByDate(list: Reservation[]): ReservationMap {
     const map: ReservationMap = {};
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/pages/book/[slug]/r/[token].tsx
+++ b/client/pages/book/[slug]/r/[token].tsx
@@ -236,12 +236,13 @@ export default function ReservationManagePage() {
     const statusMsg = reservation.statusMessage
         ? pickI18n(reservation.statusMessage.i18n, lang, reservation.statusMessage.text ?? '')
         : '';
-    // 오너가 남긴 개별 사유(원문 표시). 없으면 확정/취소 상태에 한해 기본문구로 대체.
-    const decisionMsg = reservation.decisionReason
-        ? reservation.decisionReason
-        : reservation.status === 'active' ? t.decisionApprovedDefault
-        : reservation.status === 'cancelled' ? t.decisionCancelledDefault
-        : '';
+    // 고객 안내(하나만 노출) — 우선순위: 예약별 사유 > 매장 상태 안내문구(#139) > 상태별 기본문구.
+    const hasReason = !!reservation.decisionReason;
+    const customerNotice = reservation.decisionReason
+        || statusMsg
+        || (reservation.status === 'active' ? t.decisionApprovedDefault
+            : reservation.status === 'cancelled' ? t.decisionCancelledDefault
+            : '');
 
     return (
         <StyledWrap>
@@ -259,14 +260,12 @@ export default function ReservationManagePage() {
                     {reservation.assigneeName && <StyledSummaryRow><span>{labels.assignee}</span><StyledSummaryValue>{reservation.assigneeName}</StyledSummaryValue></StyledSummaryRow>}
                 </StyledSummary>
 
-                {decisionMsg && (
+                {customerNotice && (
                     <StyledNotice>
-                        {reservation.decisionReason && <StyledNoticeLabel>{t.decisionReasonLabel}</StyledNoticeLabel>}
-                        {decisionMsg}
+                        {hasReason && <StyledNoticeLabel>{t.decisionReasonLabel}</StyledNoticeLabel>}
+                        {customerNotice}
                     </StyledNotice>
                 )}
-
-                {statusMsg && <StyledNotice>{statusMsg}</StyledNotice>}
 
                 {pending && (
                     <StyledNotice>

--- a/client/pages/book/[slug]/r/[token].tsx
+++ b/client/pages/book/[slug]/r/[token].tsx
@@ -39,6 +39,8 @@ interface ReservationView {
     canCancel: boolean;
     // 상태별 오너 안내문구(#139): 확정·취소일 때만 서버가 채운다. 없으면 null.
     statusMessage: {text: string | null; i18n: I18nText} | null;
+    // 오너가 남긴 승인/거절/취소 사유(선택). 없으면 상태별 기본문구로 대체.
+    decisionReason: string | null;
 }
 
 interface BookServiceInfo {name: string; category: string; duration: number; price: number}
@@ -234,6 +236,12 @@ export default function ReservationManagePage() {
     const statusMsg = reservation.statusMessage
         ? pickI18n(reservation.statusMessage.i18n, lang, reservation.statusMessage.text ?? '')
         : '';
+    // 오너가 남긴 개별 사유(원문 표시). 없으면 확정/취소 상태에 한해 기본문구로 대체.
+    const decisionMsg = reservation.decisionReason
+        ? reservation.decisionReason
+        : reservation.status === 'active' ? t.decisionApprovedDefault
+        : reservation.status === 'cancelled' ? t.decisionCancelledDefault
+        : '';
 
     return (
         <StyledWrap>
@@ -250,6 +258,13 @@ export default function ReservationManagePage() {
                     <StyledSummaryRow><span>{labels.service}</span><StyledSummaryValue>{reservation.serviceSummary}</StyledSummaryValue></StyledSummaryRow>
                     {reservation.assigneeName && <StyledSummaryRow><span>{labels.assignee}</span><StyledSummaryValue>{reservation.assigneeName}</StyledSummaryValue></StyledSummaryRow>}
                 </StyledSummary>
+
+                {decisionMsg && (
+                    <StyledNotice>
+                        {reservation.decisionReason && <StyledNoticeLabel>{t.decisionReasonLabel}</StyledNoticeLabel>}
+                        {decisionMsg}
+                    </StyledNotice>
+                )}
 
                 {statusMsg && <StyledNotice>{statusMsg}</StyledNotice>}
 
@@ -439,6 +454,14 @@ const StyledSectionLabel = styled.strong`
     font-size: var(--font);
     font-weight: 700;
     color: var(--black-color);
+`;
+
+const StyledNoticeLabel = styled.strong`
+    display: block;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--brand-color, #6526d9);
 `;
 
 const StyledSummary = styled.div`

--- a/client/store/calendarStore.ts
+++ b/client/store/calendarStore.ts
@@ -199,7 +199,7 @@ export interface CalendarState {
     moveServiceInCategory: (dragName: string, targetName: string) => void;
     addReservation: (reservation: Reservation) => void;
     updateReservation: (prev: Reservation, updated: Reservation) => void;
-    cancelReservation: (reservation: Reservation, status?: ReservationStatus) => void;
+    cancelReservation: (reservation: Reservation, status?: ReservationStatus, reason?: string) => void;
     restoreReservation: (reservation: Reservation) => void;
     deleteReservation: (reservation: Reservation) => void;
     addSyncNotifications: (items: SyncNotification[]) => void;
@@ -717,7 +717,7 @@ export const useCalendarStore = create<CalendarState>((set) => ({
             });
     },
 
-    cancelReservation: (reservation, status = 'cancelled') => {
+    cancelReservation: (reservation, status = 'cancelled', reason) => {
         const updated: Reservation = {...reservation, status};
 
         let nextReservationMap: ReservationMap | null = null;
@@ -743,7 +743,7 @@ export const useCalendarStore = create<CalendarState>((set) => ({
         fetch('/api/reservations', {
             method: 'PATCH',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({id: reservation.id, status})
+            body: JSON.stringify({id: reservation.id, status, ...(reason ? {reason} : {})})
         });
     },
 

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 완료 — 온라인 예약 신청 거절 확인을 브라우저 confirm → 앱 레이어로 변경
+
+> 배경(사용자): 고객 예약 페이지를 통해 들어온 예약 신청을 오너가 상세 레이어에서 **거절**할 때, 브라우저 `window.confirm` 창 대신 앱 UI 레이어(모달)로 확인받도록 변경.
+
+### 범위/설계
+- 대상: `client/components/calendar/overlays/ReservationDetail.tsx`의 `decideBooking('reject')` 경로만. 다른 confirm(취소 등)은 이미 레이어이므로 무관.
+- 기존 취소/노쇼/완료와 동일 패턴 채택: `mode`에 `'rejecting'` 추가 → 거절 버튼은 레이어를 열고(`setMode('rejecting')`), 레이어 안 `ReservationStaticDiffSection`으로 대상 정보 표시 → footer의 "거절" 확인 버튼이 실제 API 호출.
+- `window.confirm` 제거. `decideBooking`은 API 호출만 담당.
+
+### 영향 파일
+- `reservationDetailTypes.ts`: `ReservationDetailMode`에 `'rejecting'` 추가
+- `reservationDetailUtils.ts`: `MODE_LABELS.rejecting = '예약 거절'`
+- `ReservationDetail.tsx`: rejecting 섹션 렌더 + footer 배선(open/confirm)
+- `ReservationDetailFooterActions.tsx`: `rejecting` mode footer + `onRejectReservation` prop
+
+### 검증
+- ✅ 타입체크 0·빌드 성공. 온라인 신청(requested) 예약 상세에서 거절 → 레이어 노출 → 확인 시 API 호출·새로고침 흐름(기존 취소/노쇼 레이어와 동일 패턴).
+
+---
+
 ## 진행 중 — 예약 상태별 오너 안내문구 (#139: 완료·확정·취소, 4개 언어)
 
 > 배경(사용자): 사전 안내문(`noticeText`) 외에 **예약완료·확정·취소** 단계별 안내문구도 필요. 각각 오너 입력 + 4개 언어(한/영/일/중).

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,31 @@
 
 ---
 
+## 진행 중 — 온라인 예약 승인/거절/취소 UX 개선 (승인 확인 레이어·취소 예약 유지·사유)
+
+> 배경(사용자): 고객 예약 페이지로 들어온 예약 처리 흐름 3가지.
+> 1) 승인 시에도 확인 레이어(거절과 동일 패턴) 추가.
+> 2) 승인된 예약을 취소하면 타임라인(일별/주별/3일)에서 사라짐 → 취소 예약으로 남아야 함.
+> 3) 승인·거절·취소 시 사유 입력(선택). 미작성 시 "예약이 {승인/거절/취소}되었습니다." 기본문구. 고객 조회 페이지(/r/{token})에 노출.
+
+### 설계 결정
+- **사유는 필수 아님.** 빈 값이면 상태별 기본문구로 대체(고객 페이지에서 표시). 자유 텍스트(오너 입력 한국어), 번역 없음 — `memo`와 동일 취급.
+- **저장**: `Reservation.decisionReason TEXT?` 1컬럼(마지막 결정 사유 덮어쓰기). 승인 시=승인 사유(active에서 표시), 거절/취소 시=취소 사유(cancelled에서 표시). 마이그레이션 0014, 추가형·멱등(`ADD COLUMN IF NOT EXISTS`). **운영 Supabase direct(5432) 수동 선적용 → 코드 자동배포** 순서 준수.
+- **#2 타임라인**: 온라인 예약(channel=online)의 취소 건만 타임라인에 계속 표시(기존 "취소 숨김"은 수기/네이버엔 유지 — 블록·건수 부풀림 최소화). 고객 신청 예약 추적 목적.
+
+### 영향 파일
+- 스키마/마이그레이션: `schema.prisma`(Reservation.decisionReason), `migrations/0014_reservation_decision_reason/migration.sql`
+- 서버: `book/booking-helpers.ts`(토큰 select에 decisionReason), `book/reservation/[token].ts`(응답에 decisionReason), `book-requests.ts`(approve/reject 시 reason 저장), `reservations.ts`(PATCH에 reason → cancel 시 저장)
+- 클라 스토어: `calendarStore.ts` `cancelReservation(reservation, status, reason?)`
+- 상세 레이어: `reservationDetailTypes.ts`(mode 'approving'), `reservationDetailUtils.ts`(MODE_LABELS), `ReservationDetail.tsx`(approving 레이어 + 사유 입력 + 배선), `ReservationDetailFooterActions.tsx`(approving footer), `ReservationDetailSections.tsx`(사유 입력 UI)
+- 고객 페이지: `book/[slug]/r/[token].tsx`(사유/기본문구 표시), `features/booking/i18n.ts`(기본문구 4개 언어)
+- #2: `calendar/views/Timeline.tsx`(온라인 취소 유지)
+
+### 검증
+- 타입체크·빌드. 온라인 신청 승인/거절/취소 왕복(로컬), 고객 페이지 사유 표시, 타임라인 온라인 취소 유지 확인.
+
+---
+
 ## 완료 — 온라인 예약 신청 거절 확인을 브라우저 confirm → 앱 레이어로 변경
 
 > 배경(사용자): 고객 예약 페이지를 통해 들어온 예약 신청을 오너가 상세 레이어에서 **거절**할 때, 브라우저 `window.confirm` 창 대신 앱 UI 레이어(모달)로 확인받도록 변경.

--- a/server/api/book-requests.ts
+++ b/server/api/book-requests.ts
@@ -13,6 +13,7 @@ interface DecideBody {
     id?: unknown;
     legacyId?: unknown;
     decision?: unknown;
+    reason?: unknown;
 }
 
 interface ChangePayload {
@@ -109,6 +110,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const id = typeof body.id === 'string' ? body.id : '';
         const legacyId = typeof body.legacyId === 'number' ? body.legacyId : null;
         const decision = body.decision === 'approve' || body.decision === 'reject' ? body.decision : null;
+        // 승인/거절 사유(선택). 고객 조회 페이지에 노출. 빈 값은 저장하지 않음(고객 페이지가 기본문구로 대체).
+        const reason = typeof body.reason === 'string' ? body.reason.trim().slice(0, 300) : '';
         if ((!id && legacyId === null) || !decision) return res.status(400).json({error: 'invalid_input'});
 
         const reservation = await prisma.reservation.findFirst({
@@ -124,7 +127,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // 신규 예약 신청 확정/거절
         if (kind === 'new') {
             const status = decision === 'approve' ? 'active' : 'cancelled';
-            await prisma.reservation.update({where: {id: reservation.id}, data: {status}});
+            await prisma.reservation.update({
+                where: {id: reservation.id},
+                data: {status, ...(reason ? {decisionReason: reason} : {})},
+            });
             return res.status(200).json({ok: true, applied: decision === 'approve' ? 'confirmed' : 'rejected'});
         }
 

--- a/server/api/book/booking-helpers.ts
+++ b/server/api/book/booking-helpers.ts
@@ -101,6 +101,7 @@ export async function findReservationByPublicToken(token: string) {
             pendingAction: true,
             pendingPayloadJson: true,
             pendingRequestedAt: true,
+            decisionReason: true,
             store: {select: {name: true, shopType: true, bookingSlug: true, useOnlineBooking: true}},
             assignee: {select: {name: true}},
             customer: {select: {name: true, tel: true}},

--- a/server/api/book/reservation/[token].ts
+++ b/server/api/book/reservation/[token].ts
@@ -40,6 +40,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         pendingAction: reservation.pendingAction,
         pendingChange,
         pendingRequestedAt: reservation.pendingRequestedAt?.toISOString() ?? null,
+        // 오너가 남긴 승인/거절/취소 사유(선택). 없으면 null → 고객 페이지가 상태별 기본문구로 대체.
+        decisionReason: reservation.decisionReason ?? null,
         // 변경 요청은 active 예약만. 취소 요청은 확정 대기(requested)도 가능(신청 철회).
         canRequest: reservation.status === 'active',
         canCancel: reservation.status === 'active' || reservation.status === 'requested',

--- a/server/api/reservations.ts
+++ b/server/api/reservations.ts
@@ -239,7 +239,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (req.method === 'PATCH') {
         if (!requireRole(session, 'staff', res)) return;
 
-        const {id, status} = req.body as { id: number; status: ReservationStatus };
+        const {id, status, reason} = req.body as { id: number; status: ReservationStatus; reason?: string };
+        // 취소 사유(선택). 고객 조회 페이지에 노출. 빈 값은 저장하지 않음(고객 페이지가 기본문구로 대체).
+        const decisionReason = typeof reason === 'string' ? reason.trim().slice(0, 300) : '';
 
         const dbReservation = await prisma.reservation.findUnique({
             where: {storeId_legacyId: {storeId: session.storeId, legacyId: id}},
@@ -256,7 +258,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const after = await prisma.$transaction(async (tx) => {
             const updatedReservation = await tx.reservation.update({
                 where: {id: dbReservation.id},
-                data: {status: frontendReservationStatusToDb(status)},
+                data: {
+                    status: frontendReservationStatusToDb(status),
+                    ...(decisionReason ? {decisionReason} : {}),
+                },
                 select: reservationSelect,
             });
 

--- a/server/prisma/migrations/0014_reservation_decision_reason/migration.sql
+++ b/server/prisma/migrations/0014_reservation_decision_reason/migration.sql
@@ -1,0 +1,3 @@
+-- 온라인 예약 승인/거절/취소 사유(선택). 고객 조회 페이지 노출용.
+-- 추가형·nullable. 데이터 파괴 없음. IF NOT EXISTS로 멱등(Supabase direct 5432 수동 선적용 안전).
+ALTER TABLE "Reservation" ADD COLUMN IF NOT EXISTS "decisionReason" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -221,6 +221,8 @@ model Reservation {
   pendingAction    ReservationPendingAction  @default(none)
   pendingPayloadJson Json?
   pendingRequestedAt DateTime?
+  // 온라인 예약 승인/거절/취소 시 오너가 남기는 사유(선택). 고객 조회 페이지에 노출. 마지막 결정 사유로 덮어씀.
+  decisionReason   String?
   createdAt        DateTime                  @default(now())
   updatedAt        DateTime                  @updatedAt
   pointHistories   CustomerPointHistory[]


### PR DESCRIPTION
## 개요
고객 예약 페이지를 통해 들어온 온라인 예약의 승인/거절/취소 처리 흐름을 개선합니다. 브라우저 confirm 대신 앱 UI 레이어로 확인받고, 오너가 입력한 사유를 고객 조회 페이지에 노출하며, 온라인 취소 예약은 타임라인에 유지합니다.

## 주요 변경사항

### 1. 승인/거절 확인 레이어 추가
- `ReservationDetailMode`에 `'approving'`, `'rejecting'` 모드 추가
- 기존 취소/노쇼와 동일 패턴: 버튼 클릭 → 확인 레이어 노출 → footer 확인 버튼으로 API 호출
- 브라우저 `window.confirm` 제거 (`decideBooking`은 API 호출만 담당)
- `ReservationDetailFooterActions`에 approving/rejecting 모드별 footer 추가

### 2. 승인/거절/취소 사유 입력 (선택)
- `Reservation.decisionReason TEXT?` 컬럼 추가 (마이그레이션 0014)
- 확인 레이어에 선택적 사유 입력칸 추가 (`ReservationStaticDiffSection`에 `reason` prop)
- 미입력 시 고객 페이지에서 상태별 기본문구로 대체
- 사유는 최대 300자, 한국어 자유 텍스트 (번역 없음)

### 3. 고객 조회 페이지 사유 노출
- `/r/[token]` 페이지에서 `decisionReason` 표시
- 우선순위: 예약별 사유 > 매장 상태 안내문구(#139) > 상태별 기본문구
- 4개 언어 기본문구 추가 (한/영/일/중)

### 4. 온라인 취소 예약 타임라인 유지
- `isOnlineReservation()` 헬퍼 함수 추가 (channel === '온라인예약')
- Timeline에서 온라인 취소 건만 표시 (기존 "취소 숨김"은 수기/네이버엔 유지)
- 고객 신청 예약 추적 목적

## 영향 범위

### 스키마/마이그레이션
- `schema.prisma`: `Reservation.decisionReason` 추가
- `migrations/0014_reservation_decision_reason/migration.sql`: 멱등 추가형 마이그레이션

### 서버 API
- `book-requests.ts`: approve/reject 시 reason 저장
- `reservations.ts`: PATCH에서 reason → cancel 시 저장
- `book/reservation/[token].ts`: 응답에 decisionReason 포함
- `book/booking-helpers.ts`: select에 decisionReason 추가

### 클라이언트 스토어
- `calendarStore.ts`: `cancelReservation(reservation, status?, reason?)` 시그니처 확장

### 상세 레이어
- `reservationDetailTypes.ts`: mode에 'approving', 'rejecting' 추가
- `reservationDetailUtils.ts`: MODE

https://claude.ai/code/session_01ML29n2jJYxksGR8cLNBXVL