### PR TITLE
feat(auth): 모바일 Bearer 인증 브리지 (tas-ios 로그인용)

### DIFF
--- a/client/pages/api/mobile-auth/complete.ts
+++ b/client/pages/api/mobile-auth/complete.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../../server/api/mobile-auth/complete';

--- a/client/pages/api/mobile-auth/exchange.ts
+++ b/client/pages/api/mobile-auth/exchange.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../../server/api/mobile-auth/exchange';

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -112,6 +112,14 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
 
     const authError = typeof router.query.error === 'string' ? router.query.error : null;
 
+    // 모바일 앱(ASWebAuthenticationSession) 로그인: callbackUrl이 모바일 브리지 경로일 때만
+    // 허용(오픈 리다이렉트 방지). 성공 후 그쪽으로 보내 커스텀 스킴 콜백을 완료한다.
+    const mobileCallback =
+        typeof router.query.callbackUrl === 'string' &&
+        router.query.callbackUrl.startsWith('/api/mobile-auth/complete')
+            ? router.query.callbackUrl
+            : null;
+
     // 초대 링크(/login?invite=CODE)로 진입 시 코드 자동 입력 + 쿠키 세팅
     // → 로그인 직후 OAuth 콜백에서 초대가 적용되어 새 매장이 아닌 초대 매장으로 가입됨
     useEffect(() => {
@@ -125,13 +133,18 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
 
     useEffect(() => {
         if (!authError && hasAccess) {
-            router.replace(monthEntryPath);
+            // 이미 세션이 있는 모바일 로그인 진입 → 브리지로 전체 이동해 code 발급까지 완료.
+            if (mobileCallback) {
+                window.location.assign(mobileCallback);
+            } else {
+                router.replace(monthEntryPath);
+            }
             return;
         }
         if (authError && status === 'authenticated') {
             router.replace(`/settings/sns?error=${authError}`);
         }
-    }, [hasAccess, monthEntryPath, router, authError, status]);
+    }, [hasAccess, monthEntryPath, router, authError, status, mobileCallback]);
 
     if (hasAccess && !authError) {
         return null;
@@ -152,7 +165,7 @@ export default function LoginPage({providerIds, isDatabaseConfigured, loginError
         } else {
             clearInviteCookie();
         }
-        void signIn(providerId, {callbackUrl: monthEntryPath});
+        void signIn(providerId, {callbackUrl: mobileCallback ?? monthEntryPath});
     };
 
     const startGuest = () => {

--- a/server/api/mobile-auth/complete.ts
+++ b/server/api/mobile-auth/complete.ts
@@ -1,0 +1,29 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {auth} from '../../../client/auth';
+import {signMobileCode} from '../../auth/mobile-token';
+
+// 모바일 로그인 완료 지점. iOS는 ASWebAuthenticationSession으로 웹 로그인을 열고,
+// NextAuth OAuth 성공 후 callbackUrl=/api/mobile-auth/complete 로 돌아온다.
+// 여기서 세션을 읽어 1회성 code를 발급하고 커스텀 스킴으로 앱에 돌려보낸다.
+const APP_CALLBACK = 'tasios://auth/callback';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const session = await auth(req, res);
+    const nonce = typeof req.query.nonce === 'string' ? req.query.nonce : '';
+
+    // 세션 유효 + 매장/권한 확정(온보딩 완료)이어야 발급. 그 외는 오류 사유와 함께 앱으로 복귀.
+    if (!session?.user?.id || !session.user.storeId || !session.user.role) {
+        const reason = session?.user?.id ? 'no_store' : 'no_session';
+        return res.redirect(302, `${APP_CALLBACK}?error=${reason}`);
+    }
+
+    const code = signMobileCode({
+        userId: session.user.id,
+        storeId: session.user.storeId,
+        role: session.user.role,
+        nonce,
+    });
+
+    return res.redirect(302, `${APP_CALLBACK}?code=${encodeURIComponent(code)}`);
+}

--- a/server/api/mobile-auth/exchange.ts
+++ b/server/api/mobile-auth/exchange.ts
@@ -1,0 +1,36 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {verifyMobileCode, signMobileAccess, MOBILE_ACCESS_TTL_SEC} from '../../auth/mobile-token';
+
+// 1회성 code를 실제 API 인증용 access 토큰으로 교환한다.
+// iOS가 커스텀 스킴 콜백에서 받은 code + 로그인 시작 시 만든 nonce를 보낸다.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method !== 'POST') {
+        res.setHeader('Allow', 'POST');
+        return res.status(405).json({error: 'Method not allowed'});
+    }
+
+    const {code, nonce} = (req.body ?? {}) as {code?: string; nonce?: string};
+    if (!code) {
+        return res.status(400).json({error: 'Missing code'});
+    }
+
+    const claims = verifyMobileCode(code);
+    if (!claims) {
+        return res.status(401).json({error: 'Invalid or expired code'});
+    }
+
+    // nonce 바인딩: code를 발급받은 그 로그인 시도(기기)만 교환 가능.
+    if ((claims.nonce ?? '') !== (nonce ?? '')) {
+        return res.status(401).json({error: 'Nonce mismatch'});
+    }
+
+    const accessToken = signMobileAccess({
+        userId: claims.userId,
+        storeId: claims.storeId,
+        role: claims.role,
+    });
+    const expiresAt = Math.floor(Date.now() / 1000) + MOBILE_ACCESS_TTL_SEC;
+
+    return res.status(200).json({accessToken, expiresAt});
+}

