### PR TITLE
Fix timezone off-by-one bug in public booking closed dates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/index.md
+++ b/index.md
@@ -269,7 +269,7 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `prisma.ts` | Prisma 클라이언트 싱글턴 (PrismaPg driver adapter 사용) |
 | `mappers.ts` | DB ↔ 프론트엔드 변환 함수[^13] |
 
-[^13]: `dbReservationToFrontend()`, `dbCustomerToFrontend()`, `dbAssigneeToFrontend()`, `dbServiceToFrontend()`, `dbStoreToFrontend()` 등. legacyId(number) ↔ CUID(string) 변환 포함. `legacyId`가 null이면 프론트 id가 깨지므로 생성 시 반드시 부여할 것. **예약 조회는 `prisma-includes.ts`의 명시적 `select`(`reservationSelect`/`reservationSelectWithNames`)만 사용** — `include`(전체 컬럼 SELECT)는 금지. 새 컬럼을 추가한 뒤 마이그레이션이 미적용된 채 배포되면 `include`가 없는 컬럼까지 SELECT하다 전체 예약 조회가 500나기 때문(2026-07 `publicToken` 배포순서 사고 재발방지)
+[^13]: `dbReservationToFrontend()`, `dbCustomerToFrontend()`, `dbAssigneeToFrontend()`, `dbServiceToFrontend()`, `dbStoreToFrontend()` 등. legacyId(number) ↔ CUID(string) 변환 포함. `legacyId`가 null이면 프론트 id가 깨지므로 생성 시 반드시 부여할 것. **예약 조회는 `prisma-includes.ts`의 명시적 `select`(`reservationSelect`/`reservationSelectWithNames`)만 사용** — `include`(전체 컬럼 SELECT)는 금지. 새 컬럼을 추가한 뒤 마이그레이션이 미적용된 채 배포되면 `include`가 없는 컬럼까지 SELECT하다 전체 예약 조회가 500나기 때문(2026-07 `publicToken` 배포순서 사고 재발방지). **날짜 전용 컬럼(`Reservation.date`·`StoreClosedDate.date` 등) 규칙**: 저장은 `new Date(\`${dateStr}T00:00:00\`)`(서버 로컬 파싱), 읽기는 **항상 `toDateKey`**(로컬 컴포넌트 추출) — 두 방향이 서버 TZ와 무관하게 오너 입력 달력일을 왕복시킨다. `.toISOString().slice(0,10)`(UTC)로 읽으면 서버가 KST일 때 하루 밀려 휴업일이 공개 예약에서 누락되므로 금지(오너·공개 부킹 API 모두 `toDateKey` 사용). 예외: `booking-helpers.nowKst()`는 의도적으로 KST-shift된 instant에 UTC 추출(TZ 독립)
 
 ---
 

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,36 @@
 
 ---
 
