### PR TITLE
쿠폰 상품에 '고객당 1장' 설정 추가 (oncePerCustomer)

### DIFF
--- a/client/components/settings/CouponManageSection.tsx
+++ b/client/components/settings/CouponManageSection.tsx
@@ -19,10 +19,12 @@ interface DraftForm {
     minOrderAmount: string;
     validDays: string;
     code: string;
+    oncePerCustomer: boolean;
 }
 
 const EMPTY_DRAFT: DraftForm = {
     name: '', discountType: 'amount', discountValue: '', maxDiscount: '', minOrderAmount: '', validDays: '', code: '',
+    oncePerCustomer: false,
 };
 
 function describeProduct(p: CouponProduct): string {
@@ -35,6 +37,7 @@ function describeProduct(p: CouponProduct): string {
     if (p.minOrderAmount != null) parts.push(`${formatPrice(p.minOrderAmount)} 이상`);
     parts.push(p.validDays != null ? `${p.validDays}일` : '무기한');
     parts.push(p.code ? `코드 ${p.code}` : '직접발급');
+    if (p.oncePerCustomer) parts.push('고객당 1장');
     return parts.join(' · ');
 }
 
@@ -90,6 +93,7 @@ export const CouponManageSection = () => {
             minOrderAmount: p.minOrderAmount != null ? String(p.minOrderAmount) : '',
             validDays: p.validDays != null ? String(p.validDays) : '',
             code: p.code ?? '',
+            oncePerCustomer: p.oncePerCustomer ?? false,
         });
     };
 
@@ -120,6 +124,7 @@ export const CouponManageSection = () => {
             minOrderAmount: draft.minOrderAmount.trim() === '' ? null : Number(draft.minOrderAmount),
             validDays: draft.validDays.trim() === '' ? null : Number(draft.validDays),
             code: draft.code.trim() === '' ? null : draft.code.trim(),
+            oncePerCustomer: draft.oncePerCustomer,
         };
         try {
             const res = await fetch('/api/coupons', {
@@ -225,6 +230,11 @@ export const CouponManageSection = () => {
                                     <span>코드 (비우면 직접발급 전용)</span>
                                     <StyledInput id="cp-code" type="text" value={draft.code} placeholder="예: WELCOME5000"
                                                  onChange={(e) => {setDraft((d) => ({...d, code: e.target.value})); setError('');}} />
+                                </StyledField>
+                                <StyledField htmlFor="cp-once">
+                                    <span>고객당 1장 (미사용 보유 시 재발급 불가)</span>
+                                    <input id="cp-once" type="checkbox" checked={draft.oncePerCustomer}
+                                           onChange={(e) => setDraft((d) => ({...d, oncePerCustomer: e.target.checked}))} />
                                 </StyledField>
                             </StyledFieldGrid>
                             <FieldError variant="inline">{error}</FieldError>

--- a/client/features/coupons/model.ts
+++ b/client/features/coupons/model.ts
@@ -12,6 +12,7 @@ export interface CouponProduct {
     minOrderAmount: number | null; // 최소 결제금액 (null = 제한없음)
     validDays: number | null; // 발급일+유효일수 (null = 무기한)
     code: string | null; // 코드형이면 코드 (null = 직접발급 전용)
+    oncePerCustomer: boolean; // true = 고객당 1장(미사용 보유 시 재발급 불가)
     status: 'active' | 'archived';
 }
 

--- a/server/api/coupon-issue.ts
+++ b/server/api/coupon-issue.ts
@@ -38,6 +38,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (product.code) {
             return res.status(400).json({error: '코드형 쿠폰은 직접 발급 대상이 아닙니다.'});
         }
+        // 가드: 상품이 '고객당 1장'이면 미사용(active) 보유분이 있을 때 재발급 불가.
+        // (사용/만료/취소된 건 제외 — 다 쓰고 나면 다시 받을 수 있다.)
+        if (product.oncePerCustomer) {
+            const held = await prisma.customerCoupon.count({
+                where: {
+                    storeId: session.storeId,
+                    customerId: customer.id,
+                    productId: product.id,
+                    status: 'active',
+                },
+            });
+            if (held > 0) {
+                return res.status(400).json({error: '이미 보유 중인 쿠폰입니다. (고객당 1장)'});
+            }
+        }
 
         const expiresAt = product.validDays != null
             ? new Date(Date.now() + product.validDays * 24 * 60 * 60 * 1000)

--- a/server/api/coupons.ts
+++ b/server/api/coupons.ts
@@ -54,6 +54,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 minOrderAmount: p.minOrderAmount,
                 validDays: p.validDays,
                 code: p.code,
+                oncePerCustomer: p.oncePerCustomer,
                 status: p.status,
             })),
             coupons: coupons.map((c) => ({
@@ -79,6 +80,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const body = req.body as {
             name?: unknown; discountType?: unknown; discountValue?: unknown;
             maxDiscount?: unknown; minOrderAmount?: unknown; validDays?: unknown; code?: unknown;
+            oncePerCustomer?: unknown;
         };
 
         if (typeof body.name !== 'string' || !body.name.trim()) {
@@ -104,6 +106,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     minOrderAmount: parseOptInt(body.minOrderAmount),
                     validDays: parseOptInt(body.validDays),
                     code,
+                    oncePerCustomer: body.oncePerCustomer === true,
                 },
             });
             return res.status(200).json({
@@ -115,6 +118,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 minOrderAmount: created.minOrderAmount,
                 validDays: created.validDays,
                 code: created.code,
+                oncePerCustomer: created.oncePerCustomer,
                 status: created.status,
             });
         } catch (err) {
@@ -131,6 +135,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         const body = req.body as {
             id?: unknown; name?: unknown; discountType?: unknown; discountValue?: unknown;
             maxDiscount?: unknown; minOrderAmount?: unknown; validDays?: unknown; code?: unknown; status?: unknown;
+            oncePerCustomer?: unknown;
         };
 
         if (typeof body.id !== 'string') return res.status(400).json({error: 'Invalid id'});
@@ -167,6 +172,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     ...(body.minOrderAmount !== undefined && {minOrderAmount: parseOptInt(body.minOrderAmount)}),
                     ...(body.validDays !== undefined && {validDays: parseOptInt(body.validDays)}),
                     ...(body.code !== undefined && {code: parseCode(body.code)}),
+                    ...(body.oncePerCustomer !== undefined && {oncePerCustomer: body.oncePerCustomer === true}),
                     ...(body.status !== undefined && {status: body.status as string}),
                 },
             });