--- a/server/auth/api-session.ts
+++ b/server/auth/api-session.ts
@@ -3,6 +3,7 @@ import type {NextApiRequest, NextApiResponse} from 'next';
 import {auth} from '../../client/auth';
 import type {AppRole} from './roles';
 import {hasRequiredRole} from './roles';
+import {verifyMobileAccess} from './mobile-token';
 
 export interface ApiSession {
     userId: string;
@@ -10,7 +11,26 @@ export interface ApiSession {
     role: AppRole;
 }
 
+function bearerToken(req: NextApiRequest): string | null {
+    const header = req.headers.authorization;
+    if (!header) {
+        return null;
+    }
+    const [scheme, token] = header.split(' ');
+    return scheme === 'Bearer' && token ? token : null;
+}
+
 export async function getApiSession(req: NextApiRequest, res: NextApiResponse): Promise<ApiSession | null> {
+    // 1) 모바일 Bearer 토큰(앱) — 유효하면 세션으로 사용. 없거나 무효면 쿠키 경로로 폴백(웹 무회귀).
+    const token = bearerToken(req);
+    if (token) {
+        const claims = verifyMobileAccess(token);
+        if (claims) {
+            return {userId: claims.userId, storeId: claims.storeId, role: claims.role};
+        }
+    }
+
+    // 2) 웹 NextAuth 쿠키 세션 (기존 동작 그대로)
     const session = await auth(req, res);
 
     if (!session?.user?.storeId || !session.user.role) {

--- a/server/auth/mobile-token.ts
+++ b/server/auth/mobile-token.ts
@@ -1,0 +1,115 @@
+import {createHmac, timingSafeEqual, randomUUID} from 'node:crypto';
+
+import type {AppRole} from './roles';
+
+// 모바일(iOS/Android) 전용 토큰. 웹은 기존 NextAuth 쿠키 세션을 그대로 쓰고,
+// 앱만 이 Bearer 토큰으로 인증한다. 외부 의존성 없이 node:crypto로 HS256 서명한다.
+//
+// 두 종류:
+//  - code   : 로그인 완료 직후 발급하는 1회성 교환용(짧은 TTL). URL로 앱에 전달.
+//  - access : code 교환으로 받는 실제 API 인증 토큰(긴 TTL). Keychain 보관.
+
+export const MOBILE_CODE_TTL_SEC = 60;
+export const MOBILE_ACCESS_TTL_SEC = 60 * 60 * 24 * 30; // 30일
+
+interface BaseClaims {
+    iat: number;
+    exp: number;
+}
+
+interface CodeClaims extends BaseClaims {
+    typ: 'code';
+    jti: string;
+    userId: string;
+    storeId: string;
+    role: AppRole;
+    nonce: string;
+}
+
+interface AccessClaims extends BaseClaims {
+    typ: 'access';
+    userId: string;
+    storeId: string;
+    role: AppRole;
+}
+
+function getSecret(): string {
+    const secret = process.env.AUTH_SECRET;
+    if (!secret) {
+        throw new Error('AUTH_SECRET is not set');
+    }
+    return secret;
+}
+
+function encodeSegment(value: object): string {
+    return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function sign(payload: object, expiresInSec: number): string {
+    const now = Math.floor(Date.now() / 1000);
+    const header = {alg: 'HS256', typ: 'JWT'};
+    const body = {...payload, iat: now, exp: now + expiresInSec};
+    const data = `${encodeSegment(header)}.${encodeSegment(body)}`;
+    const signature = createHmac('sha256', getSecret()).update(data).digest('base64url');
+    return `${data}.${signature}`;
+}
+
+function verify<T extends BaseClaims>(token: string): T | null {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+        return null;
+    }
+
+    const [encodedHeader, encodedBody, signature] = parts;
+    const data = `${encodedHeader}.${encodedBody}`;
+    const expected = createHmac('sha256', getSecret()).update(data).digest();
+    const actual = Buffer.from(signature, 'base64url');
+    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+        return null;
+    }
+
+    let claims: T;
+    try {
+        claims = JSON.parse(Buffer.from(encodedBody, 'base64url').toString('utf8')) as T;
+    } catch {
+        return null;
+    }
+
+    if (typeof claims.exp !== 'number' || Math.floor(Date.now() / 1000) >= claims.exp) {
+        return null;
+    }
+
+    return claims;
+}
+
+// MARK: - code(1회성 교환 토큰)
+
+export function signMobileCode(input: {userId: string; storeId: string; role: AppRole; nonce: string}): string {
+    const claims: Omit<CodeClaims, keyof BaseClaims> = {typ: 'code', jti: randomUUID(), ...input};
+    return sign(claims, MOBILE_CODE_TTL_SEC);
+}
+
+export function verifyMobileCode(
+    token: string
+): {userId: string; storeId: string; role: AppRole; nonce: string} | null {
+    const claims = verify<CodeClaims>(token);
+    if (!claims || claims.typ !== 'code') {
+        return null;
+    }
+    return {userId: claims.userId, storeId: claims.storeId, role: claims.role, nonce: claims.nonce ?? ''};
+}
+
+// MARK: - access(API 인증 토큰)
+
+export function signMobileAccess(input: {userId: string; storeId: string; role: AppRole}): string {
+    const claims: Omit<AccessClaims, keyof BaseClaims> = {typ: 'access', ...input};
+    return sign(claims, MOBILE_ACCESS_TTL_SEC);
+}
+
+export function verifyMobileAccess(token: string): {userId: string; storeId: string; role: AppRole} | null {
+    const claims = verify<AccessClaims>(token);
+    if (!claims || claims.typ !== 'access') {
+        return null;
+    }
+    return {userId: claims.userId, storeId: claims.storeId, role: claims.role};
+}


### PR DESCRIPTION
## 배경
iOS 앱(`tas-ios`)이 `ASWebAuthenticationSession`(진짜 Safari) + 커스텀 스킴(`tasios://`)으로
로그인하도록, tas 백엔드에 **모바일 전용 경로만** 추가한다. 웹 NextAuth 쿠키 세션은 그대로 유지(무회귀).
설계·계약: `tas-ios` 저장소 `docs/auth-mobile-bridge.md`.

## 변경
- `server/auth/mobile-token.ts` — Node `crypto` HS256 code/access 토큰 (외부 의존성 0, lockfile 무변경)
- `server/api/mobile-auth/complete.ts` — 로그인 완료 → 1회성 code 발급 → `tasios://auth/callback?code=` 302
- `server/api/mobile-auth/exchange.ts` — `{code,nonce}` → access 토큰 반환
- `server/auth/api-session.ts` — `Authorization: Bearer` 인식(무효/부재 시 기존 쿠키 폴백 → **웹 무회귀**)
- `client/pages/login.tsx` — 모바일 브리지 `callbackUrl` 허용 (오픈 리다이렉트 가드: `/api/mobile-auth/complete` 접두만)
- `client/pages/api/mobile-auth/*` — Pages Router 재export

## 흐름
```
iOS ASWebAuth → /login?callbackUrl=/api/mobile-auth/complete?nonce=N&mobile=1
 → NextAuth OAuth(google/kakao/naver) 성공 → /api/mobile-auth/complete
 → 1회성 code → tasios://auth/callback?code=
 → iOS: POST /api/mobile-auth/exchange {code,nonce} → Bearer 토큰 → Keychain
 → 이후 API 요청 Authorization: Bearer  (getApiSession이 쿠키 대신 인식)
```

## 검증
- `tsc --noEmit` 통과. 신규 lint 에러 없음(login.tsx 기존 경고 2건은 무변경 코드).
- DB 마이그레이션 없음. 새 env 없음(기존 `AUTH_SECRET` 재사용).

## ⚠️ 배포 주의 (리뷰어)
- **자동 머지 금지 — 프로덕션 인증 변경.** CI 그린이어도 사람 확인 후 머지.
- 머지 시 Cloud Run 자동 배포 → 즉시 로그인 경로에 반영. 앱이 로그인하려면 이 배포가 선행돼야 함.
- 후속(별도): provider별 네이티브 개시(`start?provider=`), code 단일사용 강화(현재 60s TTL+nonce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zcWqBTCBKJNvr1ZpMig9o)_