### PR TITLE
refactor(book): 공개 예약 페이지에서 세션 조회·AdSense 스크립트 제거

### DIFF
--- a/client/components/layout/LayoutComponent.tsx
+++ b/client/components/layout/LayoutComponent.tsx
@@ -11,6 +11,7 @@ import {useSession} from 'next-auth/react';
 
 import styled from 'styled-components';
 
+import {isBookingRoute} from '../../features/booking/routing';
 import {useCalendarStore} from '../../store/calendarStore';
 import {useIsomorphicEffect} from '../../hooks/useIsomorphicEffect';
 
@@ -36,7 +37,8 @@ export default function LayoutComponent({children}: NodeType) {
     const isOnboardingPage = router.pathname.startsWith('/onboarding');
     const isPublicPolicyPage = router.pathname === '/terms' || router.pathname === '/privacy';
     const isMaintenancePage = router.pathname === '/maintenance';
-    const isBookingPage = router.pathname.startsWith('/book/');
+    // _app이 공개 예약 페이지를 세션 트리 밖에서 렌더하므로 평소엔 여기 도달하지 않는다(안전망).
+    const isBookingPage = isBookingRoute(router.pathname);
     // 로그인/소개/온보딩/동의/점검은 항상 풀페이지. 약관·개인정보는 미인증(로그인 전)일 때만
     // 앱 셸(Aside·Header) 없이 풀페이지로, 로그인 사용자에겐 셸 안에서 보여준다.
     // (DPA 는 운영자 전용 — 미인증 접근은 proxy.ts 에서 /login 으로 리다이렉트)

--- a/client/features/booking/routing.ts
+++ b/client/features/booking/routing.ts
@@ -32,6 +32,12 @@ const MAIN_HOSTS = ['takeaseat.co.kr', 'www.takeaseat.co.kr'];
 // 내부 Next 라우트 접두. 예약 서브도메인에서는 공개 URL에 노출되지 않는다.
 export const BOOK_ROUTE_PREFIX = '/book';
 
+// 공개 예약 페이지의 내부 라우트인지(= 비로그인 고객 구역). `router.pathname` 기준이라
+// 호스트·rewrite와 무관하게 항상 `/book/...` 이다. 앱 셸·세션·게이트 예외 판정의 단일 소스.
+export function isBookingRoute(pathname: string | undefined | null): boolean {
+    return !!pathname && pathname.startsWith(`${BOOK_ROUTE_PREFIX}/`);
+}
+
 // 프록시가 Host를 갈아끼우는 경우가 있어 x-forwarded-host를 우선 본다(둘 다 없으면 빈 문자열).
 export function resolveRequestHost(forwardedHost?: string | null, host?: string | null): string {
     const raw = forwardedHost || host || '';

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -22,6 +22,7 @@ import {toCustomerMap} from '../utils/customers';
 import {clearGuestEntryResolved, clearGuestTermsAgreed, createDefaultLocalDbSnapshot, getGuestTermsVersion, hasGuestData, isGuestConsentAck, isGuestEntryResolved, loadLocalDbSnapshot, markGuestEntryResolved, saveLocalDbSnapshot, setAuthenticated, shouldUseLocalDb} from '../lib/local-db';
 import {CURRENT_TERMS_VERSION} from '../utils/terms';
 import {SITE_TITLE} from '../lib/seo';
+import {isBookingRoute} from '../features/booking/routing';
 
 import LayoutComponent from '../components/layout/LayoutComponent';
 import {ToastContainer} from '../components/ui/ToastContainer';
@@ -167,7 +168,7 @@ function AppContent({Component, pageProps}: AppContentProps) {
         const path = router.pathname;
 
         // 로그인 / 약관 문서 / 공개 예약 페이지는 자유 접근
-        if (path === '/login' || path === '/about' || path === '/terms' || path === '/privacy' || path === '/logout' || path === '/maintenance' || path.startsWith('/book/')) return;
+        if (path === '/login' || path === '/about' || path === '/terms' || path === '/privacy' || path === '/logout' || path === '/maintenance' || isBookingRoute(path)) return;
 
         const consented = getGuestTermsVersion() === CURRENT_TERMS_VERSION;
         // 영구 동의는 온보딩 완료 시점에 기록되므로, 온보딩 진입 가드는 세션 ack도 허용
@@ -385,7 +386,7 @@ function AppContent({Component, pageProps}: AppContentProps) {
     // 데이터(서비스·담당자·예약)가 모두 준비될 때까지 오버레이로 가려 새로고침 플래시를 막음.
     // SSR/첫 렌더 모두 status==='loading'이라 하이드레이션 불일치가 없음.
     const isAuthFlowPage = router.pathname.startsWith('/login') || router.pathname.startsWith('/onboarding')
-        || router.pathname.startsWith('/book/')
+        || isBookingRoute(router.pathname)
         || router.pathname === '/consent' || router.pathname === '/about' || router.pathname === '/logout'
         || router.pathname === '/terms' || router.pathname === '/privacy' || router.pathname === '/maintenance';
     // 미인증 + 로컬데이터 없음 = /login 리다이렉트 대기 → 달력이 깜빡이지 않게 오버레이 유지
@@ -570,6 +571,26 @@ const StyledSessionExpiredClose = styled.button`
 `;
 
 function App({Component, pageProps: {session, ...pageProps}}: AppProps) {
+    const router = useRouter();
+
+    // 공개 예약 페이지는 비로그인 고객 전용이라 세션이 필요 없다.
+    // SessionProvider로 감싸면 고객이 방문할 때마다 /api/auth/session 을 치고
+    // authjs 쿠키(csrf-token·callback-url)가 고객 브라우저에 남는다.
+    // 앱 셸(LayoutComponent)도 useSession을 쓰는데, 예약 페이지에선 어차피 통과(isBarePage)일 뿐이라
+    // 세션 트리 전체를 건너뛰고 페이지만 렌더한다.
+    if (isBookingRoute(router.pathname)) {
+        return (
+            <>
+                <Head>
+                    <title>{SITE_TITLE}</title>
+                </Head>
+                <GlobalStyle/>
+                <RouteLoadingSpinner />
+                <Component {...pageProps} />
+            </>
+        );
+    }
+
     return (
         <SessionProvider session={session}>
             <RouteLoadingSpinner />

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -4,6 +4,7 @@ import {ServerStyleSheet} from 'styled-components';
 
 import {SITE_KEYWORDS, SITE_OG_DESCRIPTION, SITE_OG_IMAGE, SITE_OG_IMAGE_HEIGHT, SITE_OG_IMAGE_WIDTH, SITE_TITLE, SITE_TWITTER_DESCRIPTION, SITE_URL} from '../lib/seo';
 import {ADSENSE_CLIENT} from '../lib/ads';
+import {isBookingRoute} from '../features/booking/routing';
 
 class ReservationDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
@@ -33,6 +34,9 @@ class ReservationDocument extends Document {
     }
 
     render() {
+        // 공개 예약 페이지에는 광고 유닛(AdBanner)이 하나도 렌더되지 않는다(isBarePage라 Footer 광고 영역을 안 탐).
+        // 스크립트만 로드되면 고객 브라우저에 광고 식별 쿠키(__eoi·_gcl_au)만 남으므로 제외한다.
+        const isBookingPage = isBookingRoute(this.props.__NEXT_DATA__?.page);
         return (
             <Html lang="ko">
                 <Head>
@@ -65,7 +69,7 @@ class ReservationDocument extends Document {
                           href="/favicon/apple-icon-180x180.png" />
                     <link rel="manifest"
                           href="/favicon/manifest.json" />
-                    {ADSENSE_CLIENT && (
+                    {ADSENSE_CLIENT && !isBookingPage && (
                         <script async
                                 src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
                                 crossOrigin="anonymous" />


### PR DESCRIPTION
Closes #162

비로그인 고객만 쓰는 공개 예약 페이지가 인증·광고 관련 부수 효과를 끌고 다니던 것을 정리한다. `book.takeaseat.co.kr` 이전(#158) 후 쿠키를 점검하다 발견한 건들.

## 1. 세션 조회 제거 (#162)

`pages/_app.tsx`의 `App`이 모든 페이지를 `<SessionProvider>`로 감싸고 `AppContent`가 `useSession()`을 호출해, 예약 페이지에서도 고객 방문마다 `/api/auth/session` 요청이 나가고 authjs 쿠키가 남았다.

```
__Host-authjs.csrf-token
__Secure-authjs.callback-url
```

(로그인 세션 토큰은 새지 않았다 — 호스트 격리는 정상. 위 둘은 book 호스트가 자기 `/api/auth/*`를 호출하며 스스로 발급한 값.)

앱 셸 `LayoutComponent`도 `useSession()`을 쓰지만 예약 페이지에선 `isBarePage`라 `<>{children}</>` 통과일 뿐이다. 그래서 **세션 트리 전체를 건너뛰고 페이지만 렌더**하도록 `App`에서 분기했다(`Head` 타이틀 폴백 · `GlobalStyle` · `RouteLoadingSpinner`는 유지).

라우트 판정이 `_app.tsx` 2곳 + `LayoutComponent` 1곳에 문자열로 흩어져 있던 것을 `features/booking/routing.ts`의 **`isBookingRoute()`로 통일**했다(드리프트 방지). `LayoutComponent`의 bare 판정은 이제 도달하지 않지만 안전망으로 남겨두고 주석을 달았다.

## 2. AdSense 스크립트 미로드

예약 페이지에는 광고 유닛(`AdBanner`)이 **하나도 렌더되지 않는다**(`isBarePage`라 Footer 광고 영역을 안 탐). 그런데 `_document.tsx`가 전 페이지에 `adsbygoogle.js`를 붙여, 고객 브라우저에 광고 식별 쿠키(`__eoi`·`_gcl_au`)만 남았다. 예약 라우트에서는 스크립트를 내보내지 않도록 했다.

#163의 일부다. **#163은 닫지 않는다** — `_ga`·`_fbp`·`dable_uid`는 앱 코드에서 나오는 게 아니라(저장소 전체 검색 0건) 엣지 태그 주입으로 추정되며, 그 확인·조치는 저장소 밖(Cloudflare)이다.

## 검증

`tsc --noEmit` 0 · `next build` 성공.

**실브라우저(Playwright, 로컬 Postgres + 시드 매장, `NEXT_PUBLIC_BOOKING_HOST`로 서브도메인 재현)** — 요청·쿠키를 직접 계수:

| 페이지 | `/api/auth/*` | `adsbygoogle` | 쿠키 |
|---|---|---|---|
| 예약 랜딩 `book./myshop` | **0건** | **0건** | **없음** |
| 언어 전환 후 `book./en/myshop` | **0건** | **0건** | **없음** |
| 예약 관리 `book./myshop/r/<token>` | **0건** | **0건** | **없음** |
| 운영자 `/login` (회귀) | 2건 | 1건 | authjs.csrf-token, authjs.callback-url |

예약 페이지는 렌더·언어 전환 정상(`예약 서비스` → `Book a Reservation`), 페이지 에러 0. 운영자 앱 무회귀: `/`→`/about`, `/menu`·`/settings/booking`→`/login`(게스트 가드), `/terms` 렌더, 전부 에러 0.

## 관련

- #163 — 남은 광고·분석 쿠키(`_ga`·`_fbp`·`dable_uid`) 출처 확인 (Cloudflare 측)
- #164 — 고객 예약 시 개인정보 수집·이용 동의 (별건, 결정 대기)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp4W77JwD5GKzCw2nR4tAa)_