### PR TITLE
feat(mobile): 모바일 내비게이션 개편 — 상단 고정 헤더 + 하단 탭바

### DIFF
--- a/client/components/calendar/service/ServiceLegend.tsx
+++ b/client/components/calendar/service/ServiceLegend.tsx
@@ -71,6 +71,11 @@ const StyledWrap = styled.div`
     flex-direction: column;
     align-items: flex-end;
     gap: 8px;
+
+    /* 모바일은 하단 탭바와 겹쳐 숨긴다(범례는 데스크톱에서만). */
+    @media (max-width: 640px) {
+        display: none;
+    }
 `;
 
 const StyledPanel = styled.div`

--- a/client/components/layout/Aside.tsx
+++ b/client/components/layout/Aside.tsx
@@ -19,6 +19,7 @@ import {StoreSwitcher} from './StoreSwitcher';
 import {AsideGuestLogout} from './AsideGuestLogout';
 import {clearGuestConsentAck, clearGuestEntryResolved, clearGuestTermsAgreed} from '../../lib/local-db';
 import {AsideMenuIcon} from './AsideMenuIcon';
+import {SETTINGS_SUBMENU, isSettingsMenuVisible} from './settingsMenu';
 import {useStoreLabels} from '../../hooks/useStoreLabels';
 import {
     StyledAside,
@@ -46,23 +47,6 @@ import {
     StyledLegalLinks,
     StyledLegalLink,
 } from './Aside.styles';
-
-const SETTINGS_SUBMENU = [
-    {tab: 'revenue', href: '/settings/revenue', label: '매출', icon: 'revenue'},
-    {tab: 'store', href: '/settings/store', label: '매장 관리', icon: 'store'},
-    {tab: 'point', href: '/settings/point', label: '적립금 관리', icon: 'point'},
-    {tab: 'membership', href: '/settings/membership', label: '회원권 관리', icon: 'membership'},
-    {tab: 'coupon', href: '/settings/coupon', label: '쿠폰 관리', icon: 'coupon'},
-    {tab: 'booking', href: '/settings/booking', label: '고객 예약 설정', icon: 'booking'},
-    {tab: 'notice', href: '/settings/notice', label: '공지사항 관리', icon: 'notice'},
-    {tab: 'service', href: '/settings/service', label: '서비스 관리', icon: 'service'},
-    {tab: 'assignee', href: '/settings/assignee', label: '담당자 관리', icon: 'assignee'},
-    {tab: 'customers', href: '/address', label: '고객 명단', icon: 'customers'},
-    {tab: 'naver', href: '/settings/naver', label: '네이버예약 연동', icon: 'naver'},
-    {tab: 'sns', href: '/settings/sns', label: 'SNS 연동', icon: 'sns'},
-    {tab: 'member', href: '/settings/member', label: '멤버 관리', icon: 'member'},
-    {tab: 'my', href: '/mypage', label: '계정 관리', icon: 'account'},
-];
 
 export const Aside = () => {
     const router = useRouter();
@@ -234,23 +218,14 @@ export const Aside = () => {
                             </StyledToggleIcon>
                         </StyledAccordionToggle>
                         <StyledAccordionContent $open={settingsOpen}>
-                            {SETTINGS_SUBMENU.filter((item) => {
-                                // 서버 로그인(오너)이 필요한 기능은 오너에게만 노출.
-                                // 게스트·멤버는 물론, 세션이 아직 안 풀린 로딩 상태(isOwner=false)에서도
-                                // 절대 노출되지 않도록 isOwner 기준으로 명시 게이팅한다.
-                                if (item.tab === 'naver' || item.tab === 'sns' || item.tab === 'member') {
-                                    return isOwner;
-                                }
-                                // 멤버(staff)는 기존 노출 항목(고객 명단·계정 관리)만 유지
-                                if (isLoggedInStaff && item.tab !== 'customers' && item.tab !== 'my') return false;
-                                // 매장 기능 토글로 켠 경우에만 노출
-                                if (item.tab === 'point') return usePointSystem;
-                                if (item.tab === 'membership') return useMembershipSystem;
-                                if (item.tab === 'coupon') return useCouponSystem;
-                                if (item.tab === 'booking') return useOnlineBooking;
-                                if (item.tab === 'notice') return useOnlineBooking;
-                                return true;
-                            }).map((item) =>
+                            {SETTINGS_SUBMENU.filter((item) => isSettingsMenuVisible(item, {
+                                isOwner,
+                                isLoggedInStaff,
+                                usePointSystem,
+                                useMembershipSystem,
+                                useCouponSystem,
+                                useOnlineBooking,
+                            })).map((item) =>
                                 <StyledSubNavLink href={item.href}
                                                   $active={item.tab === 'my'
                                                       ? router.pathname === '/mypage'

--- a/client/components/layout/Header.styles.ts
+++ b/client/components/layout/Header.styles.ts
@@ -107,31 +107,36 @@ export const StyledAsideToggle = styled.button<{ $open: boolean }>`
         }
     }
 
