### PR TITLE
fix(consent): 약관 미동의 상태에서 로고 등 정적 자산이 깨지던 문제

### DIFF
--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -13,6 +13,9 @@ const authMiddleware = auth((req) => {
     const isExempt =
         pathname.startsWith('/api/') ||
         pathname.startsWith('/_next') ||
+        // public/ 정적 자산(로고·og 이미지 등): 확장자 있는 경로는 게이트 제외.
+        // 미포함 시 로그인+미동의 상태에서 /logo/*.svg 요청까지 /consent로 리다이렉트돼 로고가 깨진다.
+        /\.[^/]+$/.test(pathname) ||
         pathname.startsWith('/book/') ||
         pathname.startsWith('/login') ||
         pathname.startsWith('/about') ||

--- a/index.md
+++ b/index.md
@@ -50,6 +50,7 @@ hair_reservations/
 - `storeId` 있고 `onboarded=false`인 사용자는 허용 경로 외 접근 시 `/onboarding`으로 리다이렉트
 - 온보딩 완료자의 `/onboarding` 진입 차단은 페이지 가드가 담당 (이전 페이지로 `router.back()`)
 - **주의**: `/api/*`는 동의 게이트에서 제외(exempt)됨 — 데이터 기록 API는 `requireRole`만 검증(동의는 클라이언트 흐름으로 보장)
+- **정적 자산 exempt**: 확장자 있는 경로(`/logo/*.svg`·`/img-share.png` 등, `/\.[^/]+$/`)도 게이트 제외. 미포함 시 로그인+미동의 상태에서 로고 등 이미지 요청까지 `/consent`로 리다이렉트돼 이미지가 깨진다(HTML이 옴)
 - **점검 모드 게이트**: `MAINTENANCE_MODE==='true'`면 `auth()` 밖 최상단에서 모든 요청을 `/maintenance`로 `rewrite`(인증 독립). `/maintenance`·`/_next`만 바이패스. `/login` 포함 전 페이지 차단 — matcher는 `api/auth`·`_next/*`·`favicon.ico`만 제외(인프라/인증 엔드포인트는 점검 중에도 유지). rename 등 마이그레이션 시 500 노출 방지용
 
 ### 캘린더 URL ↔ 날짜 (`client/components/layout/LayoutComponent.tsx`)


### PR DESCRIPTION
## 증상
로그인했지만 약관 미동의 상태로 `/consent`(또는 `/onboarding`)에 진입하면 **로고가 깨져** 안 뜸.

## 원인
미들웨어(`proxy.ts`)의 `isExempt` 목록에 **정적 자산 경로가 없어서**, 로그인+미동의 상태에선 브라우저의 `/logo/logo-black.svg` 요청까지 약관 게이트에 걸려 **`/consent`로 리다이렉트**됨. 이미지 자리에 HTML(consent 페이지)이 와서 깨짐.
- matcher는 `_next/static`·`favicon.ico`만 제외 → `public/logo/*`는 미들웨어를 통과
- `isExempt`에 `/logo` 없음 → 미동의 상태에서 이미지 요청이 게이트 대상이 됨

로그인/소개 페이지는 (게이트 밖이라) 정상이고, **강제로 `/consent`에 온 상태에서만** 재현되던 것도 이 때문.

## 수정
`isExempt`에 **정적 자산(확장자 있는 경로) 예외** 추가:
```js
/\.[^/]+$/.test(pathname) ||   // /logo/*.svg, /img-share.png 등
```
페이지 경로(확장자 없음)는 그대로 게이트 유지되고, 정적 파일만 통과합니다.

## 검증
- ✅ `next build` 성공(미들웨어 컴파일).
- ✅ 정규식 로직 검증: `/logo/*.svg`·`/img-share.png`·`/favicon.ico`·`/robots.txt`·`/sitemap.xml` → 제외(통과) / `/`·`/consent`·`/month/2026/7`·`/settings/store`·`/onboarding` → 게이트 유지.

## 비고
- 버전 범프는 동시 진행 중인 #148과 `package.json` 충돌을 피하려 이 PR에선 생략했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws

---
_Generated by [Claude Code](https://claude.ai/code/session_011yYdWQD9nQm6QvhTKWGzws)_