--- a/server/prisma/migrations/0017_coupon_once_per_customer/migration.sql
+++ b/server/prisma/migrations/0017_coupon_once_per_customer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CouponProduct" ADD COLUMN     "oncePerCustomer" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -523,6 +523,7 @@ model CouponProduct {
   minOrderAmount Int? // 최소 결제금액 (null=제한없음)
   validDays      Int? // 발급일+유효일수 (null=무기한)
   code           String? // 코드형이면 코드 (null=직접발급 전용)
+  oncePerCustomer Boolean         @default(false) // true=고객당 1장(미사용 보유 시 재발급 불가)
   status         String           @default("active") // active | archived
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt


### PR DESCRIPTION
## 요약
중복 발급 허용 여부를 **전역 규칙이 아니라 쿠폰 상품별 설정**으로 둡니다. (생일 쿠폰 = 1인 1장, 이벤트 쿠폰 = 여러 장 등)

> **Base가 `claude/coupon-issue-phase2`(#156)입니다** — 발급 로직(`coupon-issue.ts`)이 그 브랜치에만 있어 스택으로 올렸습니다. #156 머지 후 base가 `main`으로 자동 전환됩니다.

## 변경
| 계층 | 내용 |
|---|---|
| 스키마 | `CouponProduct.oncePerCustomer Boolean @default(false)` |
| 마이그레이션 | `0017_coupon_once_per_customer` — 컬럼 추가 |
| API | `coupons.ts` GET 반환 / POST·PUT 저장 |
| 발급 | `coupon-issue.ts` — `true`면 중복 차단 |
| 웹 UI | `CouponManageSection` 폼 체크박스 + 목록 요약에 `고객당 1장` |

## 중복 판정 규칙
```ts
if (product.oncePerCustomer) {
    const held = await prisma.customerCoupon.count({
        where: {storeId, customerId, productId, status: 'active'},
    });
    if (held > 0) return res.status(400).json({error: '이미 보유 중인 쿠폰입니다. (고객당 1장)'});
}
```
**"미사용 보유" 기준**입니다 — 사용(`used`)·만료·취소된 건은 제외하므로, 다 쓰고 나면 다시 받을 수 있습니다.
(“평생 1회”로 하려면 `status` 조건을 빼면 되지만, 그건 신규가입 쿠폰류에나 맞아 이번 범위에서 제외했습니다.)

## 안전성
- 기본값 `false` = **현재 동작 그대로** → 기존 쿠폰·발급 흐름에 영향 없음.
- 마이그레이션은 **컬럼 추가 1줄**(NOT NULL + DEFAULT false)로 기존 행 자동 채움.

## ⚠️ 리뷰 포인트
- 이 저장소는 머지 시 자동 배포됩니다 — **자동 머지 제외 + 사람 리뷰** 부탁드립니다.
- **DB 마이그레이션이 포함**된 첫 PR입니다(#156·#157은 마이그레이션 없음). 배포 파이프라인의 마이그레이션 적용 방식 확인 부탁드립니다.
- 회원권(`MembershipProduct`)에는 이번에 넣지 않았습니다 — 10회권을 소진 전 추가 구매하는 게 자연스러워 "고객당 1개" 수요가 불분명합니다. 필요하면 동일 패턴으로 추가 가능합니다.

## 관련
- #156 쿠폰 발급 엔드포인트(base)
- #157 회원권 발급 가드
- iOS(`mjkang0987/tas-ios`)에도 동일 필드·폼 토글·발급 안내를 반영합니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWhk8JfVMi3UNFRuF4Fm45)_