+    /* 모바일은 하단 탭바의 '설정'(→/menu)이 사이드바를 대체하므로 플로팅 토글을 숨긴다. */
     @media (max-width: 640px) {
-        position: fixed;
-        bottom: 20px;
-        left: ${(props) => props.$open ? 'calc(8px + var(--aside-width) + 8px)' : '16px'};
-        z-index: 210;
-        flex-direction: column;
+        display: none;
+    }
+`;
+
+// 모바일 캘린더 헤더 우측 고정 '＋예약' 버튼. 데스크톱은 aside의 예약추가를 쓰므로 숨김.
+export const StyledMobileAddPill = styled.button`
+    display: none;
+
+    @media (max-width: 640px) {
+        display: inline-flex;
+        align-items: center;
         gap: 3px;
-        width: auto;
-        min-width: 44px;
-        height: auto;
-        padding: 8px 10px;
-        border-radius: 20px;
-        background-color: var(--aside-bg);
-        color: var(--aside-text);
-        box-shadow: 0 4px 16px rgba(0,0,0,0.22);
-        opacity: 1;
-        transition: left 0.25s ease, background-color 0.1s;
+        flex-shrink: 0;
+        margin-left: auto;
+        padding: 7px 13px 7px 9px;
+        border: none;
+        border-radius: 999px;
+        background-color: var(--brand-color);
+        color: var(--white-color);
+        font-size: var(--small-font);
+        font-weight: 700;
+        white-space: nowrap;
+        box-shadow: 0 4px 12px rgba(101, 38, 217, 0.28);
+    }
 
