### PR TITLE
쿠폰 직접 발급/취소 엔드포인트 (Phase 2)

### DIFF
--- a/client/pages/api/coupon-issue.ts
+++ b/client/pages/api/coupon-issue.ts
@@ -1,0 +1,1 @@
+export {default} from '../../../server/api/coupon-issue';

--- a/server/api/coupon-issue.ts
+++ b/server/api/coupon-issue.ts
@@ -30,6 +30,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
         if (!product) return res.status(404).json({error: 'Product not found'});
 
+        // 가드: 보관(archived) 상품은 발급 불가.
+        if (product.status !== 'active') {
+            return res.status(400).json({error: '보관된 쿠폰은 발급할 수 없습니다.'});
+        }
+        // 가드: 코드형(code 있음)은 코드 사용 흐름 전용 — 직접 발급 대상 아님.
+        if (product.code) {
+            return res.status(400).json({error: '코드형 쿠폰은 직접 발급 대상이 아닙니다.'});
+        }
+
         const expiresAt = product.validDays != null
             ? new Date(Date.now() + product.validDays * 24 * 60 * 60 * 1000)
             : null;

--- a/server/api/coupon-issue.ts
+++ b/server/api/coupon-issue.ts
@@ -1,0 +1,71 @@
+import type {NextApiRequest, NextApiResponse} from 'next';
+
+import {prisma} from '../db/prisma';
+import {getApiSession, requireRole} from '../auth/api-session';
+
+// 쿠폰 직접 발급/취소. (상품 CRUD는 ./coupons.ts) — 회원권 membership-issue 패턴 미러.
+// 코드형 발급(고객이 코드 입력) 및 결제 자동 차감(PaymentMethod.coupon)은 후속 Phase.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const session = await getApiSession(req, res);
+
+    if (req.method === 'POST') {
+        if (!requireRole(session, 'staff', res)) return;
+
+        const {customerId, productId} = req.body as {customerId?: unknown; productId?: unknown};
+        if (typeof customerId !== 'number' || !Number.isInteger(customerId)) {
+            return res.status(400).json({error: 'Invalid customerId'});
+        }
+        if (typeof productId !== 'string') {
+            return res.status(400).json({error: 'Invalid productId'});
+        }
+
+        const customer = await prisma.customer.findUnique({
+            where: {storeId_legacyId: {storeId: session.storeId, legacyId: customerId}},
+            select: {id: true},
+        });
+        if (!customer) return res.status(404).json({error: 'Customer not found'});
+
+        const product = await prisma.couponProduct.findFirst({
+            where: {id: productId, storeId: session.storeId},
+        });
+        if (!product) return res.status(404).json({error: 'Product not found'});
+
+        const expiresAt = product.validDays != null
+            ? new Date(Date.now() + product.validDays * 24 * 60 * 60 * 1000)
+            : null;
+
+        const created = await prisma.customerCoupon.create({
+            data: {
+                storeId: session.storeId,
+                customerId: customer.id,
+                productId: product.id,
+                name: product.name,
+                discountType: product.discountType,
+                discountValue: product.discountValue,
+                maxDiscount: product.maxDiscount,
+                minOrderAmount: product.minOrderAmount,
+                expiresAt,
+                status: 'active',
+            },
+        });
+
+        return res.status(200).json({id: created.id});
+    }
+
+    if (req.method === 'DELETE') {
+        if (!requireRole(session, 'staff', res)) return;
+
+        const {id} = req.body as {id?: unknown};
+        if (typeof id !== 'string') return res.status(400).json({error: 'Invalid id'});
+
+        const result = await prisma.customerCoupon.updateMany({
+            where: {id, storeId: session.storeId},
+            data: {status: 'cancelled'},
+        });
+        if (result.count === 0) return res.status(404).json({error: 'Not found'});
+        return res.status(200).json({ok: true});
+    }
+
+    res.setHeader('Allow', ['POST', 'DELETE']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+}


### PR DESCRIPTION
## 요약
쿠폰 **직접 발급/취소** 엔드포인트를 추가합니다. 회원권 `membership-issue.ts` 패턴을 그대로 미러했습니다.

- `POST /api/coupon-issue` (staff) — `{ customerId, productId }` → `CustomerCoupon` 생성(상품 스냅샷, `validDays`→`expiresAt`, `status: active`) → `{ id }`
- `DELETE /api/coupon-issue` (staff) — `{ id }` → `status: cancelled` → `{ ok: true }`

## 변경 파일
- `server/api/coupon-issue.ts` (신규)
- `client/pages/api/coupon-issue.ts` (신규, 재수출 래퍼)

## 참고
- `CustomerCoupon` 테이블은 **이미 스키마에 존재** → **마이그레이션 불필요**.
- `GET /api/coupons`는 이미 발급분(`coupons`)을 반환하므로 조회는 그대로 동작.
- iOS 클라이언트(`mjkang0987/tas-ios`)는 이 계약에 맞춰 이미 이식 완료 — `TASService.issueCoupon/cancelCoupon` + 쿠폰 화면 발급 탭(로그인 게이트).

## 범위
- 이번 PR은 **직접 발급(Phase 2)** 만. **코드형 발급**(고객 코드 입력)과 **결제 자동 차감**(`PaymentMethod.coupon`, Phase 3)은 후속.

## ⚠️ 리뷰 요청
- 이 저장소는 머지 시 자동 배포되므로 **자동 머지 대상에서 제외하고 사람 리뷰 후 머지**해 주세요.
- 권한 등급(`staff`)이 쿠폰 발급 정책에 맞는지 확인 부탁드립니다(회원권과 동일하게 맞췄습니다).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWhk8JfVMi3UNFRuF4Fm45)_