### PR TITLE
feat(notice): 매장 공지사항 (고객 예약 페이지 노출, 4개국어)

### DIFF
--- a/client/components/layout/Aside.tsx
+++ b/client/components/layout/Aside.tsx
@@ -54,6 +54,7 @@ const SETTINGS_SUBMENU = [
     {tab: 'membership', href: '/settings/membership', label: '회원권 관리', icon: 'membership'},
     {tab: 'coupon', href: '/settings/coupon', label: '쿠폰 관리', icon: 'coupon'},
     {tab: 'booking', href: '/settings/booking', label: '고객 예약 설정', icon: 'booking'},
+    {tab: 'notice', href: '/settings/notice', label: '공지사항 관리', icon: 'notice'},
     {tab: 'service', href: '/settings/service', label: '서비스 관리', icon: 'service'},
     {tab: 'assignee', href: '/settings/assignee', label: '담당자 관리', icon: 'assignee'},
     {tab: 'customers', href: '/address', label: '고객 명단', icon: 'customers'},
@@ -252,6 +253,7 @@ export const Aside = () => {
                                 if (item.tab === 'membership') return useMembershipSystem;
                                 if (item.tab === 'coupon') return useCouponSystem;
                                 if (item.tab === 'booking') return useOnlineBooking;
+                                if (item.tab === 'notice') return useOnlineBooking;
                                 return true;
                             }).map((item) =>
                                 <StyledSubNavLink href={item.href}

--- a/client/components/layout/AsideMenuIcon.tsx
+++ b/client/components/layout/AsideMenuIcon.tsx
@@ -183,6 +183,13 @@ export const AsideMenuIcon = ({icon}: {icon: string}) => {
                     <path d="M12 7V12L15 15" />
                 </StyledMenuIcon>
             );
+        case 'notice':
+            return (
+                <StyledMenuIcon viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M12 4C9.2 4 7 6.2 7 9V13L5.5 16H18.5L17 13V9C17 6.2 14.8 4 12 4Z" />
+                    <path d="M10 18C10 19.1 10.9 20 12 20C13.1 20 14 19.1 14 18" />
+                </StyledMenuIcon>
+            );
         default:
             return (
                 <StyledMenuIcon viewBox="0 0 24 24" aria-hidden="true">

--- a/client/components/settings/NoticeManageSection.tsx
+++ b/client/components/settings/NoticeManageSection.tsx
@@ -1,0 +1,382 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import styled from 'styled-components';
+
+import {PageHero} from '../ui/PageHero';
+import {FieldError} from '../ui/FieldError';
+import {LocalizedMessageField} from '../ui/LocalizedMessageField';
+import {StyledEditBtn, StyledDeleteBtn, StyledSaveBtn, StyledCancelBtn, StyledEmpty, EMPTY_TEXT} from './settings-styles';
+import {useToastStore} from '../../store/toastStore';
+import {shouldUseLocalDb} from '../../lib/local-db';
+import {NOTICE_CATEGORIES, noticeCategoryLabel} from '../../features/notices/model';
+import type {StoreNotice, NoticeCategory, NoticeI18n} from '../../features/notices/model';
+
+interface DraftForm {
+    category: NoticeCategory;
+    title: string;
+    titleI18n: NoticeI18n | null;
+    body: string;
+    bodyI18n: NoticeI18n | null;
+    visible: boolean;
+}
+
+const EMPTY_DRAFT: DraftForm = {category: 'notice', title: '', titleI18n: null, body: '', bodyI18n: null, visible: true};
+
+function formatDate(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export const NoticeManageSection = () => {
+    const toast = useToastStore((s) => s.show);
+    const isLocal = shouldUseLocalDb();
+
+    const [notices, setNotices] = useState<StoreNotice[]>([]);
+    const [loading, setLoading] = useState(!isLocal);
+
+    const [isAdding, setIsAdding] = useState(false);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [draft, setDraft] = useState<DraftForm>(EMPTY_DRAFT);
+    const [error, setError] = useState('');
+
+    const fetchData = useCallback(async () => {
+        if (isLocal) return;
+        setLoading(true);
+        try {
+            const res = await fetch('/api/notices');
+            if (!res.ok) throw new Error();
+            const data = await res.json() as {notices: StoreNotice[]};
+            setNotices(data.notices ?? []);
+        } catch {
+            toast('공지사항을 불러오지 못했습니다.', 'error');
+        } finally {
+            setLoading(false);
+        }
+    }, [isLocal, toast]);
+
+    useEffect(() => {
+        void fetchData();
+    }, [fetchData]);
+
+    const resetForm = () => {
+        setDraft(EMPTY_DRAFT);
+        setError('');
+        setIsAdding(false);
+        setEditingId(null);
+    };
+
+    const startAdd = () => {
+        setIsAdding(true);
+        setEditingId(null);
+        setDraft(EMPTY_DRAFT);
+        setError('');
+    };
+
+    const startEdit = (n: StoreNotice) => {
+        setEditingId(n.id);
+        setIsAdding(false);
+        setError('');
+        setDraft({
+            category: n.category,
+            title: n.title,
+            titleI18n: n.titleI18n ?? null,
+            body: n.body,
+            bodyI18n: n.bodyI18n ?? null,
+            visible: n.visible,
+        });
+    };
+
+    const handleSave = async () => {
+        const title = draft.title.trim();
+        const body = draft.body.trim();
+        if (!title) {
+            setError('제목을 입력해 주세요.');
+            return;
+        }
+        if (!body) {
+            setError('내용을 입력해 주세요.');
+            return;
+        }
+        const payload = {
+            category: draft.category,
+            title,
+            titleI18n: draft.titleI18n,
+            body,
+            bodyI18n: draft.bodyI18n,
+            visible: draft.visible,
+        };
+        try {
+            const res = await fetch('/api/notices', {
+                method: editingId ? 'PUT' : 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(editingId ? {id: editingId, ...payload} : payload),
+            });
+            if (!res.ok) throw new Error();
+            toast(editingId ? '공지사항이 수정되었습니다.' : '공지사항이 추가되었습니다.');
+            resetForm();
+            await fetchData();
+        } catch {
+            toast('저장에 실패했습니다.', 'error');
+        }
+    };
+
+    const handleDelete = async (n: StoreNotice) => {
+        try {
+            const res = await fetch('/api/notices', {
+                method: 'DELETE',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({id: n.id}),
+            });
+            if (!res.ok) throw new Error();
+            toast('공지사항이 삭제되었습니다.', 'info');
+            await fetchData();
+        } catch {
+            toast('삭제에 실패했습니다.', 'error');
+        }
+    };
+
+    const editing = isAdding || editingId !== null;
+
+    return (
+        <StyledWrap>
+            <PageHero
+                eyebrow="NOTICE"
+                title="공지사항 관리"
+                subtitle="고객 예약 페이지에 노출되는 공지사항입니다. 공개로 둔 항목만 고객에게 보입니다."
+            />
+
+            {isLocal ? (
+                <StyledEmpty>공지사항은 로그인 후 이용할 수 있습니다.</StyledEmpty>
+            ) : (
+                <>
+                    <StyledToolbar>
+                        {!editing && (
+                            <StyledEditBtn type="button" onClick={startAdd}>공지 추가</StyledEditBtn>
+                        )}
+                    </StyledToolbar>
+
+                    {editing && (
+                        <StyledFormCard>
+                            <StyledTopRow>
+                                <StyledField htmlFor="nt-category">
+                                    <span>분류</span>
+                                    <StyledSelect id="nt-category" value={draft.category}
+                                        onChange={(e) => setDraft((d) => ({...d, category: e.target.value as NoticeCategory}))}>
+                                        {NOTICE_CATEGORIES.map((c) => (
+                                            <option key={c.value} value={c.value}>{c.label}</option>
+                                        ))}
+                                    </StyledSelect>
+                                </StyledField>
+                                <StyledCheckboxRow htmlFor="nt-visible">
+                                    <input id="nt-visible" type="checkbox" checked={draft.visible}
+                                        onChange={(e) => setDraft((d) => ({...d, visible: e.target.checked}))} />
+                                    <span>공개 (고객 페이지에 노출)</span>
+                                </StyledCheckboxRow>
+                            </StyledTopRow>
+
+                            <LocalizedMessageField
+                                idBase="nt-title"
+                                label="제목"
+                                placeholder="예: 여름 휴가 안내"
+                                multiline={false}
+                                mainValue={draft.title}
+                                i18nValue={draft.titleI18n}
+                                onMainChange={(v) => {setDraft((d) => ({...d, title: v})); setError('');}}
+                                onI18nChange={(next) => setDraft((d) => ({...d, titleI18n: next}))}
+                            />
+
+                            <LocalizedMessageField
+                                idBase="nt-body"
+                                label="내용"
+                                caption="번역을 비우면 한국어가 그대로 노출됩니다."
+                                placeholder="예: 8/1(금)~8/5(화) 휴무합니다."
+                                mainValue={draft.body}
+                                i18nValue={draft.bodyI18n}
+                                onMainChange={(v) => {setDraft((d) => ({...d, body: v})); setError('');}}
+                                onI18nChange={(next) => setDraft((d) => ({...d, bodyI18n: next}))}
+                            />
+
+                            <FieldError variant="inline">{error}</FieldError>
+                            <StyledActionRow>
+                                <StyledCancelBtn type="button" onClick={resetForm}>취소</StyledCancelBtn>
+                                <StyledSaveBtn type="button" onClick={handleSave}>저장</StyledSaveBtn>
+                            </StyledActionRow>
+                        </StyledFormCard>
+                    )}
+
+                    {loading ? (
+                        <StyledEmpty>{EMPTY_TEXT}</StyledEmpty>
+                    ) : notices.length === 0 ? (
+                        <StyledEmpty>등록된 공지사항이 없습니다.</StyledEmpty>
+                    ) : (
+                        <StyledList>
+                            {notices.map((n) => (
+                                <StyledItem key={n.id}>
+                                    <StyledItemMain>
+                                        <StyledItemTop>
+                                            <StyledChip data-category={n.category}>{noticeCategoryLabel(n.category)}</StyledChip>
+                                            <StyledItemName>{n.title}</StyledItemName>
+                                            {!n.visible && <StyledHiddenBadge>비공개</StyledHiddenBadge>}
+                                        </StyledItemTop>
+                                        <StyledItemBody>{n.body}</StyledItemBody>
+                                        <StyledItemDate>{formatDate(n.createdAt)}</StyledItemDate>
+                                    </StyledItemMain>
+                                    {!editing && (
+                                        <StyledItemActions>
+                                            <StyledEditBtn type="button" onClick={() => startEdit(n)}>수정</StyledEditBtn>
+                                            <StyledDeleteBtn type="button" onClick={() => handleDelete(n)}>삭제</StyledDeleteBtn>
+                                        </StyledItemActions>
+                                    )}
+                                </StyledItem>
+                            ))}
+                        </StyledList>
+                    )}
+                </>
+            )}
+        </StyledWrap>
+    );
+};
+
+const StyledWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+`;
+
+const StyledToolbar = styled.div`
+    display: flex;
+    justify-content: flex-end;
+`;
+
+const StyledFormCard = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px 10px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 10px;
+    background: var(--white-color);
+`;
+
+const StyledTopRow = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+`;
+
+const StyledField = styled.label`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--dark-gray-color2);
+`;
+
+const StyledSelect = styled.select`
+    height: 42px;
+    padding: 0 12px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 8px;
+    font-size: 14px;
+    color: var(--black-color);
+    background: var(--white-color);
+    box-sizing: border-box;
+    cursor: pointer;
+
+    &:focus { outline: none; border-color: var(--blue-color); }
+`;
+
+const StyledCheckboxRow = styled.label`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 18px;
+    font-size: 13px;
+    color: var(--dark-gray-color);
+    cursor: pointer;
+`;
+
+const StyledActionRow = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+`;
+
+const StyledList = styled.div`
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--black-color-10);
+`;
+
+const StyledItem = styled.div`
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 4px;
+    border-bottom: 1px solid var(--black-color-10);
+`;
+
+const StyledItemMain = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+`;
+
+const StyledItemTop = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+`;
+
+const StyledChip = styled.span`
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 6px;
+    color: var(--blue-color);
+    background: var(--blue-color-10, rgba(59, 91, 219, 0.1));
+
+    &[data-category='event'] { color: var(--brand-color); background: var(--brand-color-10, rgba(138, 75, 176, 0.12)); }
+    &[data-category='info'] { color: var(--green-color, #16a34a); background: rgba(22, 163, 74, 0.1); }
+`;
+
+const StyledItemName = styled.strong`
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--black-color);
+`;
+
+const StyledHiddenBadge = styled.span`
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 6px;
+    color: var(--dark-gray-color2);
+    background: var(--black-color-10);
+`;
+
+const StyledItemBody = styled.span`
+    font-size: 13px;
+    color: var(--dark-gray-color);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+`;
+
+const StyledItemDate = styled.span`
+    font-size: 12px;
+    color: var(--dark-gray-color2);
+    font-variant-numeric: tabular-nums;
+`;
+
+const StyledItemActions = styled.div`
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+`;

--- a/client/components/ui/LocalizedMessageField.tsx
+++ b/client/components/ui/LocalizedMessageField.tsx
@@ -1,0 +1,123 @@
+import styled from 'styled-components';
+
+export type LocalizedI18n = {en?: string; ja?: string; zh?: string} | null | undefined;
+
+const MESSAGE_LANGS = [['en', 'English'], ['ja', '日本語'], ['zh', '中文']] as const;
+
+// 오너 입력 문구 1개 = 한국어 본문 + 언어별(영/일/중) 번역. 예약 안내문구·공지사항이 공용으로 쓴다.
+// 언어칸을 비우면 해당 키를 지워, 완전히 비면 i18n을 null로(한국어 폴백) 유지한다.
+// multiline=false면 한 줄 입력(제목 등), true면 여러 줄(본문).
+export function LocalizedMessageField({
+    idBase, label, caption, placeholder, mainValue, i18nValue, disabled = false, multiline = true,
+    onMainChange, onI18nChange,
+}: {
+    idBase: string;
+    label: string;
+    caption?: string;
+    placeholder: string;
+    mainValue: string;
+    i18nValue: LocalizedI18n;
+    disabled?: boolean;
+    multiline?: boolean;
+    onMainChange: (value: string) => void;
+    onI18nChange: (next: {en?: string; ja?: string; zh?: string} | null) => void;
+}) {
+    const setLangValue = (code: 'en' | 'ja' | 'zh', value: string) => {
+        const next = {...(i18nValue ?? {})};
+        if (value.trim()) next[code] = value; else delete next[code];
+        onI18nChange(Object.keys(next).length > 0 ? next : null);
+    };
+    return (
+        <StyledMessageBlock>
+            <StyledField>
+                <StyledLabel htmlFor={`${idBase}-ko`}>{label}</StyledLabel>
+                {caption ? <StyledFieldCaption>{caption}</StyledFieldCaption> : null}
+                <FieldControl id={`${idBase}-ko`} multiline={multiline} value={mainValue}
+                    placeholder={placeholder} disabled={disabled} rows={3} onChange={onMainChange} />
+            </StyledField>
+            {MESSAGE_LANGS.map(([code, langLabel]) => (
+                <StyledField key={code}>
+                    <StyledLabel htmlFor={`${idBase}-${code}`}>{langLabel}</StyledLabel>
+                    <FieldControl id={`${idBase}-${code}`} multiline={multiline} value={i18nValue?.[code] ?? ''}
+                        placeholder={langLabel} disabled={disabled} rows={2} onChange={(v) => setLangValue(code, v)} />
+                </StyledField>
+            ))}
+        </StyledMessageBlock>
+    );
+}
+
+function FieldControl({id, multiline, value, placeholder, disabled, rows, onChange}: {
+    id: string; multiline: boolean; value: string; placeholder: string;
+    disabled: boolean; rows: number; onChange: (v: string) => void;
+}) {
+    if (multiline) {
+        return (
+            <StyledTextarea id={id} value={value} placeholder={placeholder} disabled={disabled}
+                rows={rows} onChange={(e) => onChange(e.target.value)} />
+        );
+    }
+    return (
+        <StyledInput id={id} value={value} placeholder={placeholder} disabled={disabled}
+            onChange={(e) => onChange(e.target.value)} />
+    );
+}
+
+// 본문+번역 한 종을 시각적으로 묶는다. 종끼리 구분선으로 나눠 가독성 확보.
+const StyledMessageBlock = styled.div`
+    margin-top: 8px;
+    padding-top: 8px;
+
+    & + & {
+        margin-top: 18px;
+        padding-top: 18px;
+        border-top: 1px solid var(--light-gray-color);
+    }
+`;
+
+const StyledField = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 14px;
+`;
+
+const StyledLabel = styled.label`
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--dark-gray-color);
+`;
+
+const StyledFieldCaption = styled.span`
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--dark-gray-color2);
+`;
+
+const StyledTextarea = styled.textarea`
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 8px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--black-color);
+    background: var(--white-color);
+    box-sizing: border-box;
+    resize: none;
+
+    &:focus { outline: none; border-color: var(--blue-color); }
+`;
+
+const StyledInput = styled.input`
+    width: 100%;
+    height: 42px;
+    padding: 0 12px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: 8px;
+    font-size: 14px;
+    color: var(--black-color);
+    background: var(--white-color);
+    box-sizing: border-box;
+
+    &:focus { outline: none; border-color: var(--blue-color); }
+`;

--- a/client/features/booking/i18n.ts
+++ b/client/features/booking/i18n.ts
@@ -284,6 +284,9 @@ export interface BookI18n {
     decisionReasonLabel: string;
     decisionApprovedDefault: string;
     decisionCancelledDefault: string;
+    // 공지사항(공개 예약 페이지 노출)
+    noticeSectionTitle: string;
+    noticeCategories: {notice: string; event: string; info: string};
     // 완료화면/조회 상태 라벨은 statusLabelL/lookupStatusL 사용
 }
 
@@ -365,6 +368,8 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         decisionReasonLabel: '매장 안내',
         decisionApprovedDefault: '예약이 승인되었습니다.',
         decisionCancelledDefault: '예약이 취소되었습니다.',
+        noticeSectionTitle: '공지사항',
+        noticeCategories: {notice: '공지', event: '이벤트', info: '안내'},
     },
     en: {
         loading: 'Loading…',
@@ -443,6 +448,8 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         decisionReasonLabel: 'Message from the store',
         decisionApprovedDefault: 'Your reservation has been confirmed.',
         decisionCancelledDefault: 'Your reservation has been cancelled.',
+        noticeSectionTitle: 'Notices',
+        noticeCategories: {notice: 'Notice', event: 'Event', info: 'Info'},
     },
     zh: {
         loading: '加载中…',
@@ -521,6 +528,8 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         decisionReasonLabel: '门店说明',
         decisionApprovedDefault: '您的预约已确认。',
         decisionCancelledDefault: '您的预约已取消。',
+        noticeSectionTitle: '公告',
+        noticeCategories: {notice: '公告', event: '活动', info: '须知'},
     },
     ja: {
         loading: '読み込み中…',
@@ -599,5 +608,7 @@ export const BOOK_STRINGS: Record<BookLang, BookI18n> = {
         decisionReasonLabel: '店舗からのご案内',
         decisionApprovedDefault: 'ご予約が確定しました。',
         decisionCancelledDefault: 'ご予約がキャンセルされました。',
+        noticeSectionTitle: 'お知らせ',
+        noticeCategories: {notice: 'お知らせ', event: 'イベント', info: 'ご案内'},
     },
 };

--- a/client/features/notices/model.ts
+++ b/client/features/notices/model.ts
@@ -1,0 +1,30 @@
+// 매장 공지사항(공개 예약 페이지 노출). 오너 관리, id는 서버 cuid.
+export type NoticeCategory = 'notice' | 'event' | 'info';
+
+export interface NoticeI18n {
+    en?: string;
+    ja?: string;
+    zh?: string;
+}
+
+export interface StoreNotice {
+    id: string;
+    category: NoticeCategory;
+    title: string;
+    titleI18n?: NoticeI18n | null;
+    body: string;
+    bodyI18n?: NoticeI18n | null;
+    visible: boolean;
+    createdAt: string; // ISO
+}
+
+// 오너 관리 화면 카테고리 라벨(한국어). 고객 페이지 라벨은 booking/i18n.ts에서 4개국어로 별도 관리.
+export const NOTICE_CATEGORIES: {value: NoticeCategory; label: string}[] = [
+    {value: 'notice', label: '공지'},
+    {value: 'event', label: '이벤트'},
+    {value: 'info', label: '안내'},
+];
+
+export function noticeCategoryLabel(category: string): string {
+    return NOTICE_CATEGORIES.find((c) => c.value === category)?.label ?? '공지';
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/pages/api/notices.ts
+++ b/client/pages/api/notices.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../server/api/notices';

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -39,6 +39,14 @@ interface BookBusinessHour {
     closeTime: string;
     enabled: boolean;
 }
+interface BookNotice {
+    category: string;
+    title: string;
+    titleI18n?: I18nText;
+    body: string;
+    bodyI18n?: I18nText;
+    createdAt: string;
+}
 interface BookStoreInfo {
     storeName: string;
     storeNameI18n?: I18nText;
@@ -48,6 +56,7 @@ interface BookStoreInfo {
     businessHours: BookBusinessHour[];
     closedDates: string[];
     settings: {allowAssigneeChoice: boolean; noticeText: string | null; noticeI18n?: I18nText; doneText?: string | null; doneI18n?: I18nText; maxAdvanceDays: number};
+    notices: BookNotice[];
 }
 interface ReserveResult {
     publicToken: string;
@@ -359,6 +368,7 @@ export default function BookingPage() {
     const storeDisplay = pickI18n(info.storeNameI18n, lang, info.storeName);
     const noticeDisplay = pickI18n(info.settings.noticeI18n, lang, info.settings.noticeText ?? '');
     const doneDisplay = pickI18n(info.settings.doneI18n, lang, info.settings.doneText ?? '');
+    const noticeCat = (c: string): string => t.noticeCategories[c as 'notice' | 'event' | 'info'] ?? t.noticeCategories.notice;
 
     if (result) {
         return (
@@ -390,6 +400,21 @@ export default function BookingPage() {
                     <StyledStore>{storeDisplay}</StyledStore>
                     <StyledTitle>{t.homeTitle}</StyledTitle>
                     {noticeDisplay && <StyledNotice>{noticeDisplay}</StyledNotice>}
+                    {info.notices.length > 0 && (
+                        <StyledNoticeBoard>
+                            <StyledNoticeHead>{t.noticeSectionTitle}</StyledNoticeHead>
+                            {info.notices.map((n, i) => (
+                                <StyledNoticeItem key={i} open={i === 0}>
+                                    <StyledNoticeSummary>
+                                        <StyledNoticeChip data-category={n.category}>{noticeCat(n.category)}</StyledNoticeChip>
+                                        <StyledNoticeItemTitle>{pickI18n(n.titleI18n, lang, n.title)}</StyledNoticeItemTitle>
+                                        <StyledNoticeChevron aria-hidden="true">⌄</StyledNoticeChevron>
+                                    </StyledNoticeSummary>
+                                    <StyledNoticeBody>{pickI18n(n.bodyI18n, lang, n.body)}</StyledNoticeBody>
+                                </StyledNoticeItem>
+                            ))}
+                        </StyledNoticeBoard>
+                    )}
                     <StyledHomeActions>
                         <StyledHomeBtn type="button" $primary onClick={() => goView('new')}>
                             <span className="t">{t.newReservation}</span>
@@ -719,6 +744,69 @@ const StyledNotice = styled.p`
     font-size: var(--small-font);
     line-height: 1.5;
     color: var(--dark-gray-color);