-        .menu-label { display: block; }
-
-        @media (hover: hover) and (pointer: fine) {
-            &:hover {
-                background-color: var(--aside-hover);
-            }
-        }
+    svg {
+        width: 15px;
+        height: 15px;
     }
 `;
 

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -10,10 +10,13 @@ import {useCustomerMergeSuggestion} from '../../hooks/useCustomerMergeSuggestion
 import {splitAssigneesByStatus, getAssigneeColor} from '../../utils/assignees';
 import {isCalendar} from '../../utils/router';
 import type {Reservation} from '../../utils/reservations';
+import {toDateKey} from '../../utils/reservations';
+import {roundToHalfHour, pad} from '../../utils/timeRound';
 
 import {CalendarDirection} from '../calendar/CalendarDirection';
 import {CalendarHeading} from '../calendar/CalendarHeading';
 import {ReservationDetail} from '../calendar/overlays/ReservationDetail';
+import {MobileViewTabs} from './MobileViewTabs';
 import {NaverSyncNotification} from './NaverSyncNotification';
 import {BookingRequestNotification} from './BookingRequestNotification';
 import {NaverSyncConflictModal} from '../modals/NaverSyncConflictModal';
@@ -37,12 +40,14 @@ import {
     StyledTokenExpiredToast,
     StyledTokenReconnect,
     StyledTokenClose,
+    StyledMobileAddPill,
 } from './Header.styles';
 
 const PAGE_TITLES: Record<string, string> = {
     '/address': '고객 명단',
     '/mypage': '계정 정보',
     '/logout': '로그아웃',
+    '/menu': '설정',
 };
 
 function getSettingsTabTitles(labels: StoreLabels): Record<string, string> {
@@ -67,6 +72,15 @@ export const Header = () => {
     const assignees = useCalendarStore((s) => s.assignees);
     const calendarAssigneeId = useCalendarStore((s) => s.calendarAssigneeId);
     const setCalendarAssigneeId = useCalendarStore((s) => s.setCalendarAssigneeId);
+    const setCreateReservationInitial = useCalendarStore((s) => s.setCreateReservationInitial);
+
+    // 모바일 상단 '＋예약' 버튼 — aside의 예약추가와 동일(현재 시각 30분 반올림)
+    const handleCreateReservation = () => {
+        const now = new Date();
+        const {hour, rounded} = roundToHalfHour(now.getHours(), now.getMinutes());
+        const date = toDateKey(now.getFullYear(), now.getMonth(), now.getDate());
+        setCreateReservationInitial({date, startTime: `${pad(hour)}:${pad(rounded)}`});
+    };
     const pathSegments = router.asPath.split('?')[0].split('/');
     const isRootPath = pathSegments.join('').length === 0;
     const isCalendarPage = isRootPath || isCalendar(pathSegments);
@@ -177,6 +191,19 @@ export const Header = () => {
                 <StyledCalendarRow>
                     <CalendarDirection />
                     <CalendarHeading />
+                    <StyledMobileAddPill type="button"
+                                         onClick={handleCreateReservation}
+                                         aria-label="예약 추가">
+                        <svg viewBox="0 0 24 24"
+                             fill="none"
+                             stroke="currentColor"
+                             strokeWidth="2.3"
+                             strokeLinecap="round"
+                             aria-hidden="true">
+                            <path d="M12 5v14M5 12h14" />
+                        </svg>
+                        예약
+                    </StyledMobileAddPill>
                 </StyledCalendarRow>
                 <StyledToolRow>
                     <StyledAssigneeFilter value={calendarAssigneeId ?? ''}
@@ -253,6 +280,7 @@ export const Header = () => {
                         </StyledSearchIcon>
                     </StyledCustomerSearchButton>
                 </StyledToolRow>
+                <MobileViewTabs />
             </>}
             {!isCalendarPage && <>
                 <StyledPageTitle>{pageTitle}</StyledPageTitle>

--- a/client/components/layout/LayoutComponent.tsx
+++ b/client/components/layout/LayoutComponent.tsx
@@ -22,6 +22,7 @@ import {ViewType} from '../../utils/constants';
 
 import {Header} from './Header';
 import {Aside} from './Aside';
+import {MobileTabBar} from './MobileTabBar';
 import {Icon} from '../ui/Icons';
 import {ReservationCreate} from '../calendar/overlays/ReservationCreate';
 import {AdBanner} from '../ad/AdBanner';
@@ -212,6 +213,7 @@ export default function LayoutComponent({children}: NodeType) {
                                            onSave={addReservation}/>
                     )}
                 </>}
+                <MobileTabBar/>
             </StyledContent>
         </StyledWrapper>
     );

--- a/client/components/layout/MobileTabBar.tsx
+++ b/client/components/layout/MobileTabBar.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link';
+import {useRouter} from 'next/router';
+
+import styled from 'styled-components';
+
+import {isCalendar} from '../../utils/router';
+import {AsideMenuIcon} from './AsideMenuIcon';
+
+type TabKey = 'calendar' | 'customers' | 'revenue' | 'settings';
+
+interface TabDef {
+    key: TabKey;
+    label: string;
+    href: string;
+    icon: string;
+}
+
+// 아이콘은 기존 웹앱(AsideMenuIcon) 재사용
+const TABS: TabDef[] = [
+    {key: 'calendar', label: '캘린더', href: '/', icon: 'calendarManage'},
+    {key: 'customers', label: '고객', href: '/address', icon: 'customers'},
+    {key: 'revenue', label: '매출', href: '/settings/revenue', icon: 'revenue'},
+    {key: 'settings', label: '설정', href: '/menu', icon: 'settings'},
+];
+
+function resolveActiveTab(pathname: string, asPath: string, tabQuery: string): TabKey | null {
+    const segments = asPath.split('?')[0].split('/');
+    const isRoot = segments.join('').length === 0;
+
+    if (isRoot || isCalendar(segments)) return 'calendar';
+    if (pathname === '/address') return 'customers';
+    // 매출은 설정의 한 탭(/settings/revenue)이지만 하단 탭에선 독립 항목
+    if ((pathname === '/settings' || pathname === '/settings/[tab]') && tabQuery === 'revenue') return 'revenue';
+    if (pathname === '/menu'
+        || pathname === '/mypage'
+        || pathname === '/inquiry'
+        || pathname === '/settings'
+        || pathname === '/settings/[tab]') {
+        return 'settings';
+    }
+    return null;
+}
+
+export const MobileTabBar = () => {
+    const router = useRouter();
+    const tabQuery = typeof router.query.tab === 'string' ? router.query.tab : '';
+    const active = resolveActiveTab(router.pathname, router.asPath, tabQuery);
+
+    return (
+        <StyledTabBar aria-label="모바일 하단 내비게이션">
+            {TABS.map((tab) => (
+                <StyledTab key={tab.key}
+                           href={tab.href}
+                           $active={active === tab.key}
+                           aria-current={active === tab.key ? 'page' : undefined}>
+                    <AsideMenuIcon icon={tab.icon} />
+                    <StyledTabLabel>{tab.label}</StyledTabLabel>
+                </StyledTab>
+            ))}
+        </StyledTabBar>
+    );
+};
+
+// 데스크톱에선 숨기고 모바일(≤640px)에서만 하단 고정 탭바로 노출.
+// LayoutComponent의 StyledContent 플렉스 자식이라 Main(내부 스크롤) 아래에 자연히 붙는다.
+const StyledTabBar = styled.nav`
+    display: none;
+
+    @media (max-width: 640px) {
+        flex-shrink: 0;
+        display: flex;
+        align-items: stretch;
+        background-color: var(--white-color);
+        border-top: 1px solid var(--light-gray-color);
+        /* 홈 인디케이터(safe-area)까지 탭바 배경색으로 채움 */
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+        z-index: 40;
+    }
+`;
+
+const StyledTab = styled(Link)<{ $active: boolean }>`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    padding: 7px 0 5px;
+    text-decoration: none;
+    color: ${(props) => props.$active ? 'var(--brand-color)' : 'var(--dark-gray-color2)'};
+
+    svg {
+        width: 24px;
+        height: 24px;
+        stroke-width: ${(props) => props.$active ? 2.1 : 1.8};
+    }
+
+    &:active {
+        opacity: 0.6;
+    }
+`;
+
+const StyledTabLabel = styled.span`
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    color: inherit;
+`;

--- a/client/components/layout/MobileViewTabs.tsx
+++ b/client/components/layout/MobileViewTabs.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+
+import styled from 'styled-components';
+
+import {useCalendarStore} from '../../store/calendarStore';
+import {ViewType} from '../../utils/constants';
+
+// 모바일 캘린더 상단 세그먼트 뷰 탭. aside의 뷰 전환(setChangeView/setAsPath) 로직을 그대로 재사용.
+// 3일(three) 뷰는 모바일 탭에서 제외(일·주·월·년 4종).
+const VIEW_TABS: Array<{ type: string; label: string }> = [
+    {type: ViewType.Day, label: '일'},
+    {type: ViewType.Week, label: '주'},
+    {type: ViewType.Month, label: '월'},
+    {type: ViewType.Year, label: '년'},
+];
+
+function todayMidnight(): Date {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+// aside.setAsPath 와 동일 — 뷰별 URL 세그먼트 생성.
+function buildViewPath(type: string): (string | number)[] {
+    const routeDate = todayMidnight();
+
+    if (type === ViewType.Week) {
+        routeDate.setDate(routeDate.getDate() - routeDate.getDay());
+    }
+
+    const result: (string | number)[] = [type, routeDate.getFullYear()];
+
+    if (type !== ViewType.Year) {
+        result.push(routeDate.getMonth() + 1);
+    }
+
+    if (type === ViewType.Day || type === ViewType.Week || type === ViewType.Three) {
+        result.push(routeDate.getDate());
+    }
+
+    return result;
+}
+
+export const MobileViewTabs = () => {
+    const view = useCalendarStore((s) => s.view);
+    const setView = useCalendarStore((s) => s.setView);
+    const setCurr = useCalendarStore((s) => s.setTargetFromDate);
+
+    const changeView = (type: string) => {
+        setView({type});
+
+        const today = todayMidnight();
+        if (type === ViewType.Week) {
+            today.setDate(today.getDate() - today.getDay());
+        }
+        setCurr(today);
+    };
+
+    return (
+        <StyledSegment role="tablist" aria-label="캘린더 보기 전환">
+            {VIEW_TABS.map((tab) => (
+                <StyledSegmentTab key={tab.type}
+                                  href={`/${buildViewPath(tab.type).join('/')}`}
+                                  role="tab"
+                                  aria-selected={view.type === tab.type}
+                                  $active={view.type === tab.type}
+                                  onClick={() => changeView(tab.type)}>
+                    {tab.label}
+                </StyledSegmentTab>
+            ))}
+        </StyledSegment>
+    );
+};
+
+// 데스크톱 숨김, 모바일에서만 노출.
+const StyledSegment = styled.div`
+    display: none;
+
+    @media (max-width: 640px) {
+        display: flex;
+        gap: 2px;
+        margin: 2px 8px 6px;
+        padding: 3px;
+        background-color: var(--gray-color2);
+        border-radius: var(--radius-lg);
+    }
+`;
+
+const StyledSegmentTab = styled(Link)<{ $active: boolean }>`
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 7px 0;
+    border-radius: var(--radius-md);
+    font-size: var(--small-font);
+    font-weight: 700;
+    text-decoration: none;
+    color: ${(props) => props.$active ? 'var(--brand-color)' : 'var(--dark-gray-color)'};
+    background-color: ${(props) => props.$active ? 'var(--white-color)' : 'transparent'};
+    box-shadow: ${(props) => props.$active ? 'var(--shadow-sm)' : 'none'};
+    transition: background-color 0.15s, color 0.15s;
+`;

--- a/client/components/layout/MobileViewTabs.tsx
+++ b/client/components/layout/MobileViewTabs.tsx
@@ -78,8 +78,10 @@ const StyledSegment = styled.div`
     @media (max-width: 640px) {
         display: flex;
         gap: 2px;
-        width: calc(100% - 16px);
-        margin: 2px 8px 6px;
+        /* 헤더가 좌측에만 8px 패딩이라, 좌우 여백을 10px로 대칭 맞춤
+           (다른 행 오늘·전체보기의 좌측 인셋과 정렬). */
+        width: calc(100% - 12px);
+        margin: 2px 10px 6px 2px;
         padding: 3px;
         box-sizing: border-box;
         background-color: var(--gray-color2);

--- a/client/components/layout/MobileViewTabs.tsx
+++ b/client/components/layout/MobileViewTabs.tsx
@@ -78,8 +78,10 @@ const StyledSegment = styled.div`
     @media (max-width: 640px) {
         display: flex;
         gap: 2px;
+        width: calc(100% - 16px);
         margin: 2px 8px 6px;
         padding: 3px;
+        box-sizing: border-box;
         background-color: var(--gray-color2);
         border-radius: var(--radius-lg);
     }

--- a/client/components/layout/settingsMenu.ts
+++ b/client/components/layout/settingsMenu.ts
@@ -1,0 +1,53 @@
+// aside(데스크톱 사이드바)와 /menu(모바일 설정 화면)가 공유하는 설정 메뉴 정의.
+// 한 곳에서만 관리해 두 화면의 항목/게이팅이 어긋나지 않도록 한다.
+
+export interface SettingsMenuItem {
+    tab: string;
+    href: string;
+    label: string;
+    icon: string;
+}
+
+export const SETTINGS_SUBMENU: SettingsMenuItem[] = [
+    {tab: 'revenue', href: '/settings/revenue', label: '매출', icon: 'revenue'},
+    {tab: 'store', href: '/settings/store', label: '매장 관리', icon: 'store'},
+    {tab: 'point', href: '/settings/point', label: '적립금 관리', icon: 'point'},
+    {tab: 'membership', href: '/settings/membership', label: '회원권 관리', icon: 'membership'},
+    {tab: 'coupon', href: '/settings/coupon', label: '쿠폰 관리', icon: 'coupon'},
+    {tab: 'booking', href: '/settings/booking', label: '고객 예약 설정', icon: 'booking'},
+    {tab: 'notice', href: '/settings/notice', label: '공지사항 관리', icon: 'notice'},
+    {tab: 'service', href: '/settings/service', label: '서비스 관리', icon: 'service'},
+    {tab: 'assignee', href: '/settings/assignee', label: '담당자 관리', icon: 'assignee'},
+    {tab: 'customers', href: '/address', label: '고객 명단', icon: 'customers'},
+    {tab: 'naver', href: '/settings/naver', label: '네이버예약 연동', icon: 'naver'},
+    {tab: 'sns', href: '/settings/sns', label: 'SNS 연동', icon: 'sns'},
+    {tab: 'member', href: '/settings/member', label: '멤버 관리', icon: 'member'},
+    {tab: 'my', href: '/mypage', label: '계정 관리', icon: 'account'},
+];
+
+export interface SettingsMenuGate {
+    isOwner: boolean;
+    isLoggedInStaff: boolean;
+    usePointSystem: boolean;
+    useMembershipSystem: boolean;
+    useCouponSystem: boolean;
+    useOnlineBooking: boolean;
+}
+
+// aside의 필터 로직과 동일 — 권한·기능 토글 게이팅.
+export function isSettingsMenuVisible(item: SettingsMenuItem, gate: SettingsMenuGate): boolean {
+    // 서버 로그인(오너)이 필요한 기능은 오너에게만 노출.
+    // 게스트·멤버는 물론, 세션이 아직 안 풀린 로딩 상태(isOwner=false)에서도 노출 금지.
+    if (item.tab === 'naver' || item.tab === 'sns' || item.tab === 'member') {
+        return gate.isOwner;
+    }
+    // 멤버(staff)는 기존 노출 항목(고객 명단·계정 관리)만 유지
+    if (gate.isLoggedInStaff && item.tab !== 'customers' && item.tab !== 'my') return false;
+    // 매장 기능 토글로 켠 경우에만 노출
+    if (item.tab === 'point') return gate.usePointSystem;
+    if (item.tab === 'membership') return gate.useMembershipSystem;
+    if (item.tab === 'coupon') return gate.useCouponSystem;
+    if (item.tab === 'booking') return gate.useOnlineBooking;
+    if (item.tab === 'notice') return gate.useOnlineBooking;
+    return true;
+}

--- a/client/components/settings/revenue/RevenueFilters.tsx
+++ b/client/components/settings/revenue/RevenueFilters.tsx
@@ -94,7 +94,7 @@ export const RevenueFilters = ({
             <StyledRow3>
                 <StyledTabGroup>
                     <StyledViewTab type="button" $active={revenueViewTab === 'all'} onClick={() => setRevenueViewTab('all')}>전체</StyledViewTab>
-                    <StyledViewTab type="button" $active={revenueViewTab === 'chart'} onClick={() => setRevenueViewTab('chart')}>매출 그래프</StyledViewTab>
+                    <StyledViewTab type="button" $active={revenueViewTab === 'chart'} $mobileHide onClick={() => setRevenueViewTab('chart')}>매출 그래프</StyledViewTab>
                     <StyledViewTab type="button" $active={revenueViewTab === 'list'} onClick={() => setRevenueViewTab('list')}>매출 일별목록</StyledViewTab>
                     <StyledExportButton type="button" onClick={onExport} aria-label="엑셀 다운로드">
                         <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -249,7 +249,7 @@ const StyledTabGroup = styled.div`
     align-items: center;
 `;
 
-const StyledViewTab = styled.button<{ $active: boolean }>`
+const StyledViewTab = styled.button<{ $active: boolean; $mobileHide?: boolean }>`
     ${actionButtonStyle};
     white-space: nowrap;
     border: 1px solid ${(p) => p.$active ? 'var(--black-color)' : 'var(--light-gray-color)'};
@@ -259,6 +259,7 @@ const StyledViewTab = styled.button<{ $active: boolean }>`
     @media (max-width: 640px) {
         min-width: 0;
         padding: 0 8px;
+        ${(p) => p.$mobileHide ? 'display: none;' : ''}
     }
 `;
 

--- a/client/components/settings/revenue/revenue-chart-styles.ts
+++ b/client/components/settings/revenue/revenue-chart-styles.ts
@@ -17,6 +17,11 @@ export const StyledChartGrid = styled.div`
     @media (max-width: 900px) {
         grid-template-columns: 1fr;
     }
+
+    /* 모바일은 좁아 차트 가독성이 떨어져 분석 그리드를 숨긴다(KPI·일별 목록만 노출). */
+    @media (max-width: 640px) {
+        display: none;
+    }
 `;
 
 export const StyledChartCard = styled.div<{ $hero?: boolean; $autoHeight?: boolean }>`

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.39.4",
+  "version": "0.40.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/client/pages/menu.tsx
+++ b/client/pages/menu.tsx
@@ -1,0 +1,260 @@
+import React, {useState} from 'react';
+
+import type {NextPage} from 'next';
+import Link from 'next/link';
+
+import {signOut, useSession} from 'next-auth/react';
+
+import styled from 'styled-components';
+
+import {useCalendarStore} from '../store/calendarStore';
+import {useStoreLabels} from '../hooks/useStoreLabels';
+import {SeoHead} from '../components/ui/SeoHead';
+import {AsideMenuIcon} from '../components/layout/AsideMenuIcon';
+import {AuthActionIcon} from '../components/ui/AuthActionIcon';
+import {AsideGuestLogout} from '../components/layout/AsideGuestLogout';
+import {SETTINGS_SUBMENU, isSettingsMenuVisible, type SettingsMenuItem} from '../components/layout/settingsMenu';
+import {clearGuestConsentAck, clearGuestEntryResolved, clearGuestTermsAgreed} from '../lib/local-db';
+
+// 하단 탭바에 이미 있는 항목(매출·고객 명단)은 설정 리스트에서 제외해 중복을 없앤다.
+const HIDDEN_IN_MENU = new Set(['revenue', 'customers']);
+
+const Menu: NextPage = () => {
+    const {data: session} = useSession();
+    const [showGuestLogout, setShowGuestLogout] = useState(false);
+    const storeName = useCalendarStore((s) => s.storeName);
+    const usePointSystem = useCalendarStore((s) => s.usePointSystem);
+    const useMembershipSystem = useCalendarStore((s) => s.useMembershipSystem);
+    const useCouponSystem = useCalendarStore((s) => s.useCouponSystem);
+    const useOnlineBooking = useCalendarStore((s) => s.useOnlineBooking);
+    const labels = useStoreLabels();
+
+    const isGuest = !session;
+    const isOwner = session?.user?.role === 'owner';
+    const isLoggedInStaff = !!session?.user && !isOwner;
+
+    const gate = {
+        isOwner,
+        isLoggedInStaff,
+        usePointSystem,
+        useMembershipSystem,
+        useCouponSystem,
+        useOnlineBooking,
+    };
+
+    const items = SETTINGS_SUBMENU.filter(
+        (item) => !HIDDEN_IN_MENU.has(item.tab) && isSettingsMenuVisible(item, gate)
+    );
+
+    const submenuLabel = (item: SettingsMenuItem) =>
+        item.tab === 'assignee' ? `${labels.assignee} 관리`
+            : item.tab === 'service' ? `${labels.service} 관리`
+                : item.label;
+
+    const startTour = () => {
+        if (typeof window !== 'undefined') window.dispatchEvent(new Event('tas:start-tour'));
+    };
+
+    return (
+        <StyledPage>
+            <SeoHead title="설정" />
+
+            <StyledHeaderCard>
+                {storeName && <StyledStoreName>{storeName}</StyledStoreName>}
+                <StyledUserName>{isGuest ? '게스트' : (session?.user?.name ?? '-')}</StyledUserName>
+                {!isGuest && session?.user?.email && (
+                    <StyledUserEmail>{session.user.email}</StyledUserEmail>
+                )}
+            </StyledHeaderCard>
+
+            <StyledGroup>
+                {items.map((item) => (
+                    <StyledRow key={item.tab} href={item.href}>
+                        <StyledRowIcon>
+                            <AsideMenuIcon icon={item.icon} />
+                        </StyledRowIcon>
+                        <StyledRowLabel>{submenuLabel(item)}</StyledRowLabel>
+                        <StyledChevron viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M9 6l6 6-6 6" />
+                        </StyledChevron>
+                    </StyledRow>
+                ))}
+            </StyledGroup>
+
+            <StyledGroup>
+                <StyledRow href="/inquiry">
+                    <StyledRowIcon><AsideMenuIcon icon="inquiry" /></StyledRowIcon>
+                    <StyledRowLabel>고객센터</StyledRowLabel>
+                    <StyledChevron viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6" /></StyledChevron>
+                </StyledRow>
+                <StyledButtonRow type="button" onClick={startTour}>
+                    <StyledRowIcon><AsideMenuIcon icon="guide" /></StyledRowIcon>
+                    <StyledRowLabel>사용 안내</StyledRowLabel>
+                    <StyledChevron viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6" /></StyledChevron>
+                </StyledButtonRow>
+                <StyledButtonRow type="button"
+                                 onClick={() => isGuest ? setShowGuestLogout(true) : signOut({callbackUrl: '/login'})}>
+                    <StyledRowIcon><AuthActionIcon direction="logout" /></StyledRowIcon>
+                    <StyledRowLabel>로그아웃</StyledRowLabel>
+                </StyledButtonRow>
+            </StyledGroup>
+
+            <StyledLegalLinks>
+                <StyledLegalLink href="/terms">이용약관</StyledLegalLink>
+                <StyledLegalLink href="/privacy">개인정보처리방침</StyledLegalLink>
+                {!isGuest && <StyledLegalLink href="/dpa">개인정보 처리위탁</StyledLegalLink>}
+            </StyledLegalLinks>
+
+            {showGuestLogout && (
+                <AsideGuestLogout onClose={() => setShowGuestLogout(false)}
+                                  onConfirm={() => {
+                                      localStorage.removeItem('takeaseat.local-db.v1');
+                                      clearGuestTermsAgreed();
+                                      clearGuestEntryResolved();
+                                      clearGuestConsentAck();
+                                      window.location.href = '/login';
+                                  }} />
+            )}
+        </StyledPage>
+    );
+};
+
+export default Menu;
+
+/* ── Styles ── */
+
+const StyledPage = styled.div`
+    flex: 1;
+    width: 100%;
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 12px 12px 24px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+`;
+
+const StyledHeaderCard = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 14px 16px;
+    background-color: var(--white-color);
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-lg);
+`;
+
+const StyledStoreName = styled.span`
+    font-size: var(--xsmall-font);
+    font-weight: 600;
+    color: var(--dark-gray-color2);
+    word-break: break-all;
+`;
+
+const StyledUserName = styled.span`
+    font-size: var(--big-font);
+    font-weight: 700;
+    color: var(--black-color);
+`;
+
+const StyledUserEmail = styled.span`
+    font-size: var(--small-font);
+    color: var(--dark-gray-color2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const StyledGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    background-color: var(--white-color);
+    border: 1px solid var(--light-gray-color);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+`;
+
+const rowBase = `
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 52px;
+    padding: 0 14px;
+    box-sizing: border-box;
+    background-color: var(--white-color);
+    border: none;
+    border-top: 1px solid var(--light-gray-color);
+    text-align: left;
+    text-decoration: none;
+
+    &:first-child {
+        border-top: none;
+    }
+
+    &:active {
+        background-color: var(--gray-color2);
+    }
+`;
+
+const StyledRow = styled(Link)`
+    ${rowBase}
+`;
+
+const StyledButtonRow = styled.button`
+    ${rowBase}
+`;
+
+const StyledRowIcon = styled.span`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    border-radius: var(--radius-md);
+    background-color: var(--brand-color-bg);
+    color: var(--brand-color);
+
+    svg {
+        width: 18px;
+        height: 18px;
+    }
+`;
+
+const StyledRowLabel = styled.span`
+    flex: 1;
+    min-width: 0;
+    font-size: var(--font);
+    font-weight: 600;
+    color: var(--black-color);
+`;
+
+const StyledChevron = styled.svg`
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    stroke: var(--dark-gray-color2);
+    fill: none;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+`;
+
+const StyledLegalLinks = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    padding: 4px 6px 0;
+`;
+
+const StyledLegalLink = styled(Link)`
+    font-size: var(--xsmall-font);
+    color: var(--dark-gray-color2);
+    text-decoration: none;
+
+    &:active {
+        text-decoration: underline;
+    }
+`;

--- a/client/pages/menu.tsx
+++ b/client/pages/menu.tsx
@@ -125,6 +125,7 @@ export default Menu;
 
 const StyledPage = styled.div`
     flex: 1;
+    align-self: flex-start;
     width: 100%;
     max-width: 640px;
     margin: 0 auto;
@@ -136,6 +137,7 @@ const StyledPage = styled.div`
 `;
 
 const StyledHeaderCard = styled.div`
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     gap: 3px;
@@ -167,6 +169,7 @@ const StyledUserEmail = styled.span`
 `;
 
 const StyledGroup = styled.div`
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     background-color: var(--white-color);

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,38 @@
 
 ---
 
+## 진행 중 — 모바일 내비게이션 개편 (aside → 상단 고정 헤더 + 하단 탭바)
+
+> 배경(사용자): tas-ios 조작감을 웹앱 모바일에 이식. 좌측 드로어(aside) 대신 iOS식 **상단 고정 헤더 + 하단 고정 탭바**로 재구성. 시안 3안 비교 후 **"C 헤더 + B 나머지"** 조합으로 확정(아티팩트 시안).
+
+### 확정 디자인 (사용자 결정)
+- **상단 고정(캘린더)**: 좌측 라지타이틀(=날짜, 탭→날짜점프) + 이전/다음, 우측 **＋예약 텍스트 알약**(상단 고정), 아래 **일·주·월·년 풀폭 세그먼트 탭**(캘린더에서만). 3일(three) 뷰는 모바일 탭에서 제외(데스크톱 aside엔 유지).
+- **하단 고정 탭바**: **캘린더 · 고객 · 매출 · 설정** 4탭. 아이콘은 기존 `AsideMenuIcon` 재사용.
+- **서비스는 설정 안으로** — 하단 탭엔 없음. 설정(더보기) 화면에 '서비스 관리' 행으로.
+- **모바일 매출**: 차트는 숨김(작은 화면 가독성). KPI·목록만.
+- 비캘린더(고객·매출·설정) 상단은 **타이틀만**(뷰 탭·＋예약 없음).
+
+### 구현 방침 (모바일 ≤640px 전용, 데스크톱 무변경)
+- **하단 탭바** `MobileTabBar` — `LayoutComponent`의 `StyledContent` 플렉스 자식으로 렌더(고정 position 아님, Main이 내부 스크롤 → 자연히 하단 고정). `display:none` 기본, `@media(max-width:640px)`에서만 노출. safe-area 하단 패딩. 활성상태=경로 기반.
+  - 캘린더→`/`, 고객→`/address`, 매출→`/settings/revenue`, 설정→`/menu`(신규).
+- **설정(더보기) 페이지** `/menu`(신규 `pages/menu.tsx`) — aside의 설정 메뉴를 iOS 리스트로 이관. `SETTINGS_SUBMENU`+게이팅을 `layout/settingsMenu.ts`로 추출해 aside와 공유(드리프트 방지). 매출·고객명단은 하단 탭과 중복이라 리스트에서 제외. 고객센터·사용안내·로그아웃·약관도 포함(모바일에서 aside를 완전히 대체).
+- **상단 헤더** `Header` — 모바일 전용 요소 추가(전부 `display:none`+`@media`로 데스크톱 격리): ①＋예약 알약(캘린더 행 우측), ②세그먼트 뷰 탭 `MobileViewTabs`(툴 행 아래). 기존 담당자 필터·검색·동기화·알림 툴 행은 유지. 플로팅 aside 토글은 모바일에서 숨김(＝/menu가 대체).
+- **뷰 전환 로직 재사용**: `MobileViewTabs`는 aside의 `setChangeView`/`setAsPath` 패턴(스토어 `setView`+URL push) 그대로. 라벨 일/주/월/년.
+- **매출 차트 숨김**: RevenueSection 차트 그리드에 `@media(max-width:640px){display:none}`.
+
+### 영향 파일
+- 신규: `components/layout/MobileTabBar.tsx`, `components/layout/MobileViewTabs.tsx`, `components/layout/settingsMenu.ts`, `pages/menu.tsx`.
+- 수정: `components/layout/LayoutComponent.tsx`(탭바 렌더+Main 하단 패딩), `components/layout/Header.tsx`·`Header.styles.ts`(＋예약·뷰탭·토글 숨김), `components/layout/Aside.tsx`(SETTINGS_SUBMENU를 공유 모듈에서 import), `components/settings/revenue/*`(모바일 차트 숨김).
+
+### 검증
+- 타입체크(`tsc --noEmit`)·`next build`. 모바일 폭(≤640px)에서 상단 헤더(타이틀·＋예약·뷰탭)·하단 탭바·설정(/menu) 동작, 데스크톱 레이아웃 무변경 확인.
+
+### 리스크/주의
+- 공유 컴포넌트(CalendarHeading 등) 미변경 — 모바일 요소는 신규+CSS 격리로만. 라지타이틀 폰트 확대는 공유 컴포넌트 건드리므로 v1 보류(레이아웃으로 강조).
+- 스키마·API 무변경(코드-온리 배포).
+
+---
+
 ## 진행 중 — 매장 공지사항 (StoreNotice, 예약 페이지 목록형 공지)
 
 > 배경(사용자): 고객 예약 페이지에 매장 공지사항을 넣고 싶음. 목업 비교 후 **③ 여러 공지 목록**(제목·날짜로 여러 개, 펼치는 아코디언) 선택. 오너가 관리(CRUD), 공개된 공지만 고객에게 노출, 4개국어(한·영·일·중).


### PR DESCRIPTION
## 배경

tas-ios의 조작감을 웹앱 모바일에 이식합니다. 좌측 드로어(aside) 대신 iOS식 **상단 고정 헤더 + 하단 고정 탭바**로 재구성했습니다. 시안 비교 후 **"C 헤더 + B 나머지"** 조합으로 확정.

모든 변경은 `@media (max-width: 640px)` CSS로 격리해 **데스크톱 레이아웃은 무변경**입니다. 스키마·API 변경 없음(코드-온리 배포).

## 변경 사항

### 하단 고정 탭바 (신규 `MobileTabBar`)
- **캘린더 · 고객 · 매출 · 설정** 4탭. 경로 기반 활성 상태.
- 아이콘은 기존 `AsideMenuIcon` 재사용. `env(safe-area-inset-bottom)`을 탭바 배경색으로 채움.
- `LayoutComponent`의 플렉스 자식으로 렌더 → Main(내부 스크롤) 아래 자연히 고정.

### 상단 헤더 (모바일)
- 우측 고정 **＋예약** 알약 + **일·주·월·년 풀폭 세그먼트 뷰 탭**(`MobileViewTabs`, 캘린더에서만 노출, 좌우 대칭 정렬).
- 뷰 전환은 aside의 기존 로직 재사용. 플로팅 aside 토글은 숨김(하단 '설정' 탭이 대체).

### 설정(더보기) 페이지 (신규 `/menu`)
- aside 설정 메뉴를 iOS식 리스트로 이관. **서비스 관리가 설정 안으로** 이동(하단 탭엔 매출·고객이 있어 제외).
- 고객센터·사용안내·로그아웃·약관 포함해 모바일에서 aside를 완전 대체. 권한·기능 토글 게이팅 재사용.

### 매출 (모바일)
- 좁은 화면 가독성 저하로 **분석 차트 그리드 숨김** + **'매출 그래프' 탭 숨김** → KPI + 일별 목록만.

### 리팩터링
- `SETTINGS_SUBMENU` + 게이팅을 `layout/settingsMenu.ts`로 추출해 aside·`/menu` 공유(항목/권한 드리프트 방지).
- 시술 범례 플로팅 버튼은 하단 탭바와 겹쳐 모바일에서 숨김(데스크톱 유지).

## 영향 파일
- **신규**: `components/layout/MobileTabBar.tsx`, `MobileViewTabs.tsx`, `settingsMenu.ts`, `pages/menu.tsx`
- **수정**: `LayoutComponent.tsx`, `Header.tsx`·`Header.styles.ts`, `Aside.tsx`, `calendar/service/ServiceLegend.tsx`, `settings/revenue/revenue-chart-styles.ts`·`RevenueFilters.tsx`
- 버전: `client` 0.39.4 → **0.40.0** (minor)

## 검증
- `tsc --noEmit` 0 에러, `next build` 성공(클린 빌드, `/menu` 포함 전 페이지 컴파일).
- **게스트 모드 · iPhone 뷰포트 실앱 구동 스크린샷**으로 5개 화면 확인: 월/일 캘린더, 설정(`/menu`), 매출(차트 숨김), 고객.

## 남은 후속 (범위 밖)
- 라지타이틀 탭 → 달력 날짜 선택(현재는 상단 `오늘 ‹ ›`로 이동). 공유 `CalendarHeading` 변경이 필요해 별도 작업으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mrju48F4YYnRa72N2Xd3HT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrju48F4YYnRa72N2Xd3HT)_