### PR TITLE
style(notice): 공지 아코디언 아이콘을 고객 명단과 통일 + 미사용 작성일 제거

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/pages/book/[slug].tsx
+++ b/client/pages/book/[slug].tsx
@@ -45,7 +45,6 @@ interface BookNotice {
     titleI18n?: I18nText;
     body: string;
     bodyI18n?: I18nText;
-    createdAt: string;
 }
 interface BookStoreInfo {
     storeName: string;
@@ -408,7 +407,7 @@ export default function BookingPage() {
                                     <StyledNoticeSummary>
                                         <StyledNoticeChip data-category={n.category}>{noticeCat(n.category)}</StyledNoticeChip>
                                         <StyledNoticeItemTitle>{pickI18n(n.titleI18n, lang, n.title)}</StyledNoticeItemTitle>
-                                        <StyledNoticeChevron aria-hidden="true">⌄</StyledNoticeChevron>
+                                        <StyledNoticeChevron aria-hidden="true" />
                                     </StyledNoticeSummary>
                                     <StyledNoticeBody>{pickI18n(n.bodyI18n, lang, n.body)}</StyledNoticeBody>
                                 </StyledNoticeItem>
@@ -782,8 +781,12 @@ const StyledNoticeItemTitle = styled.span`
 `;
 const StyledNoticeChevron = styled.span`
     flex-shrink: 0;
-    color: var(--dark-gray-color2);
-    transition: transform 0.2s ease;
+    width: 0;
+    height: 0;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid var(--dark-gray-color);
+    transition: transform 0.15s ease;
 `;
 const StyledNoticeSummary = styled.summary`
     list-style: none;
@@ -797,7 +800,7 @@ const StyledNoticeSummary = styled.summary`
 `;
 const StyledNoticeItem = styled.details`
     & + & { border-top: 1px solid var(--light-gray-color); }
-    &[open] ${StyledNoticeChevron} { transform: rotate(180deg); }
+    &[open] ${StyledNoticeChevron} { transform: rotate(90deg); }
 `;
 const StyledNoticeBody = styled.p`
     margin: 0;

--- a/server/api/book/[slug].ts
+++ b/server/api/book/[slug].ts
@@ -57,12 +57,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const visibleServices = whitelist ? services.filter((s) => whitelist.includes(s.name)) : services;
 
     // 공지사항(공개 = visible만, 최신순). 테이블 미존재(마이그레이션 지연) 시 빈 목록으로 방어 → 페이지 무중단.
-    let notices: Array<{category: string; title: string; titleI18n: ReturnType<typeof parseI18nText>; body: string; bodyI18n: ReturnType<typeof parseI18nText>; createdAt: string}> = [];
+    let notices: Array<{category: string; title: string; titleI18n: ReturnType<typeof parseI18nText>; body: string; bodyI18n: ReturnType<typeof parseI18nText>}> = [];
     try {
         const noticeRows = await prisma.storeNotice.findMany({
             where: {storeId: store.id, visible: true},
             orderBy: {createdAt: 'desc'},
-            select: {category: true, title: true, titleI18nJson: true, body: true, bodyI18nJson: true, createdAt: true},
+            select: {category: true, title: true, titleI18nJson: true, body: true, bodyI18nJson: true},
         });
         notices = noticeRows.map((n) => ({
             category: n.category,
@@ -70,7 +70,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             titleI18n: parseI18nText(n.titleI18nJson),
             body: n.body,
             bodyI18n: parseI18nText(n.bodyI18nJson),
-            createdAt: n.createdAt.toISOString(),
         }));
     } catch {
         notices = [];


### PR DESCRIPTION
## 요약
공지사항(#145) 소스 검증 후속. 고객 예약 페이지 공지 아코디언의 펼침 아이콘을 **고객 명단과 동일한 스타일**로 맞추고, 고객 페이지에 노출하지 않는 작성일 데이터를 정리합니다.

## 변경 내용
- **아코디언 아이콘 통일**: `⌄` 문자 → 고객 명단(`AddressCustomerSummary`)이 쓰는 것과 동일한 **CSS 삼각형 캐럿**. 닫힘 ▶ / 열림 시 `rotate(90deg)`로 ▼ (고객 명단과 동일한 동작).
- **미사용 작성일 제거**: 고객 페이지엔 공지 작성일을 노출하지 않으므로, 공개 API(`book/[slug]`) 응답과 `BookNotice` 타입에서 `createdAt`를 제거(최신순 `orderBy`는 유지). 오너 관리화면의 작성일 표시는 그대로.

## 배포
- **코드-온리, 마이그레이션·스키마 변경 없음.**

## 검증
- ✅ 타입체크 `tsc --noEmit` 0 · `next build` 성공(`/book/[slug]` 컴파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws

---
_Generated by [Claude Code](https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws)_