### PR TITLE
chore: 미사용 고객 메모 3종 제거 + 사람 진료 업종 제외

### DIFF
--- a/client/components/layout/LayoutComponent.tsx
+++ b/client/components/layout/LayoutComponent.tsx
@@ -11,6 +11,7 @@ import {useSession} from 'next-auth/react';
 
 import styled from 'styled-components';
 
+import {isBookingRoute} from '../../features/booking/routing';
 import {useCalendarStore} from '../../store/calendarStore';
 import {useIsomorphicEffect} from '../../hooks/useIsomorphicEffect';
 
@@ -36,7 +37,8 @@ export default function LayoutComponent({children}: NodeType) {
     const isOnboardingPage = router.pathname.startsWith('/onboarding');
     const isPublicPolicyPage = router.pathname === '/terms' || router.pathname === '/privacy';
     const isMaintenancePage = router.pathname === '/maintenance';
-    const isBookingPage = router.pathname.startsWith('/book/');
+    // _app이 공개 예약 페이지를 세션 트리 밖에서 렌더하므로 평소엔 여기 도달하지 않는다(안전망).
+    const isBookingPage = isBookingRoute(router.pathname);
     // 로그인/소개/온보딩/동의/점검은 항상 풀페이지. 약관·개인정보는 미인증(로그인 전)일 때만
     // 앱 셸(Aside·Header) 없이 풀페이지로, 로그인 사용자에겐 셸 안에서 보여준다.
     // (DPA 는 운영자 전용 — 미인증 접근은 proxy.ts 에서 /login 으로 리다이렉트)

--- a/client/components/modals/CustomerMergeSuggestionModal.tsx
+++ b/client/components/modals/CustomerMergeSuggestionModal.tsx
@@ -160,7 +160,6 @@ export const CustomerMergeSuggestionModal = ({
                             const resCount = countReservations(customer.id, reservationMap);
                             const lastRes = getLastReservation(customer.id, reservationMap);
                             const hasTags = customer.memoTags && customer.memoTags.length > 0;
-                            const hasNotes = customer.allergyNote || customer.claimNote || customer.preferenceNote;
                             const assigneeName = lastRes?.assigneeId
                                 ? (assigneeNameMap[lastRes.assigneeId] ?? '미지정')
                                 : '미지정';
@@ -223,13 +222,6 @@ export const CustomerMergeSuggestionModal = ({
                                                     <StyledTag key={i} $color={tag.color}>{tag.text}</StyledTag>
                                                 ))}
                                             </StyledTagList>
-                                        )}
-                                        {hasNotes && (
-                                            <StyledNotes>
-                                                {customer.allergyNote && <StyledNoteItem>알레르기: {customer.allergyNote}</StyledNoteItem>}
-                                                {customer.preferenceNote && <StyledNoteItem>선호: {customer.preferenceNote}</StyledNoteItem>}
-                                                {customer.claimNote && <StyledNoteItem>클레임: {customer.claimNote}</StyledNoteItem>}
-                                            </StyledNotes>
                                         )}
                                         {lastRes && (
                                             <StyledCardSection onClick={(e) => e.stopPropagation()}>
@@ -401,21 +393,6 @@ const StyledTag = styled.span<{$color: string}>`
     font-weight: 600;
     background: ${(p) => p.$color}1a;
     color: ${(p) => p.$color};
-`;
-
-const StyledNotes = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    font-size: 11px;
-    color: var(--dark-gray-color);
-    line-height: 1.4;
-`;
-
-const StyledNoteItem = styled.span`
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 `;
 
 const StyledCardSection = styled.div`

--- a/client/features/booking/routing.ts
+++ b/client/features/booking/routing.ts
@@ -32,6 +32,12 @@ const MAIN_HOSTS = ['takeaseat.co.kr', 'www.takeaseat.co.kr'];
 // 내부 Next 라우트 접두. 예약 서브도메인에서는 공개 URL에 노출되지 않는다.
 export const BOOK_ROUTE_PREFIX = '/book';
 
+// 공개 예약 페이지의 내부 라우트인지(= 비로그인 고객 구역). `router.pathname` 기준이라
+// 호스트·rewrite와 무관하게 항상 `/book/...` 이다. 앱 셸·세션·게이트 예외 판정의 단일 소스.
+export function isBookingRoute(pathname: string | undefined | null): boolean {
+    return !!pathname && pathname.startsWith(`${BOOK_ROUTE_PREFIX}/`);
+}
+
 // 프록시가 Host를 갈아끼우는 경우가 있어 x-forwarded-host를 우선 본다(둘 다 없으면 빈 문자열).
 export function resolveRequestHost(forwardedHost?: string | null, host?: string | null): string {
     const raw = forwardedHost || host || '';

--- a/client/features/customers/model.ts
+++ b/client/features/customers/model.ts
@@ -34,9 +34,6 @@ export interface Customer {
     firstVisitDate?: string | null;
     pointHistories?: PointHistoryEntry[];
     memoTags?: CustomerMemoTag[];
-    allergyNote?: string;
-    claimNote?: string;
-    preferenceNote?: string;
 }
 
 export type CustomerMap = Record<number, Customer>;

--- a/client/features/services/default-services.ts
+++ b/client/features/services/default-services.ts
@@ -3,8 +3,8 @@ export type ShopType =
     | 'hair' | 'nail' | 'waxing' | 'lash' | 'skin' | 'makeup' | 'tattoo'
     // food
     | 'restaurant' | 'cafe' | 'bar'
-    // medical
-    | 'clinic' | 'dental' | 'oriental' | 'vet'
+    // medical (사람 진료는 업종 목록에서 제외 — labels.ts 주석 참고. 동물병원만 유지)
+    | 'vet'
     // fitness
     | 'gym' | 'yoga' | 'golf' | 'dance'
     // class / education

--- a/client/features/store-settings/labels.ts
+++ b/client/features/store-settings/labels.ts
@@ -62,10 +62,10 @@ export const SHOP_INDUSTRIES: ShopIndustry[] = [
     {value: 'restaurant', label: '음식점', emoji: '🍽️', desc: '식당·레스토랑', category: 'food'},
     {value: 'cafe', label: '카페', emoji: '☕', desc: '카페·디저트', category: 'food'},
     {value: 'bar', label: '주점·바', emoji: '🍺', desc: '바·펍·주점', category: 'food'},
-    // 의료
-    {value: 'clinic', label: '병원·의원', emoji: '🏥', desc: '진료·검진', category: 'medical'},
-    {value: 'dental', label: '치과', emoji: '🦷', desc: '치과 진료', category: 'medical'},
-    {value: 'oriental', label: '한의원', emoji: '🌿', desc: '한방 진료', category: 'medical'},
+    // 의료 — 사람 진료(병원·의원/치과/한의원)는 목록에서 제외한다.
+    // 진료 내용은 건강정보(민감정보)라 개인정보보호법 제23조의 별도 동의·안전조치가 필요한데
+    // 예약 요청사항 등 자유 입력 경로가 열려 있어 현재 구조로는 감당하지 않는다(#167).
+    // 동물병원은 반려동물 정보라 사람 민감정보에 해당하지 않아 유지.
     {value: 'vet', label: '동물병원', emoji: '🐾', desc: '반려동물 진료', category: 'medical'},
     // 피트니스
     {value: 'gym', label: '헬스·PT', emoji: '💪', desc: '헬스·퍼스널 트레이닝', category: 'fitness'},

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -22,6 +22,7 @@ import {toCustomerMap} from '../utils/customers';
 import {clearGuestEntryResolved, clearGuestTermsAgreed, createDefaultLocalDbSnapshot, getGuestTermsVersion, hasGuestData, isGuestConsentAck, isGuestEntryResolved, loadLocalDbSnapshot, markGuestEntryResolved, saveLocalDbSnapshot, setAuthenticated, shouldUseLocalDb} from '../lib/local-db';
 import {CURRENT_TERMS_VERSION} from '../utils/terms';
 import {SITE_TITLE} from '../lib/seo';
+import {isBookingRoute} from '../features/booking/routing';
 
 import LayoutComponent from '../components/layout/LayoutComponent';
 import {ToastContainer} from '../components/ui/ToastContainer';
@@ -167,7 +168,7 @@ function AppContent({Component, pageProps}: AppContentProps) {
         const path = router.pathname;
 
         // 로그인 / 약관 문서 / 공개 예약 페이지는 자유 접근
-        if (path === '/login' || path === '/about' || path === '/terms' || path === '/privacy' || path === '/logout' || path === '/maintenance' || path.startsWith('/book/')) return;
+        if (path === '/login' || path === '/about' || path === '/terms' || path === '/privacy' || path === '/logout' || path === '/maintenance' || isBookingRoute(path)) return;
 
         const consented = getGuestTermsVersion() === CURRENT_TERMS_VERSION;
         // 영구 동의는 온보딩 완료 시점에 기록되므로, 온보딩 진입 가드는 세션 ack도 허용
@@ -385,7 +386,7 @@ function AppContent({Component, pageProps}: AppContentProps) {
     // 데이터(서비스·담당자·예약)가 모두 준비될 때까지 오버레이로 가려 새로고침 플래시를 막음.
     // SSR/첫 렌더 모두 status==='loading'이라 하이드레이션 불일치가 없음.
     const isAuthFlowPage = router.pathname.startsWith('/login') || router.pathname.startsWith('/onboarding')
-        || router.pathname.startsWith('/book/')
+        || isBookingRoute(router.pathname)
         || router.pathname === '/consent' || router.pathname === '/about' || router.pathname === '/logout'
         || router.pathname === '/terms' || router.pathname === '/privacy' || router.pathname === '/maintenance';
     // 미인증 + 로컬데이터 없음 = /login 리다이렉트 대기 → 달력이 깜빡이지 않게 오버레이 유지
@@ -570,6 +571,26 @@ const StyledSessionExpiredClose = styled.button`
 `;
 
 function App({Component, pageProps: {session, ...pageProps}}: AppProps) {
+    const router = useRouter();
+
+    // 공개 예약 페이지는 비로그인 고객 전용이라 세션이 필요 없다.
+    // SessionProvider로 감싸면 고객이 방문할 때마다 /api/auth/session 을 치고
+    // authjs 쿠키(csrf-token·callback-url)가 고객 브라우저에 남는다.
+    // 앱 셸(LayoutComponent)도 useSession을 쓰는데, 예약 페이지에선 어차피 통과(isBarePage)일 뿐이라
+    // 세션 트리 전체를 건너뛰고 페이지만 렌더한다.
+    if (isBookingRoute(router.pathname)) {
+        return (
+            <>
+                <Head>
+                    <title>{SITE_TITLE}</title>
+                </Head>
+                <GlobalStyle/>
+                <RouteLoadingSpinner />
+                <Component {...pageProps} />
+            </>
+        );
+    }
+
     return (
         <SessionProvider session={session}>
             <RouteLoadingSpinner />

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -4,6 +4,7 @@ import {ServerStyleSheet} from 'styled-components';
 
 import {SITE_KEYWORDS, SITE_OG_DESCRIPTION, SITE_OG_IMAGE, SITE_OG_IMAGE_HEIGHT, SITE_OG_IMAGE_WIDTH, SITE_TITLE, SITE_TWITTER_DESCRIPTION, SITE_URL} from '../lib/seo';
 import {ADSENSE_CLIENT} from '../lib/ads';
+import {isBookingRoute} from '../features/booking/routing';
 
 class ReservationDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
@@ -33,6 +34,9 @@ class ReservationDocument extends Document {
     }
 
     render() {
+        // 공개 예약 페이지에는 광고 유닛(AdBanner)이 하나도 렌더되지 않는다(isBarePage라 Footer 광고 영역을 안 탐).
+        // 스크립트만 로드되면 고객 브라우저에 광고 식별 쿠키(__eoi·_gcl_au)만 남으므로 제외한다.
+        const isBookingPage = isBookingRoute(this.props.__NEXT_DATA__?.page);
         return (
             <Html lang="ko">
                 <Head>
@@ -65,7 +69,7 @@ class ReservationDocument extends Document {
                           href="/favicon/apple-icon-180x180.png" />
                     <link rel="manifest"
                           href="/favicon/manifest.json" />
-                    {ADSENSE_CLIENT && (
+                    {ADSENSE_CLIENT && !isBookingPage && (
                         <script async
                                 src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
                                 crossOrigin="anonymous" />

--- a/index.md
+++ b/index.md
@@ -108,7 +108,7 @@ hair_reservations/
 | 파일 | 모델 | 핵심 필드 |
 |------|------|----------|
 | `reservations/model.ts` | `Reservation` | id, date, startTime/endTime, customerId, assigneeId?, service, status[^4], price, naverBookingId?, channel[^5], publicToken?(온라인예약 고객 관리 링크) |
-| `customers/model.ts` | `Customer` | id, name, tel, points, memoTags, pointHistories, allergyNote, claimNote, preferenceNote. 헬퍼: `formatTel`(표시 000-0000-0000)·`normalizeTel`(저장용 숫자만, 단일 출처) |
+| `customers/model.ts` | `Customer` | id, name, tel, points, memoTags, pointHistories. 헬퍼: `formatTel`(표시 000-0000-0000)·`normalizeTel`(저장용 숫자만, 단일 출처) |
 | `memberships/model.ts` | `MembershipProduct`/`CustomerMembership` | 회원권(횟수·기간권, 적립금과 별개). product: totalCount?/validDays?/price/status, 발급분: remainingCount/expiresAt?/status |
 | `assignees/model.ts` | `Assignee` | id, name, schedule(7일), status[^6], color, phone |
 | `services/model.ts` | `ServiceItem` | name, durationMinutes, category, price |
@@ -423,7 +423,7 @@ StorePointSettings (적립률, 충전규칙)
 |----------|---------|------------|------------|
 | beauty | 헤어/네일/왁싱/속눈썹/피부/메이크업/반영구 | 담당자 | 서비스 |
 | food | 음식점/카페/주점·바 | 테이블 | 메뉴 |
-| medical | 병원·의원/치과/한의원/동물병원 | 담당의 | 진료 |
+| medical | 동물병원 | 담당의 | 진료 |[^26]
 | fitness | 헬스·PT/요가·필라테스/골프/댄스 | 강사 | 수업 |
 | class | 학원/공방·클래스/과외 | 선생님 | 수업 |
 | pet | 애견미용 | 담당자 | 서비스 |
@@ -431,6 +431,8 @@ StorePointSettings (적립률, 충전규칙)
 | space | 공간대여/연습실 | 룸 | 이용 |
 | counsel | 상담 | 상담사 | 상담 |
 | etc | 기타 | 담당자 | 서비스 |
+
+[^26]: **사람 진료 업종(병원·의원·치과·한의원)은 업종 목록에서 제외**(마이그레이션 `0018` 작업 시 함께 정리). 진료 내용은 건강정보(민감정보)라 개인정보보호법 제23조의 별도 동의·안전조치가 필요한데, 예약 요청사항(`Reservation.memo`) 등 자유 입력 경로가 열려 있어 현재 구조로는 감당하지 않는다. 동물병원은 반려동물 정보라 사람 민감정보가 아니어서 유지. 되살리려면 이슈 #167의 체크리스트를 함께 이행할 것.
 
 > 적용 범위: aside 메뉴·담당자 관리·서비스 관리 등 운영 화면(예약 폼·캘린더·매출 포함, 단계적 확대). 기존 뷰티 매장은 표시어 변화 없음(담당자/서비스 유지).
 

--- a/plan.md
+++ b/plan.md
@@ -4,6 +4,35 @@
 
 ---
 
+## 진행 중 — 고객 개인정보 정리 (예약 페이지 이전 후속)
+
+> 배경: `book.takeaseat.co.kr` 이전(#158) 직후 쿠키를 점검하다 공개 예약 페이지가 동의 게이트 밖이라는 점에서 파생된 건들. 이슈 #162·#163·#164·#166·#167.
+
+### 완료
+- **#162 공개 예약 페이지 세션 조회 제거** (PR #165 머지) — `_app`이 예약 라우트를 `SessionProvider` 밖에서 렌더. 예약 페이지 `/api/auth/*` 0건·쿠키 0개. 라우트 판정은 `features/booking/routing.ts`의 `isBookingRoute`로 통일.
+- **#163 일부** (PR #165) — 예약 페이지에 광고 유닛이 없으므로 AdSense 스크립트 미로드. 나머지(`_ga`·`_fbp`·`dable_uid`)는 앱 코드 밖(Cloudflare 엣지 주입 추정) → 사용자 확인 대기.
+
+### 이번 작업 — #167 고객 메모 3종 제거 + 사람 진료 업종 제외
+- **`allergyNote`·`claimNote`·`preferenceNote` 완전 제거.** 초기 임포트 시절 레거시로, **입력 UI가 없어 값을 넣을 방법이 없었고** 병합 제안 모달에서 표시만 했다. 운영 데이터 **3종 모두 0건 확인**(사용자).
+  - 코드 배선 제거: 클라 모델·병합 모달(+미사용 styled)·`mappers.ts`·`customers.ts`·`customers-merge/unmerge.ts`·`migrate-local.ts`·`seed.mjs`·`seed-data/customers.json`.
+  - **마이그레이션 `0018_drop_unused_customer_notes`** — `DROP COLUMN IF EXISTS` ×3(멱등).
+  - **⚠️ 배포 순서가 평소와 반대: 코드 배포 먼저 → 마이그레이션 나중.** `customers.ts`의 고객 조회가 `include`(전체 컬럼 SELECT)라, 컬럼을 먼저 지우면 구버전 Prisma 클라이언트가 없는 컬럼을 SELECT 해 **전체 고객 조회가 500**난다(2026-07 `publicToken` 사고와 같은 구조, 방향만 반대). 코드를 먼저 배포하면 컬럼이 남아도 아무도 읽지 않아 무해하다.
+- **업종 목록에서 사람 진료 3종 제외** (병원·의원/치과/한의원). 진료 내용은 건강정보(민감정보)라 §23 별도 동의·안전조치가 필요한데 예약 요청사항 등 자유 입력 경로가 열려 있어 현 구조로 감당하지 않는다. **동물병원은 유지**(반려동물 정보는 사람 민감정보 아님).
+  - 주의: `sanitizeShopType`이 목록 밖 값을 걸러 `null`로 만들므로, 해당 업종 매장이 있으면 다음 저장 때 업종이 지워진다 → 사용자 확인 필요.
+
+### 검증 (완료)
+- ✅ `tsc --noEmit` 0 · `next build` 성공.
+- ✅ 로컬 Postgres에 `0018` 적용(대상 datasource가 로컬 `takeaseat`임을 출력으로 확인 후 실행). 컬럼 3개 제거 확인, **스키마 드리프트 0**(`migrate diff --exit-code` 0).
+- ✅ **컬럼 없는 DB에서 `customers.ts`와 동일한 `include` 쿼리 직접 실행** → 정상 조회, 응답에 노트 필드 없음. 공개 예약 생성(Customer upsert 경유) 201. Prisma 에러 0건.
+
+### 남은 것
+- **#164** 고객 예약 시 개인정보 수집·이용 안내 — 방향 확정됨(안내 방식·문서 2건·4개국어·서버 검증), 체크박스 여부만 미정.
+- **#166** 삭제 요청 시 매출 이력 소실(익명화) — 실제 요청 발생 시 판단.
+- **#163** 광고·분석 쿠키 출처 — Cloudflare Zaraz 확인(사용자).
+- **#167** 되살릴 경우 체크리스트는 이슈에 보존.
+
+---
+
 ## 완료(운영 반영 확인됨 2026-07-27) — 고객 예약 페이지 경로 이전 (`takeaseat.co.kr/book/[slug]` → `book.takeaseat.co.kr/[slug]`)
 
 > 요청(사용자): 고객예약페이지 path 변경 — `takeaseat.co.kr/book` → `book.takeaseat.co.kr`.

--- a/server/api/customers-merge.ts
+++ b/server/api/customers-merge.ts
@@ -97,9 +97,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                         tel: source.tel,
                         points: source.points,
                         firstVisitDate: source.firstVisitDate,
-                        allergyNote: source.allergyNote,
-                        claimNote: source.claimNote,
-                        preferenceNote: source.preferenceNote,
                         memoTags: source.memoTags.map((t) => ({text: t.text, color: t.color})),
                     },
                     targetCustomerJson: {

--- a/server/api/customers-unmerge.ts
+++ b/server/api/customers-unmerge.ts
@@ -11,9 +11,6 @@ type SourceSnapshot = {
     tel: string;
     points: number;
     firstVisitDate: string | null;
-    allergyNote: string | null;
-    claimNote: string | null;
-    preferenceNote: string | null;
     memoTags: { text: string; color: string }[];
 };
 
@@ -69,9 +66,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     tel: normalizeTel(source.tel),
                     points: source.points,
                     firstVisitDate: source.firstVisitDate ? new Date(source.firstVisitDate) : null,
-                    allergyNote: source.allergyNote,
-                    claimNote: source.claimNote,
-                    preferenceNote: source.preferenceNote,
                 },
             });
 

--- a/server/api/customers.ts
+++ b/server/api/customers.ts
@@ -45,9 +45,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             tel: normalizeTel(customer.tel),
             points: customer.points ?? 0,
             firstVisitDate: customer.firstVisitDate ? new Date(`${customer.firstVisitDate}T00:00:00`) : null,
-            allergyNote: customer.allergyNote ?? null,
-            claimNote: customer.claimNote ?? null,
-            preferenceNote: customer.preferenceNote ?? null,
         };
 
         await prisma.customer.upsert({
@@ -120,9 +117,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                             tel: normalizeTel(customer.tel),
                             points: customer.points ?? 0,
                             firstVisitDate: customer.firstVisitDate ? new Date(`${customer.firstVisitDate}T00:00:00`) : null,
-                            allergyNote: customer.allergyNote ?? null,
-                            claimNote: customer.claimNote ?? null,
-                            preferenceNote: customer.preferenceNote ?? null,
                         },
                         create: {
                             storeId: session.storeId,
@@ -131,9 +125,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                             tel: normalizeTel(customer.tel),
                             points: customer.points ?? 0,
                             firstVisitDate: customer.firstVisitDate ? new Date(`${customer.firstVisitDate}T00:00:00`) : null,
-                            allergyNote: customer.allergyNote ?? null,
-                            claimNote: customer.claimNote ?? null,
-                            preferenceNote: customer.preferenceNote ?? null,
                         },
                     });
 

--- a/server/api/migrate-local.ts
+++ b/server/api/migrate-local.ts
@@ -103,9 +103,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                             tel: normalizeTel(c.tel ?? ''),
                             points: c.points ?? 0,
                             firstVisitDate: c.firstVisitDate ? new Date(`${c.firstVisitDate}T00:00:00`) : null,
-                            allergyNote: c.allergyNote ?? null,
-                            claimNote: c.claimNote ?? null,
-                            preferenceNote: c.preferenceNote ?? null,
                         },
                     });
                     customerCuidMap.set(c.id, created.id);
@@ -183,9 +180,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                             tel: normalizeTel(c.tel ?? ''),
                             points: c.points ?? 0,
                             firstVisitDate: c.firstVisitDate ? new Date(`${c.firstVisitDate}T00:00:00`) : null,
-                            allergyNote: c.allergyNote ?? null,
-                            claimNote: c.claimNote ?? null,
-                            preferenceNote: c.preferenceNote ?? null,
                         },
                     });
                     customerCuidMap.set(c.id, created.id);

--- a/server/db/mappers.ts
+++ b/server/db/mappers.ts
@@ -160,9 +160,6 @@ type DbCustomerRow = {
     tel: string;
     points: number;
     firstVisitDate: Date | null;
-    allergyNote: string | null;
-    claimNote: string | null;
-    preferenceNote: string | null;
     memoTags: Array<{ text: string; color: string }>;
     pointHistories: Array<{
         id: string;
@@ -192,9 +189,6 @@ export function dbCustomerToFrontend(row: DbCustomerRow): Customer {
             createdAt: h.createdAt.toISOString(),
             ...(h.relatedReservation?.legacyId != null && {relatedReservationId: h.relatedReservation.legacyId}),
         })),
-        ...(row.allergyNote !== null && {allergyNote: row.allergyNote}),
-        ...(row.claimNote !== null && {claimNote: row.claimNote}),
-        ...(row.preferenceNote !== null && {preferenceNote: row.preferenceNote}),
     };
 }
 

--- a/server/prisma/migrations/0018_drop_unused_customer_notes/migration.sql
+++ b/server/prisma/migrations/0018_drop_unused_customer_notes/migration.sql
@@ -1,0 +1,20 @@
+-- 고객 메모 3종(allergyNote·claimNote·preferenceNote) 컬럼 제거.
+--
+-- 배경: 초기 임포트 시절의 레거시 컬럼으로, 입력 UI가 없어 값을 넣을 방법이 없었다.
+-- 운영 데이터 0건 확인 후 앱 배선(모델·매퍼·API·병합 모달)을 전부 제거했다(#167).
+-- allergyNote 는 건강정보(민감정보)라 되살릴 경우 개인정보보호법 제23조 별도 동의가 필요하다.
+--
+-- ⚠️ 적용 순서가 평소와 반대다 — "코드 배포 먼저, 이 마이그레이션 나중".
+--   server/api/customers.ts 의 고객 조회가 include(=전체 컬럼 SELECT)를 쓴다.
+--   컬럼을 먼저 지우면 구버전 Prisma 클라이언트가 없는 컬럼을 SELECT 해 전체 고객 조회가 500난다
+--   (2026-07 publicToken 배포순서 사고와 같은 구조, 방향만 반대).
+--   반대로 코드를 먼저 배포하면 컬럼이 남아 있어도 아무도 읽지 않으므로 무해하다.
+--
+-- IF EXISTS 로 멱등. 데이터 0건 확인 후 실행할 것:
+--   SELECT COUNT(*) FILTER (WHERE "allergyNote"    IS NOT NULL AND "allergyNote"    <> '') AS allergy,
+--          COUNT(*) FILTER (WHERE "claimNote"      IS NOT NULL AND "claimNote"      <> '') AS claim,
+--          COUNT(*) FILTER (WHERE "preferenceNote" IS NOT NULL AND "preferenceNote" <> '') AS pref
+--   FROM "Customer";
+ALTER TABLE "Customer" DROP COLUMN IF EXISTS "allergyNote";
+ALTER TABLE "Customer" DROP COLUMN IF EXISTS "claimNote";
+ALTER TABLE "Customer" DROP COLUMN IF EXISTS "preferenceNote";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -110,9 +110,6 @@ model Customer {
   tel            String
   points         Int                    @default(0)
   firstVisitDate DateTime?
-  allergyNote    String?
-  claimNote      String?
-  preferenceNote String?
   createdAt      DateTime               @default(now())
   updatedAt      DateTime               @updatedAt
   store          Store                  @relation(fields: [storeId], references: [id], onDelete: Cascade)

--- a/server/prisma/seed-data/customers.json
+++ b/server/prisma/seed-data/customers.json
@@ -6,7 +6,6 @@
             "tel": "01012345678",
             "points": 18000,
             "firstVisitDate": "2026-02-03",
-            "allergyNote": "염색 약제 알레르기 있음",
             "memoTags": []
         },
         {
@@ -15,7 +14,6 @@
             "tel": "01098765432",
             "points": 12000,
             "firstVisitDate": "2026-03-07",
-            "preferenceNote": "짧은 앞머리보다 자연스러운 길이 선호",
             "memoTags": [
                 {
                     "text": "앞머리 길이 체크",
@@ -46,7 +44,6 @@
             "tel": "01077778888",
             "points": 25000,
             "firstVisitDate": "2026-02-03",
-            "claimNote": "지난 커트 길이감 민감, 서비스 전 길이 확인 필요",
             "memoTags": [
                 {
                     "text": "길이 민감",

--- a/server/prisma/seed.mjs
+++ b/server/prisma/seed.mjs
@@ -360,9 +360,6 @@ async function seedCustomers() {
                 tel: customer.tel,
                 points: Number(customer.points ?? 0),
                 firstVisitDate: customer.firstVisitDate ? new Date(`${customer.firstVisitDate}T00:00:00`) : null,
-                allergyNote: customer.allergyNote ?? null,
-                claimNote: customer.claimNote ?? null,
-                preferenceNote: customer.preferenceNote ?? null,
             },
             create: {
                 storeId,
@@ -371,9 +368,6 @@ async function seedCustomers() {
                 tel: customer.tel,
                 points: Number(customer.points ?? 0),
                 firstVisitDate: customer.firstVisitDate ? new Date(`${customer.firstVisitDate}T00:00:00`) : null,
-                allergyNote: customer.allergyNote ?? null,
-                claimNote: customer.claimNote ?? null,
-                preferenceNote: customer.preferenceNote ?? null,
             },
         });
 


### PR DESCRIPTION
Closes #167

## ⚠️ 배포 순서가 평소와 반대입니다 — 먼저 읽어주세요

이 PR은 마이그레이션 `0018`이 **컬럼을 DROP** 합니다. 평소 규칙("마이그레이션 수동 선적용 → 코드 자동배포")을 **그대로 따르면 장애가 납니다.**

```
✅ 올바른 순서:  이 PR 머지(코드 배포)  →  그 다음 마이그레이션 0018 적용
❌ 평소 순서:    마이그레이션 먼저      →  전체 고객 조회 500
```

`server/api/customers.ts`의 고객 조회가 `include`(= 전체 스칼라 컬럼 SELECT)를 쓴다. 컬럼을 먼저 지우면 **구버전 Prisma 클라이언트가 없는 컬럼을 SELECT** 해 전체 고객 조회가 500난다 — 2026-07 `publicToken` 배포순서 사고와 같은 구조이고 방향만 반대다. 반대로 코드를 먼저 배포하면 컬럼이 남아 있어도 아무도 읽지 않으므로 무해하다.

마이그레이션 파일 헤더와 `plan.md`에도 같은 경고를 적어두었다.

## 1. 미사용 고객 메모 3종 제거 (#167)

`Customer.allergyNote` · `claimNote` · `preferenceNote` 는 초기 임포트 시절의 레거시 컬럼이다.

| 계층 | 제거 전 상태 |
|---|---|
| DB 컬럼 | 있음 (`0001_init`부터) |
| 서버 매퍼·API | 완전 배선 (읽기·쓰기) |
| 클라이언트 모델 | 정의됨 |
| **입력 UI** | **없음 — 값을 넣을 방법이 자체가 없었음** |
| 표시 | `CustomerMergeSuggestionModal` 한 곳 (값이 없으니 사실상 죽은 코드) |
| **운영 데이터** | **3종 모두 0건** (확인 완료) |

`allergyNote`는 건강정보(민감정보)라 되살릴 경우 개인정보보호법 제23조의 별도 동의가 필요하다. 되살릴 때 함께 넣어야 할 항목은 #167에 체크리스트로 보존했다.

제거 대상: 클라 모델 · 병합 모달(+ 미사용 styled 2개) · `mappers.ts` · `customers.ts` · `customers-merge.ts` · `customers-unmerge.ts` · `migrate-local.ts` · `seed.mjs` · `seed-data/customers.json` · `schema.prisma`.

마이그레이션 `0018_drop_unused_customer_notes` — `DROP COLUMN IF EXISTS` ×3(멱등).

## 2. 업종 목록에서 사람 진료 업종 제외

`병원·의원`(clinic) · `치과`(dental) · `한의원`(oriental) 제거. **동물병원(vet)은 유지** — 반려동물 정보라 사람 민감정보가 아니다.

진료 내용은 건강정보라 §23의 별도 동의·안전조치가 필요한데, 예약 요청사항(`Reservation.memo`)처럼 자유 입력 경로가 열려 있어 현재 구조로는 감당하지 않는다.

**주의**: `sanitizeShopType`이 목록 밖 값을 걸러 `null`로 만든다. 해당 업종으로 설정된 매장이 있으면 다음 저장 때 업종이 지워진다. 확인 쿼리(조회만):

```sql
SELECT "shopType", COUNT(*) FROM "Store"
WHERE "shopType" ~ '(clinic|dental|oriental)' GROUP BY 1;
```

## 검증

- `tsc --noEmit` 0 · `next build` 성공.
- 로컬 Postgres에 `0018` 적용 — **실행 전 datasource 출력으로 로컬 `takeaseat` DB임을 확인**(`CLAUDE.md` DB Safety 절차). 컬럼 3개 제거 확인, **스키마 드리프트 0**(`migrate diff --exit-code` → 0).
- **컬럼 없는 DB에서 `customers.ts`와 동일한 `include` 쿼리를 직접 실행** → 정상 조회(2건), 응답 필드에서 노트 3종 사라짐. 공개 예약 생성(Customer upsert 경유) 201. 서버 로그 Prisma 에러 0건.
- 업종 목록 렌더 확인 — 사람 진료 3종 사라지고 동물병원 유지.

## 관련 이슈

- #164 — 고객 예약 시 개인정보 수집·이용 안내 (별건, 착수 대기)
- #166 — 삭제 요청 시 매출 이력 소실 (별건)
- #163 — 광고·분석 쿠키 출처 확인 (Cloudflare 측)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp4W77JwD5GKzCw2nR4tAa)_