+## 완료 — 휴업일 설정해도 고객 예약 페이지에서 예약되는 버그 (TZ 오프바이원)
+
+> 배경(사용자): "휴업일 설정했는데, 고객 예약 페이지 통해서 예약되네." 오너가 특정 날짜 휴업일(`StoreClosedDate`)을 설정했는데도 공개 예약 페이지에서 그 날짜 예약이 통과됨.
+
+### 원인 (근본)
+- **날짜 전용 컬럼의 저장/읽기 TZ 규칙 불일치.** 앱 전역 규칙은 "저장=`new Date(\`${date}T00:00:00\`)`(서버 로컬 파싱), 읽기=`mappers.toDateKey`(로컬 컴포넌트 추출)" → 서버 TZ와 무관하게 오너가 입력한 달력일을 되돌려줌(오너 흐름은 정상).
+- **공개 예약 API들만 이 규칙을 깨고 UTC `.toISOString().slice(0,10)`로 읽음.** 서버가 KST(운영)면 로컬 파싱으로 저장된 `2026-07-25`가 `2026-07-24T15:00:00Z`로 저장돼, `.toISOString()`은 `2026-07-24`를 돌려줌 → 하루 밀림.
+- 결과: 오너는 25일이 휴업일로 보이지만(정상), 공개 API의 `closedDates`엔 24일이 들어가 고객이 고른 25일이 차단되지 않음 → `evaluateDateWindow`가 ok:true → `reserve`가 201. 클라이언트 제출 경로·서버 재검증 로직 자체는 정상.
+- TZ=UTC에선 두 방식이 우연히 일치해 재현 안 됨(운영은 KST로 동작 → 재현). `node -e` 시뮬레이션으로 UTC 정상 / Asia/Seoul 하루 밀림 확증.
+
+### 수정 방침 (관례 복원 — `toDateKey`로 통일, 전 TZ에서 정확·UTC서 무회귀)
+- `mappers.ts`의 `toDateKey`를 `export` 하고, 공개 예약 흐름의 모든 날짜 읽기를 `.toISOString().slice(0,10)` → `toDateKey(...)`로 교체.
+- **A. 휴업일 비교(신고 버그)**: `book/[slug].ts`, `book/[slug]/availability.ts`, `book/[slug]/reserve.ts`, `book/[slug]/day.ts`, `book/reservation/[token]/request-change.ts`의 `closedDates` 생성.
+- **B. 예약 날짜 표시(동일 뿌리, KST서 하루 밀려 표시)**: `book/[slug]/lookup.ts`, `book/reservation/[token].ts`, `request-change.ts`(Slack), `request-cancel.ts`(Slack), `book-requests.ts`(오너 요청목록).
+- **손대지 않음**: `booking-helpers.ts` `nowKst()`의 `shifted.toISOString().slice(0,10)` — 의도적으로 KST-shift된 instant에 UTC 추출(정상, TZ 독립).
+- 스키마·마이그레이션 무변경(코드-온리 배포). 저장 형식 불변이라 기존 데이터 그대로 정상 해석.
+
+### 검증 (완료)
+- ✅ 타입체크 exit 0(`tsc --noEmit`, select 완전성 포함)·`next build` exit 0(부킹 라우트 포함 전 API 컴파일).
+- ✅ `node` 시뮬레이션(실제 `toDateKey`)으로 라운드트립 확인: **수정 전** KST에서 `closedDates=["2026-07-24"]` → 고객 25일 예약 통과(버그). **수정 후** UTC·Asia/Seoul·America/New_York 전부 `["2026-07-25"]` → 25일 예약 차단.
+- (테스트 러너 없음) 회귀 방지는 단일 헬퍼(`toDateKey`) 통일 + 타입체크로 담보. 후속 하드닝 후보: 날짜 전용 컬럼을 `@db.Date`/문자열로 두어 instant 왕복 자체를 제거(마이그레이션 필요 → 범위 밖).
+
+### 결과물 (수정 파일)
+- `server/db/mappers.ts`: `toDateKey` `export`(공개 API가 오너 흐름과 동일 헬퍼 재사용).
+- A(휴업일 비교): `book/[slug].ts`·`book/[slug]/availability.ts`·`book/[slug]/reserve.ts`·`book/[slug]/day.ts`·`book/reservation/[token]/request-change.ts`.
+- B(예약 날짜 표시): `book/[slug]/lookup.ts`·`book/reservation/[token].ts`·`request-change.ts`(Slack)·`request-cancel.ts`(Slack)·`book-requests.ts`.
+- `client/package.json` 0.37.0→0.37.1(patch).
+
+---
+
 ## 진행 중 — 온라인 예약 승인/거절/취소 UX 개선 (승인 확인 레이어·취소 예약 유지·사유)
 
 > 배경(사용자): 고객 예약 페이지로 들어온 예약 처리 흐름 3가지.

--- a/server/api/book-requests.ts
+++ b/server/api/book-requests.ts
@@ -2,6 +2,7 @@ import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {Prisma} from '../../client/prisma/generated/prisma/client';
 import {prisma} from '../db/prisma';
+import {toDateKey} from '../db/mappers';
 import {getApiSession, requireRole} from '../auth/api-session';
 
 // 오너 확정 대기 항목을 오너가 수락/거절하는 인증 API. 로그인 + staff 이상 + storeId 스코프.
@@ -73,7 +74,7 @@ function toRequestDto(r: PendingRow) {
         assigneeName: r.assignee?.name ?? null,
         requestedAt: (r.pendingRequestedAt ?? r.createdAt)?.toISOString() ?? null,
         current: {
-            date: r.date.toISOString().slice(0, 10),
+            date: toDateKey(r.date),
             startTime: r.startTime,
             endTime: r.endTime,
             serviceSummary: r.serviceSummary,

--- a/server/api/book/[slug].ts
+++ b/server/api/book/[slug].ts
@@ -1,7 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../db/prisma';
-import {parseI18nText} from '../../db/mappers';
+import {parseI18nText, toDateKey} from '../../db/mappers';
 import {DEFAULT_BOOKING_SETTINGS, parseBookableServiceNames} from '../../../client/features/store-settings/model';
 
 // 공개(비로그인) 예약 매장 정보. 데이터 최소 노출 — 고객/예약 정보는 절대 반환하지 않는다.
@@ -67,7 +67,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             ? assignees.map((a) => ({id: a.id, name: a.name, nameI18n: parseI18nText(a.nameI18nJson), color: a.color, offDays: a.schedules.filter((s) => !s.enabled).map((s) => s.dayIndex)}))
             : [],
         businessHours: businessHours.map((b) => ({dayIndex: b.dayIndex, openTime: b.openTime, closeTime: b.closeTime, enabled: b.enabled})),
-        closedDates: closedDates.map((c) => c.date.toISOString().slice(0, 10)),
+        closedDates: closedDates.map((c) => toDateKey(c.date)),
         settings,
     });
 }

