### PR TITLE
회원권 발급 가드 — 보관(archived) 상품 차단

### DIFF
--- a/server/api/membership-issue.ts
+++ b/server/api/membership-issue.ts
@@ -29,6 +29,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
         if (!product) return res.status(404).json({error: 'Product not found'});
 
+        // 가드: 보관(archived) 상품은 발급 불가. (쿠폰 coupon-issue와 동일 규칙)
+        if (product.status !== 'active') {
+            return res.status(400).json({error: '보관된 회원권은 발급할 수 없습니다.'});
+        }
+
         const expiresAt = product.validDays != null
             ? new Date(Date.now() + product.validDays * 24 * 60 * 60 * 1000)
             : null;


### PR DESCRIPTION
## 요약
쿠폰 발급(#156)에 추가한 가드와 규칙을 맞춥니다. `MembershipProduct.status`가 `active`가 아니면(보관) 발급을 400으로 차단합니다.

```ts
// 가드: 보관(archived) 상품은 발급 불가. (쿠폰 coupon-issue와 동일 규칙)
if (product.status !== 'active') {
    return res.status(400).json({error: '보관된 회원권은 발급할 수 없습니다.'});
}
```

## 변경 파일
- `server/api/membership-issue.ts` (+5줄)

## ⚠️ 라이브 동작 변경 — 리뷰 포인트
`membership-issue`는 **이미 운영 중인 엔드포인트**입니다. 현재는 보관 상품도 발급 가능하지만, 이 PR 이후 400을 반환합니다.

- 의도적으로 **보관 상품 발급을 막는 것**이 정책과 맞는지 확인 부탁드립니다.
- 웹 UI는 발급 셀렉트에 활성 상품만 노출하므로 정상 흐름에는 영향이 없을 것으로 보이나, 직접 API 호출/이전 화면 상태에서는 400을 만날 수 있습니다.
- 이 저장소는 머지 시 자동 배포되므로 **자동 머지 제외 + 사람 리뷰 후 머지** 부탁드립니다.

## 범위
- 회원권엔 코드형 개념이 없어 쿠폰의 `code` 가드는 해당 없음.
- `Store.useMembershipSystem` 토글 체크·중복 발급 제한은 이번에도 미포함(쿠폰과 동일하게 유지) — 필요하면 별도로 양쪽 동시에 적용하는 편이 일관적입니다.

## 관련
- 쿠폰 발급 엔드포인트 + 동일 가드: #156
- iOS(`mjkang0987/tas-ios`)는 회원권 발급 목록에서 이미 보관 상품을 제외 중이라 클라이언트 변경 불필요.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWhk8JfVMi3UNFRuF4Fm45)_