+`;
+const StyledNoticeBoard = styled.div`
+    margin-top: 4px;
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+`;
+const StyledNoticeHead = styled.div`
+    padding: 10px 12px;
+    background: var(--brand-color-bg);
+    font-size: var(--small-font);
+    font-weight: 700;
+    color: var(--brand-color);
+`;
+const StyledNoticeChip = styled.span`
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 6px;
+    color: var(--brand-color);
+    background: var(--brand-color-bg);
+
+    &[data-category='event'] { color: #8a4bb0; background: rgba(138, 75, 176, 0.12); }
+    &[data-category='info'] { color: #16a34a; background: rgba(22, 163, 74, 0.1); }
+`;
+const StyledNoticeItemTitle = styled.span`
+    flex: 1;
+    min-width: 0;
+    font-size: var(--small-font);
+    font-weight: 600;
+    color: var(--black-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+const StyledNoticeChevron = styled.span`
+    flex-shrink: 0;
+    color: var(--dark-gray-color2);
+    transition: transform 0.2s ease;
+`;
+const StyledNoticeSummary = styled.summary`
+    list-style: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+
+    &::-webkit-details-marker { display: none; }
+`;
+const StyledNoticeItem = styled.details`
+    & + & { border-top: 1px solid var(--light-gray-color); }
+    &[open] ${StyledNoticeChevron} { transform: rotate(180deg); }
+`;
+const StyledNoticeBody = styled.p`
+    margin: 0;
+    padding: 0 12px 12px;
+    font-size: var(--small-font);
+    line-height: 1.5;
+    color: var(--dark-gray-color);
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
 `;
 
 const StyledSectionLabel = styled.strong`

--- a/client/pages/settings.tsx
+++ b/client/pages/settings.tsx
@@ -27,6 +27,7 @@ import {NaverBookingSection} from '../components/settings/NaverBookingSection';
 import {SNSLinkingSection} from '../components/settings/SNSLinkingSection';
 import {StoreManageSection} from '../components/settings/StoreManageSection';
 import {BookingManageSection} from '../components/settings/BookingManageSection';
+import {NoticeManageSection} from '../components/settings/NoticeManageSection';
 
 import {loadLocalDbSnapshot, subscribeLocalDb, type LocalDbSnapshot} from '../lib/local-db';
 import {getPageSession, loadPageData} from '../lib/page-data';
@@ -40,7 +41,7 @@ type SettingsProps = {
     storageMode: 'remote' | 'local';
 };
 
-type SettingsTab = 'revenue' | 'point' | 'membership' | 'coupon' | 'booking' | 'service' | 'assignee' | 'store' | 'member' | 'sns' | 'naver';
+type SettingsTab = 'revenue' | 'point' | 'membership' | 'coupon' | 'booking' | 'notice' | 'service' | 'assignee' | 'store' | 'member' | 'sns' | 'naver';
 
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -62,7 +63,7 @@ function shiftDateKey(baseDate: Date, days: number): string {
 }
 
 function isSettingsTab(value: string): value is SettingsTab {
-    return value === 'revenue' || value === 'point' || value === 'membership' || value === 'coupon' || value === 'booking' || value === 'service' || value === 'assignee' || value === 'store' || value === 'member' || value === 'sns' || value === 'naver';
+    return value === 'revenue' || value === 'point' || value === 'membership' || value === 'coupon' || value === 'booking' || value === 'notice' || value === 'service' || value === 'assignee' || value === 'store' || value === 'member' || value === 'sns' || value === 'naver';
 }
 
 /* ── Service Manage Section ── */
@@ -261,6 +262,7 @@ const Settings: NextPage<SettingsProps> = ({reservations, customers, history, st
                 {tab === 'membership' && <MembershipManageSection />}
                 {tab === 'coupon' && <CouponManageSection />}
                 {tab === 'booking' && <BookingManageSection />}
+                {tab === 'notice' && <NoticeManageSection />}
                 {tab === 'store' && <StoreManageSection formatDateLabel={formatDateLabel}/>}
                 {tab === 'service' && <ServiceManageSection/>}
                 {tab === 'assignee' && <AssigneeManageSection/>}

--- a/index.md
+++ b/index.md
@@ -94,6 +94,7 @@ hair_reservations/
 [^22]: 쿠폰 관리는 `Store.useCouponSystem` 토글 ON일 때만 aside 메뉴·`/settings/coupon` 탭 노출. **Phase 1만 구현** — 상품(정액 amount/정률 rate, maxDiscount·minOrderAmount·validDays·code) CRUD(`/api/coupons` owner, `server/api/coupons.ts`). **발급(직접·코드형, Phase 2)·결제 자동 차감(`PaymentMethod.coupon`, Phase 3)은 미구현.** 회원권 시스템 패턴 미러링
 [^24]: **고객 예약 페이지 다국어**: 공개 페이지(`book/[slug].tsx`·`book/[slug]/r/[token].tsx`)만 대상. 언어 전환기는 **하단 고정 바**(`components/booking/LangSwitcher.tsx`, 네이티브 `<select>`) — 같은 경로에서 즉시 전환, `useBookLang` 훅이 localStorage(`tas-book-lang`) 영속 + `navigator.language` 자동감지 + `<html lang>` 동기화(`useSyncExternalStore`로 SSR 안전). 예약 sticky 요약 바는 `LANG_BAR_OFFSET`만큼 위로 띄워 겹침 방지. 서버 API·스키마 무변경(코드-온리). 전역 `formatDuration`(features/services)은 앱 전반 사용이라 미수정 — 예약 전용 `formatDurationL` 신설.
 [^23]: **고객 공개 온라인 예약**(`Store.useOnlineBooking` ON + `bookingSlug` 매장만). 공개 구역은 비로그인 — `proxy.ts`/`_app.tsx`/`LayoutComponent`가 `/book/*`를 인증·게이트에서 제외. 공개 API(`server/api/book/*`)는 **매장 스코프 + 데이터 최소 노출**(고객/예약 정보 절대 미반환). 페이지 `pages/book/[slug].tsx`: 서비스·담당자·날짜·시간 선택 + 이름/연락처 → 예약 생성 → `publicToken` 발급(고객 관리 링크 `/book/[slug]/r/[token]`는 Phase 1d). 슬롯 계산은 `features/booking/availability.ts` 순수함수, 예약 생성은 트랜잭션(Serializable) 슬롯 재검증으로 동시성 방어. **노출 서비스 선택(1c)**: 오너가 `/settings/booking`에서 공개할 서비스만 선택(`BookingSettings.bookableServiceNames`→DB `bookableServiceIdsJson`), 공개 API가 필터·거부(`not_bookable`). **Phase 1c까지 구현**(공개정보·슬롯·예약생성·노출서비스). 확인/변경/취소(1d, Phase 2)·알림(1f, Phase 3)·서브도메인 rewrite(1e)는 미구현. 마이그레이션 `0008`(채널·토글·슬러그·규칙)·`0009`(`Reservation.publicToken`·`StoreBookingSettings.bookableServiceIdsJson`)
+[^25]: **매장 공지사항**(`StoreNotice`, 마이그레이션 `0015`). 오너가 `/settings/notice`(aside '공지사항 관리', `useOnlineBooking` ON일 때만 노출)에서 CRUD — 제목·내용·카테고리(공지/이벤트/안내)·공개여부, 제목/내용 4개국어(`titleI18nJson`/`bodyI18nJson`, `LocalizedMessageField` 공용). 고객 예약 페이지(`book/[slug].tsx`) 랜딩에 visible 공지만 최신순 아코디언(`<details>`)으로 노출. 공개 API(`book/[slug].ts`)는 테이블 미존재 시 `[]` 방어(마이그레이션 지연 무중단). 새 Store 토글 없이 `useOnlineBooking` 재사용
 
 ### 도메인 모델 (`client/features/`)
 
@@ -205,6 +206,7 @@ NextAuth 5.0 설정. Google·Kakao·Naver OAuth 지원.
 | `membership-issue.ts` | `/api/membership-issue` | POST(staff) | - | 고객에게 회원권 발급/취소 (상품 스냅샷 → CustomerMembership) |
 | `membership-use.ts` | `/api/membership-use` | POST(staff) | - | 회원권 횟수 수동 차감/복원 (결제 흐름과 독립, MembershipUsage 기록) |
 | `coupons.ts` | `/api/coupons` | GET(staff) / POST·PUT·DELETE(owner) | - | 쿠폰 상품(정액/정률) CRUD. 코드형 중복 시 409. 발급분 있으면 DELETE=보관(archive). 발급·결제차감 미구현(Phase 1) |
+| `notices.ts` | `/api/notices` | GET(staff) / POST·PUT·DELETE(owner) | - | 매장 공지사항 CRUD(제목·내용·카테고리[notice/event/info]·공개여부 visible, 제목/내용 4개국어). 공개 노출은 `book/[slug]`가 visible=true만 반환(방어적 조회) |
 | `book/[slug].ts` | `/api/book/[slug]` | GET | **공개(비로그인)** | 온라인예약 매장 공개정보(매장명·서비스·담당자·영업시간·휴무일·규칙). 고객/예약 정보 절대 미노출[^23] |
 | `book/[slug]/availability.ts` | `/api/book/[slug]/availability` | GET | **공개(비로그인)** | 선택 서비스·담당자·날짜의 예약 가능 슬롯 배열. 순수 슬롯 계산(`features/booking/availability.ts`) 재사용, KST 기준 날짜 검증[^23] |
 | `book/[slug]/reserve.ts` | `/api/book/[slug]/reserve` | POST | **공개(비로그인)** | 셀프 예약 생성. 서버 슬롯 재검증(트랜잭션 Serializable) + 고객 upsert(정규화 tel) + 예약 생성(channel=online·`publicToken` 발급) + Slack 알림[^23] |
@@ -301,6 +303,7 @@ Store ─┬── Customer ──── Reservation ──── ReservationPay
        │                          └─ GmailConnection (1유저 1연동, 로그인 계정과 분리)
        ├── StoreBusinessHour (7일)
        ├── StoreClosedDate
+       ├── StoreNotice
        ├── StorePointSettings
        └── Invite
 ```

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,69 @@
 
 ---
 
+## 진행 중 — 매장 공지사항 (StoreNotice, 예약 페이지 목록형 공지)
+
+> 배경(사용자): 고객 예약 페이지에 매장 공지사항을 넣고 싶음. 목업 비교 후 **③ 여러 공지 목록**(제목·날짜로 여러 개, 펼치는 아코디언) 선택. 오너가 관리(CRUD), 공개된 공지만 고객에게 노출, 4개국어(한·영·일·중).
+
+### 설계 결정
+- **새 Store 토글 없음.** 공지사항은 공개 예약 페이지 콘텐츠 → 기존 `useOnlineBooking`으로 설정탭·aside 게이트(대량 토글 배선 회피, 리스크↓). 온라인예약 ON 매장만 관리·노출.
+- **`legacyId` 생략.** 공지는 로컬DB/네이버 등 import 경로가 없어 정수 ID 불필요 → cuid `id`만 사용(프론트 식별자=cuid). (쿠폰의 `@@unique([storeId, legacyId])` 대신 `@@index([storeId])`.)
+- **자식 행 없음 → 하드 삭제**(쿠폰의 archive 분기 불필요).
+- **title·body 모두 i18n**(`titleI18nJson`/`bodyI18nJson`, `{en,ja,zh}`). 오너는 한국어만 채우고 번역은 비워도 됨(비면 null=한국어 폴백). 기존 `noticeI18n` 패턴·`parseI18nText` 재사용.
+- **카테고리** `category`(notice/이벤트/안내) — 프리스트링(Prisma enum 미사용, 쿠폰 관례). 목업의 칩.
+- **게시일** = `createdAt`(별도 컬럼·날짜피커 없이 표시). 정렬 최신순(desc).
+
+### 데이터 모델 (마이그레이션 0015 — 추가형·멱등)
+```prisma
+model StoreNotice {
+  id            String   @id @default(cuid())
+  storeId       String
+  category      String   @default("notice") // notice | event | info
+  title         String
+  titleI18nJson Json?
+  body          String
+  bodyI18nJson  Json?
+  visible       Boolean  @default(true)     // 공개/숨김
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  store         Store    @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  @@index([storeId])
+}
+```
+- `Store`에 back-ref `storeNotices StoreNotice[]`.
+- `0015_store_notices/migration.sql`: `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` + FK(멱등 DO 블록), 0012/0013 스타일 한국어 헤더. **운영 Supabase direct(5432) 수동 선적용 → 머지(자동배포) 나중** 순서 준수.
+
+### API
+- **`server/api/notices.ts`**(+`client/pages/api/notices.ts` 재export): GET(staff+) 목록, POST·PUT·DELETE(owner). 전부 `storeId: session.storeId` 스코프. 응답 인라인 셰이핑(쿠폰과 동일, 매퍼 미사용). i18n 입력은 `parseI18nText`로 정규화, `Json?` null은 `Prisma.JsonNull`.
+- **공개 노출** `server/api/book/[slug].ts`: 응답에 `notices`(visible=true, 최신순, {category,title,titleI18n,body,bodyI18n,createdAt}) 추가. **try/catch로 감싸 테이블 미존재 시 `[]`**(마이그레이션 지연 방어 — 사용자 약속).
+
+### 클라이언트
+- **`client/features/notices/model.ts`**: `StoreNotice` 타입(id=cuid, category, title, titleI18n?, body, bodyI18n?, visible, createdAt).
+- **`client/components/settings/NoticeManageSection.tsx`**: `CouponManageSection` 패턴 클론(로컬 state + `/api/notices` fetch, 편집/저장/삭제). 본문·제목은 공용 `LocalizedMessageField` 사용.
+- **`LocalizedMessageField` 공용화**: `BookingManageSection.tsx`의 로컬 함수를 `client/components/ui/LocalizedMessageField.tsx`(+ 필요한 styled)로 승격, BookingManageSection·NoticeManageSection 공유(중복 제거).
+- **`client/pages/settings.tsx`**: `SettingsTab`에 `'notice'` + `isSettingsTab` + 렌더 분기. (오너 게이트는 기존 getServerSideProps).
+- **`client/components/layout/Aside.tsx`**: `SETTINGS_SUBMENU`에 `{tab:'notice', href:'/settings/notice', label:'공지사항 관리', icon:'booking' 재사용}` + 필터에서 `useOnlineBooking` 게이트(booking 탭과 동일).
+- **`client/pages/book/[slug].tsx`**: 매장명 아래 '공지사항' 아코디언(`<details>`), `pickI18n(title/body, lang, ko)` 표시, 카테고리 칩. `BookStoreInfo`에 `notices` 타입 추가.
+- **`client/features/booking/i18n.ts`**: `noticeSectionTitle` + 카테고리 라벨(notice/event/info) 4개 언어 추가(앱 UI 문구라 번역 대상).
+
+### 검증 (완료)
+- ✅ 타입체크 `tsc --noEmit` 0 에러, `next build` 성공(`/api/notices`·`/book/[slug]`·`/settings/[tab]` 컴파일).
+- ✅ 로컬 Postgres 16으로 **전체 마이그레이션 재생**(0015 포함) 성공 + **스키마 드리프트 없음**(0015 SQL = schema 모델 정확히 일치, `migrate diff --exit-code` 0).
+- ✅ psql 왕복: 공개 쿼리(visible=true·createdAt DESC) 정확, i18n JSONB 저장/조회, 숨김 필터(all=3/visible=2), FK Cascade(Store 삭제 시 공지 삭제) 확인.
+- 실계정(OAuth 오너) 저장 왕복은 배포 후. 마이그레이션은 **머지 전 수동 선적용**(사용자, Supabase direct 5432). 공개 조회 try/catch로 순서 어긋나도 무중단.
+
+### 결과물 (파일)
+- 스키마/마이그레이션: `schema.prisma`(StoreNotice + Store back-ref), `migrations/0015_store_notices/migration.sql`.
+- 서버: `api/notices.ts`(CRUD), `pages/api/notices.ts`(재export), `api/book/[slug].ts`(공개 노출 방어).
+- 클라: `features/notices/model.ts`, `components/settings/NoticeManageSection.tsx`, `components/ui/LocalizedMessageField.tsx`(공용), `pages/settings.tsx`(탭), `components/layout/Aside.tsx`·`AsideMenuIcon.tsx`(메뉴·벨 아이콘), `pages/book/[slug].tsx`(아코디언), `features/booking/i18n.ts`(4개국어).
+- 후속(범위 밖): `BookingManageSection`의 로컬 `LocalizedMessageField`를 공용 컴포넌트로 마이그레이션(중복 제거) — /simplify에서 빌드 검증과 함께.
+
+### 리스크/주의
+- 새 테이블 조회가 배포>마이그레이션 순서로 뒤집히면 500 위험 → try/catch 방어 + 순서 준수로 이중 안전.
+- `reservationSelect` 하드닝 규칙은 이 작업과 무관(Reservation 컬럼 미변경).
+
+---
+
 ## 완료 — 휴업일 설정해도 고객 예약 페이지에서 예약되는 버그 (TZ 오프바이원)
 
 > 배경(사용자): "휴업일 설정했는데, 고객 예약 페이지 통해서 예약되네." 오너가 특정 날짜 휴업일(`StoreClosedDate`)을 설정했는데도 공개 예약 페이지에서 그 날짜 예약이 통과됨.

--- a/server/api/book/[slug].ts
+++ b/server/api/book/[slug].ts
@@ -56,6 +56,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const whitelist = parseBookableServiceNames(bookingSettings?.bookableServiceIdsJson);
     const visibleServices = whitelist ? services.filter((s) => whitelist.includes(s.name)) : services;
 
+    // 공지사항(공개 = visible만, 최신순). 테이블 미존재(마이그레이션 지연) 시 빈 목록으로 방어 → 페이지 무중단.
+    let notices: Array<{category: string; title: string; titleI18n: ReturnType<typeof parseI18nText>; body: string; bodyI18n: ReturnType<typeof parseI18nText>; createdAt: string}> = [];
+    try {
+        const noticeRows = await prisma.storeNotice.findMany({
+            where: {storeId: store.id, visible: true},
+            orderBy: {createdAt: 'desc'},
+            select: {category: true, title: true, titleI18nJson: true, body: true, bodyI18nJson: true, createdAt: true},
+        });
+        notices = noticeRows.map((n) => ({
+            category: n.category,
+            title: n.title,
+            titleI18n: parseI18nText(n.titleI18nJson),
+            body: n.body,
+            bodyI18n: parseI18nText(n.bodyI18nJson),
+            createdAt: n.createdAt.toISOString(),
+        }));
+    } catch {
+        notices = [];
+    }
+
     return res.status(200).json({
         storeName: store.name,
         storeNameI18n: parseI18nText(store.nameI18nJson),
@@ -69,5 +89,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         businessHours: businessHours.map((b) => ({dayIndex: b.dayIndex, openTime: b.openTime, closeTime: b.closeTime, enabled: b.enabled})),
         closedDates: closedDates.map((c) => toDateKey(c.date)),
         settings,
+        notices,
     });
 }

--- a/server/api/notices.ts
+++ b/server/api/notices.ts
@@ -1,0 +1,133 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {Prisma} from '../../client/prisma/generated/prisma/client';
+
+import {prisma} from '../db/prisma';
+import {parseI18nText} from '../db/mappers';
+import {getApiSession, requireRole} from '../auth/api-session';
+
+const CATEGORIES = ['notice', 'event', 'info'] as const;
+
+function isCategory(value: unknown): value is (typeof CATEGORIES)[number] {
+    return typeof value === 'string' && (CATEGORIES as readonly string[]).includes(value);
+}
+
+// i18n 입력(JSON 컬럼)을 정규화해 Prisma 값으로. en/ja/zh 문자열만 남기고, 비면 JsonNull(한국어 폴백).
+function i18nInput(value: unknown): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+    const parsed = parseI18nText(value);
+    return parsed ? (parsed as Prisma.InputJsonValue) : Prisma.JsonNull;
+}
+
+type NoticeRow = {
+    id: string; category: string; title: string; titleI18nJson: unknown;
+    body: string; bodyI18nJson: unknown; visible: boolean; createdAt: Date;
+};
+
+// 공지 1건을 프론트 응답 형태로. i18n은 parseI18nText로 정규화(비면 null).
+function shapeNotice(n: NoticeRow) {
+    return {
+        id: n.id,
+        category: n.category,
+        title: n.title,
+        titleI18n: parseI18nText(n.titleI18nJson),
+        body: n.body,
+        bodyI18n: parseI18nText(n.bodyI18nJson),
+        visible: n.visible,
+        createdAt: n.createdAt.toISOString(),
+    };
+}
+
+// 매장 공지사항 CRUD. 조회는 staff+, 생성/수정/삭제는 owner. 전부 storeId 스코프.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const session = await getApiSession(req, res);
+
+    if (req.method === 'GET') {
+        if (!requireRole(session, 'staff', res)) return;
+
+        const notices = await prisma.storeNotice.findMany({
+            where: {storeId: session.storeId},
+            orderBy: {createdAt: 'desc'},
+        });
+        return res.status(200).json({notices: notices.map(shapeNotice)});
+    }
+
+    if (req.method === 'POST') {
+        if (!requireRole(session, 'owner', res)) return;
+
+        const body = req.body as {
+            category?: unknown; title?: unknown; titleI18n?: unknown;
+            body?: unknown; bodyI18n?: unknown; visible?: unknown;
+        };
+
+        if (typeof body.title !== 'string' || !body.title.trim()) {
+            return res.status(400).json({error: 'Invalid title'});
+        }
+        if (typeof body.body !== 'string' || !body.body.trim()) {
+            return res.status(400).json({error: 'Invalid body'});
+        }
+        if (body.category !== undefined && !isCategory(body.category)) {
+            return res.status(400).json({error: 'Invalid category'});
+        }
+
+        const created = await prisma.storeNotice.create({
+            data: {
+                storeId: session.storeId,
+                category: isCategory(body.category) ? body.category : 'notice',
+                title: body.title.trim(),
+                titleI18nJson: i18nInput(body.titleI18n),
+                body: body.body.trim(),
+                bodyI18nJson: i18nInput(body.bodyI18n),
+                visible: body.visible === undefined ? true : Boolean(body.visible),
+            },
+        });
+        return res.status(200).json(shapeNotice(created));
+    }
+
+    if (req.method === 'PUT') {
+        if (!requireRole(session, 'owner', res)) return;
+
+        const body = req.body as {
+            id?: unknown; category?: unknown; title?: unknown; titleI18n?: unknown;
+            body?: unknown; bodyI18n?: unknown; visible?: unknown;
+        };
+
+        if (typeof body.id !== 'string') return res.status(400).json({error: 'Invalid id'});
+        if (body.title !== undefined && (typeof body.title !== 'string' || !body.title.trim())) {
+            return res.status(400).json({error: 'Invalid title'});
+        }
+        if (body.body !== undefined && (typeof body.body !== 'string' || !body.body.trim())) {
+            return res.status(400).json({error: 'Invalid body'});
+        }
+        if (body.category !== undefined && !isCategory(body.category)) {
+            return res.status(400).json({error: 'Invalid category'});
+        }
+
+        const result = await prisma.storeNotice.updateMany({
+            where: {id: body.id, storeId: session.storeId},
+            data: {
+                ...(body.category !== undefined && {category: body.category as string}),
+                ...(body.title !== undefined && {title: (body.title as string).trim()}),
+                ...(body.titleI18n !== undefined && {titleI18nJson: i18nInput(body.titleI18n)}),
+                ...(body.body !== undefined && {body: (body.body as string).trim()}),
+                ...(body.bodyI18n !== undefined && {bodyI18nJson: i18nInput(body.bodyI18n)}),
+                ...(body.visible !== undefined && {visible: Boolean(body.visible)}),
+            },
+        });
+        if (result.count === 0) return res.status(404).json({error: 'Not found'});
+        return res.status(200).json({ok: true});
+    }
+
+    if (req.method === 'DELETE') {
+        if (!requireRole(session, 'owner', res)) return;
+
+        const {id} = req.body as {id?: unknown};
+        if (typeof id !== 'string') return res.status(400).json({error: 'Invalid id'});
+
+        // 공지엔 발급 등 자식 행이 없어 하드 삭제(스토어 스코프).
+        await prisma.storeNotice.deleteMany({where: {id, storeId: session.storeId}});
+        return res.status(200).json({deleted: true});
+    }
+
+    res.setHeader('Allow', ['GET', 'POST', 'PUT', 'DELETE']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/server/prisma/migrations/0015_store_notices/migration.sql
+++ b/server/prisma/migrations/0015_store_notices/migration.sql
@@ -1,0 +1,26 @@
+-- 매장 공지사항(StoreNotice): 공개 예약 페이지 노출용 오너 공지 목록.
+-- 신규 테이블 추가형. 데이터 파괴 없음. IF NOT EXISTS로 멱등(Supabase direct 5432 수동 선적용 안전).
+-- title/body 다국어: {"en":"...","ja":"...","zh":"..."} (일부 키만 있어도 됨). 없으면 한국어(title/body) 폴백.
+-- category: notice(공지) | event(이벤트) | info(안내). visible=false면 비공개(고객 미노출).
+
+CREATE TABLE IF NOT EXISTS "StoreNotice" (
+    "id" TEXT NOT NULL,
+    "storeId" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'notice',
+    "title" TEXT NOT NULL,
+    "titleI18nJson" JSONB,
+    "body" TEXT NOT NULL,
+    "bodyI18nJson" JSONB,
+    "visible" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "StoreNotice_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "StoreNotice_storeId_idx" ON "StoreNotice"("storeId");
+
+-- FK: 매장 삭제 시 공지도 함께 삭제. 재실행해도 중복 제약 오류 없이 통과.
+DO $$ BEGIN
+  ALTER TABLE "StoreNotice" ADD CONSTRAINT "StoreNotice_storeId_fkey"
+    FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN null; END $$;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Store {
   customerMemberships    CustomerMembership[]
   couponProducts         CouponProduct[]
   customerCoupons        CustomerCoupon[]
+  storeNotices           StoreNotice[]
 }
 
 model User {
@@ -293,6 +294,24 @@ model StoreClosedDate {
   store     Store    @relation(fields: [storeId], references: [id], onDelete: Cascade)
 
   @@unique([storeId, date])
+}
+
+// 매장 공지사항(공개 예약 페이지 노출). 오너가 관리, visible=true만 고객에게 표시.
+// title/body 다국어({en?,ja?,zh?}, 없으면 한국어 폴백). category: notice | event | info.
+model StoreNotice {
+  id            String   @id @default(cuid())
+  storeId       String
+  category      String   @default("notice")
+  title         String
+  titleI18nJson Json?
+  body          String
+  bodyI18nJson  Json?
+  visible       Boolean  @default(true)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  store         Store    @relation(fields: [storeId], references: [id], onDelete: Cascade)
+
+  @@index([storeId])
 }
 
 // 공개(고객) 온라인 예약 규칙. Store.useOnlineBooking ON일 때만 의미.


### PR DESCRIPTION
## 요약
고객 예약 페이지에 **매장 공지사항**을 추가합니다(목업 ③ 목록형 채택). 오너가 여러 공지를 관리하고, 공개로 둔 공지만 고객에게 최신순 아코디언으로 노출됩니다. 제목·내용은 4개국어(한·영·일·중)를 지원합니다.

## ⚠️ 배포 순서 — 마이그레이션 먼저(수동), 머지는 그다음
새 테이블(`StoreNotice`)이 생깁니다. main 머지 = 자동 배포이므로, **머지 전에 Supabase `direct`(5432)에서 아래 SQL을 먼저 적용**해 주세요. 추가형 `CREATE TABLE IF NOT EXISTS`라 기존 데이터는 안전하고 재실행해도 됩니다. (공개 조회는 테이블이 없어도 빈 목록으로 방어하지만, 오너 관리 화면은 테이블이 있어야 동작합니다.)

```sql
CREATE TABLE IF NOT EXISTS "StoreNotice" (
    "id" TEXT NOT NULL,
    "storeId" TEXT NOT NULL,
    "category" TEXT NOT NULL DEFAULT 'notice',
    "title" TEXT NOT NULL,
    "titleI18nJson" JSONB,
    "body" TEXT NOT NULL,
    "bodyI18nJson" JSONB,
    "visible" BOOLEAN NOT NULL DEFAULT true,
    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
    "updatedAt" TIMESTAMP(3) NOT NULL,
    CONSTRAINT "StoreNotice_pkey" PRIMARY KEY ("id")
);
CREATE INDEX IF NOT EXISTS "StoreNotice_storeId_idx" ON "StoreNotice"("storeId");
DO $$ BEGIN
  ALTER TABLE "StoreNotice" ADD CONSTRAINT "StoreNotice_storeId_fkey"
    FOREIGN KEY ("storeId") REFERENCES "Store"("id") ON DELETE CASCADE ON UPDATE CASCADE;
EXCEPTION WHEN duplicate_object THEN null; END $$;
```
(리포의 `server/prisma/migrations/0015_store_notices/migration.sql`와 동일)

## 변경 내용
**백엔드**
- `StoreNotice` 모델 + 마이그레이션 `0015`(카테고리 notice/event/info · title/body + `*I18nJson` · visible).
- `GET/POST/PUT/DELETE /api/notices` — 조회 staff+, 생성·수정·삭제 owner, 전부 `storeId` 스코프. 자식 행 없어 하드 삭제.
- `GET /api/book/[slug]` 공개정보에 `notices`(visible=true·최신순) 추가. **테이블 미존재 시 try/catch로 `[]` 방어** → 배포 순서 어긋나도 무중단.

**프론트엔드**
- 설정 → **공지사항 관리**(`/settings/notice`) 탭 + aside 메뉴(벨 아이콘). `useOnlineBooking` ON일 때만 노출(새 토글 없음).
- `NoticeManageSection`: 분류·제목·내용·공개여부 등록/수정/삭제. 제목·내용 다국어 입력은 공용 `LocalizedMessageField`(단일행·여러행 지원, `ui/`로 신설).
- 고객 예약 페이지 랜딩에 공지 아코디언(`<details>`) — `pickI18n`로 언어별 표시, 카테고리 라벨 4개국어.

## 검증
- ✅ 타입체크 `tsc --noEmit` 0 · `next build` 성공.
- ✅ 로컬 Postgres 16: 전체 마이그레이션 재생(0015 포함) + **스키마 드리프트 없음**(SQL=모델 일치).
- ✅ psql 왕복: 공개 쿼리(visible·최신순)·i18n JSONB·숨김 필터(all=3/visible=2)·FK Cascade 확인.
- 실계정(오너 로그인) 저장 왕복은 배포 후 확인.

## 후속(범위 밖)
- `BookingManageSection`의 로컬 `LocalizedMessageField`를 공용 컴포넌트로 이관(중복 제거) — 별도 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws

---
_Generated by [Claude Code](https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws)_