--- a/server/api/book/[slug]/availability.ts
+++ b/server/api/book/[slug]/availability.ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../db/prisma';
+import {toDateKey} from '../../../db/mappers';
 import {
     computeAvailableSlots,
     type SlotAssignee,
@@ -52,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!areServicesBookable(serviceNames, settings.bookableServiceNames)) return res.status(400).json({error: 'not_bookable'});
     const durationMin = services.reduce((sum, s) => sum + s.duration, 0);
 
-    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const closedDates = closedRows.map((c) => toDateKey(c.date));
     const window = evaluateDateWindow(dateStr, settings, closedDates);
     if (!window.ok) return res.status(200).json({date: dateStr, durationMin, slots: []});
 

--- a/server/api/book/[slug]/day.ts
+++ b/server/api/book/[slug]/day.ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../db/prisma';
+import {toDateKey} from '../../../db/mappers';
 import {
     assigneeWorksOnDay,
     computeSlotCapacities,
@@ -46,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // 담당자 근무여부(휴무 판정)는 날짜에만 의존 — 선택 담당자와 무관하게 항상 반환.
     const assigneeStatus = assignees.map((a) => ({id: a.id, working: assigneeWorksOnDay(a, dayIndex)}));
 
-    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const closedDates = closedRows.map((c) => toDateKey(c.date));
     const window = evaluateDateWindow(dateStr, settings, closedDates);
 
     const bh = businessHour

--- a/server/api/book/[slug]/lookup.ts
+++ b/server/api/book/[slug]/lookup.ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../db/prisma';
+import {toDateKey} from '../../../db/mappers';
 import {normalizeTel} from '../../../../client/features/customers/model';
 import {findBookableStore, nowKst} from '../booking-helpers';
 
@@ -62,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         reservations: rows.map((r) => ({
             token: r.publicToken,
             status: r.status,
-            date: r.date.toISOString().slice(0, 10),
+            date: toDateKey(r.date),
             startTime: r.startTime,
             endTime: r.endTime,
             serviceSummary: r.serviceSummary,

--- a/server/api/book/[slug]/reserve.ts
+++ b/server/api/book/[slug]/reserve.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../db/prisma';
+import {toDateKey} from '../../../db/mappers';
 import {normalizeTel} from '../../../../client/features/customers/model';
 import {calcEndTime, joinServiceNames} from '../../../../client/features/services/model';
 import {areServicesBookable} from '../../../../client/features/store-settings/model';
@@ -86,7 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const endTime = calcEndTime(startTime, durationMin);
     const serviceSummary = joinServiceNames(serviceNames);
 
-    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const closedDates = closedRows.map((c) => toDateKey(c.date));
     const window = evaluateDateWindow(dateStr, settings, closedDates);
     if (!window.ok) return res.status(409).json({error: 'unavailable_date'});
 

--- a/server/api/book/reservation/[token].ts
+++ b/server/api/book/reservation/[token].ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {findReservationByPublicToken, loadBookingSettings} from '../booking-helpers';
+import {toDateKey} from '../../../db/mappers';
 
 // 공개(비로그인) 예약 조회. 관리 링크 토큰으로만 접근하며, 고객 본인 예약의 최소 정보만 반환한다.
 // 다른 고객·매장 데이터는 절대 노출하지 않는다(토큰이 곧 접근 권한).
@@ -28,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json({
         status: reservation.status,
-        date: reservation.date.toISOString().slice(0, 10),
+        date: toDateKey(reservation.date),
         startTime: reservation.startTime,
         endTime: reservation.endTime,
         serviceSummary: reservation.serviceSummary,

--- a/server/api/book/reservation/[token]/request-cancel.ts
+++ b/server/api/book/reservation/[token]/request-cancel.ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../../db/prisma';
+import {toDateKey} from '../../../../db/mappers';
 import {notifySlackForStore} from '../../../../notify/slack';
 import {findReservationByPublicToken} from '../../booking-helpers';
 
@@ -26,7 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // 오너 알림(커밋 후 격리 — 실패해도 요청 접수 성공에 영향 없음)
     try {
         await notifySlackForStore(reservation.storeId,
-            `🔔 *예약 취소 요청*\n• 날짜: ${reservation.date.toISOString().slice(0, 10)}`
+            `🔔 *예약 취소 요청*\n• 날짜: ${toDateKey(reservation.date)}`
             + `\n• 시간: ${reservation.startTime}~${reservation.endTime}`
             + `\n• 시술: ${reservation.serviceSummary}`
             + `\n• 고객: ${reservation.customer?.name ?? ''}${reservation.customer?.tel ? ` (${reservation.customer.tel})` : ''}`

--- a/server/api/book/reservation/[token]/request-change.ts
+++ b/server/api/book/reservation/[token]/request-change.ts
@@ -1,6 +1,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 
 import {prisma} from '../../../../db/prisma';
+import {toDateKey} from '../../../../db/mappers';
 import {notifySlackForStore} from '../../../../notify/slack';
 import {calcEndTime, joinServiceNames} from '../../../../../client/features/services/model';
 import {areServicesBookable} from '../../../../../client/features/store-settings/model';
@@ -74,7 +75,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const endTime = calcEndTime(startTime, durationMin);
     const serviceSummary = joinServiceNames(serviceNames);
 
-    const closedDates = closedRows.map((c) => c.date.toISOString().slice(0, 10));
+    const closedDates = closedRows.map((c) => toDateKey(c.date));
     const window = evaluateDateWindow(dateStr, settings, closedDates);
     if (!window.ok) return res.status(409).json({error: 'unavailable_date'});
 
@@ -113,7 +114,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     try {
         await notifySlackForStore(storeId,
-            `🔔 *예약 변경 요청*\n• 기존: ${reservation.date.toISOString().slice(0, 10)} ${reservation.startTime}~${reservation.endTime} (${reservation.serviceSummary})`
+            `🔔 *예약 변경 요청*\n• 기존: ${toDateKey(reservation.date)} ${reservation.startTime}~${reservation.endTime} (${reservation.serviceSummary})`
             + `\n• 변경: ${dateStr} ${startTime}~${endTime} (${serviceSummary})`
             + `\n• 고객: ${reservation.customer?.name ?? ''}${reservation.customer?.tel ? ` (${reservation.customer.tel})` : ''}`
             + `\n앱에서 수락/거절해 주세요.`,

--- a/server/db/mappers.ts
+++ b/server/db/mappers.ts
@@ -106,7 +106,7 @@ export function frontendReservationStatusToDb(status: string | undefined): DbRes
 
 // ── Date Helpers ──
 
-function toDateKey(d: Date): string {
+export function toDateKey(d: Date): string {
     const y = d.getFullYear();
     const m = String(d.getMonth() + 1).padStart(2, '0');
     const day = String(d.getDate()).padStart(2, '0');


### PR DESCRIPTION
## Summary
Fixes a timezone-related bug where store closed dates were off by one day in the public booking API, causing customers to bypass closure restrictions. The root cause was inconsistent date serialization: the app stores dates using local timezone parsing but the public booking APIs were reading them using UTC `.toISOString()`, causing a one-day shift on non-UTC servers (e.g., KST).

## Changes
- **Export `toDateKey` helper** (`server/db/mappers.ts`): Made the existing date normalization function public so all date reads use a consistent, timezone-independent approach.
- **Unify date reading across public booking APIs** to use `toDateKey()` instead of `.toISOString().slice(0,10)`:
  - Closed date comparisons (A): `book/[slug].ts`, `book/[slug]/availability.ts`, `book/[slug]/reserve.ts`, `book/[slug]/day.ts`, `book/reservation/[token]/request-change.ts`
  - Reservation date display (B): `book/[slug]/lookup.ts`, `book/reservation/[token].ts`, `request-change.ts` (Slack), `request-cancel.ts` (Slack), `book-requests.ts` (owner list)
- **Preserve intentional behavior**: `booking-helpers.nowKst()` continues to use UTC extraction on KST-shifted instants (correct by design).
- **Update documentation** (`index.md`): Added date column handling rules to prevent future regressions.
- **Bump version** (`client/package.json`): 0.37.0 → 0.37.1 (patch).

## Implementation Details
- **No schema or migration changes**: The fix is code-only. Date storage format remains unchanged; only the read path is corrected.
- **Verified across timezones**: Simulation confirms the fix works correctly in UTC, Asia/Seoul, and America/New_York.
- **Type-safe**: Full `tsc --noEmit` and `next build` validation passed.

Closes #<issue-number>

https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws